### PR TITLE
Handle string indexes with no meta

### DIFF
--- a/shared/reports/types.py
+++ b/shared/reports/types.py
@@ -223,7 +223,7 @@ class SessionTotalsArray(object):
                     extra=dict(sessions_array=sessions_array),
                 )
                 sessions_array["meta"] = {
-                    "session_count": max(sessions_array.keys()) + 1
+                    "session_count": int(max(sessions_array.keys())) + 1
                 }
             meta_info = sessions_array.pop("meta")
             session_count = meta_info["session_count"]

--- a/tests/unit/reports/test_types.py
+++ b/tests/unit/reports/test_types.py
@@ -194,6 +194,9 @@ class TestSessionTotalsArray(object):
         "meta": {"session_count": 5},
         "4": [0, 35, 35, 0, 0, "100", 5, 0, 0, 0, 0, 0, 0],
     }
+    encoded_obj_string_no_meta = {
+        "4": [0, 35, 35, 0, 0, "100", 5, 0, 0, 0, 0, 0, 0],
+    }
 
     def test_decode_session_totals_array_from_legacy(self):
         expected = SessionTotalsArray(
@@ -222,6 +225,16 @@ class TestSessionTotalsArray(object):
 
     def test_decode_session_totals_array_string_indexes(self):
         encoded_obj_copy = deepcopy(self.encoded_obj_string_index)
+        expected = SessionTotalsArray(
+            session_count=5,
+            non_null_items={4: [0, 35, 35, 0, 0, "100", 5, 0, 0, 0, 0, 0, 0]},
+        )
+        result = SessionTotalsArray.build_from_encoded_data(encoded_obj_copy)
+        assert expected.session_count == result.session_count
+        assert expected.non_null_items == result.non_null_items
+
+    def test_decode_session_totals_array_string_indexes_no_meta(self):
+        encoded_obj_copy = deepcopy(self.encoded_obj_string_no_meta)
         expected = SessionTotalsArray(
             session_count=5,
             non_null_items={4: [0, 35, 35, 0, 0, "100", 5, 0, 0, 0, 0, 0, 0]},


### PR DESCRIPTION
These changes let `SessionTotalsArray.build_from_encoded_data` handle the creation of `SessionTotalsArray` from encoded data that has no "meta" info and the indexes of the sessions are strings (as it happens when you pull them from storage).

These changes address https://codecov.sentry.io/issues/4326038619/?project=5215654&query=is%3Aunresolved&referrer=issue-stream&stream_index=0

<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.