### PR TITLE
add regex constraint to percent_type

### DIFF
--- a/shared/validation/helpers.py
+++ b/shared/validation/helpers.py
@@ -72,9 +72,11 @@ class PercentSchemaField(object):
 
     field_regex = re.compile(r"(\d+)(\.\d+)?%?")
 
-    def validate(self, value):
-        if value == "auto":
+    def validate(self, value, allow_auto=False):
+        if value == "auto" and allow_auto:
             return value
+        elif value == "auto":
+            raise Invalid("This field does not accept auto")
         if isinstance(value, numbers.Number):
             return float(value)
         if not self.field_regex.match(value):

--- a/shared/validation/user_schema.py
+++ b/shared/validation/user_schema.py
@@ -61,7 +61,7 @@ percent_type_or_auto = {
     "type": ["string", "number"],
     "anyof": [{"allowed": ["auto"]}, {"regex": r"(\d+)(\.\d+)?%?"}],
     "nullable": True,
-    "coerce": "percentage_to_number",
+    "coerce": "percentage_to_number_or_auto",
 }
 
 percent_type = {

--- a/shared/validation/user_schema.py
+++ b/shared/validation/user_schema.py
@@ -103,11 +103,7 @@ component_status_attributes = {**status_common_config, **custom_status_common_co
 notification_standard_attributes = {
     "url": {"type": "string", "coerce": "secret", "nullable": True},
     "branches": branches_structure,
-    "threshold": {
-        "type": ["string", "number"],
-        "nullable": True,
-        "coerce": "percentage_to_number",
-    },
+    "threshold": percent_type,
     "message": {"type": "string"},
     "flags": flag_list_structure,
     "base": {"type": "string", "allowed": ("parent", "pr", "auto")},

--- a/shared/validation/user_schema.py
+++ b/shared/validation/user_schema.py
@@ -66,6 +66,7 @@ percent_type_or_auto = {
 
 percent_type = {
     "type": ["string", "number"],
+    "regex": r"(\d+)(\.\d+)?%?",
     "nullable": True,
     "coerce": "percentage_to_number",
 }

--- a/shared/validation/validator.py
+++ b/shared/validation/validator.py
@@ -28,6 +28,9 @@ class CodecovYamlValidator(Validator):
     def _normalize_coerce_percentage_to_number(self, value):
         return PercentSchemaField().validate(value)
 
+    def _normalize_coerce_percentage_to_number_or_auto(self, value):
+        return PercentSchemaField().validate(value, allow_auto=True)
+
     def _normalize_coerce_string_to_range(self, value):
         return CoverageRangeSchemaField().validate(value)
 

--- a/tests/unit/validation/test_helpers.py
+++ b/tests/unit/validation/test_helpers.py
@@ -181,12 +181,14 @@ class TestPercentSchemaField(BaseTestCase):
     def test_simple_coverage_range(self):
         crsf = PercentSchemaField()
         assert crsf.validate(80) == 80.0
-        assert crsf.validate("auto") == "auto"
+        assert crsf.validate("auto", allow_auto=True) == "auto"
         assert crsf.validate(80.0) == 80.0
         assert crsf.validate("80%") == 80.0
         assert crsf.validate("80") == 80.0
         assert crsf.validate("0") == 0.0
         assert crsf.validate("150%") == 150.0
+        with pytest.raises(Invalid):
+            crsf.validate("auto")
         with pytest.raises(Invalid):
             crsf.validate("nana")
         with pytest.raises(Invalid):


### PR DESCRIPTION
The current code that is missing the regex accepts any string for this field, but we only want strings that represent percentages or decimal numbers.