### PR TITLE
perf: quit eagerly populating fork information in api queries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,7 +141,8 @@ dmypy.json
 # Cython debug symbols
 cython_debug/
 
-# vscode settings
+# Editor junk
 .vscode/settings.json
+.*.sw?
 
 /target

--- a/shared/torngit/bitbucket.py
+++ b/shared/torngit/bitbucket.py
@@ -358,7 +358,6 @@ class Bitbucket(TorngitBaseAdapter):
                                         ),
                                         private=repo["is_private"],
                                         branch="master",
-                                        fork=None,
                                     ),
                                 )
                             )

--- a/shared/torngit/bitbucket_server.py
+++ b/shared/torngit/bitbucket_server.py
@@ -240,26 +240,6 @@ class BitbucketServer(TorngitBaseAdapter):
         if res["project"]["type"] == "PERSONAL":
             owner_service_id = "U%d" % res["project"]["owner"]["id"]
 
-        fork = None
-        if res.get("origin"):
-            _fork_owner_service_id = res["origin"]["project"]["id"]
-            if res["origin"]["project"]["type"] == "PERSONAL":
-                _fork_owner_service_id = "U%d" % res["origin"]["project"]["owner"]["id"]
-
-            fork = dict(
-                owner=dict(
-                    service_id=_fork_owner_service_id,
-                    username=res["origin"]["project"]["key"],
-                ),
-                repo=dict(
-                    service_id=res["origin"]["id"],
-                    language=None,
-                    private=(not res["origin"]["public"]),
-                    branch="master",
-                    name=res["origin"]["slug"],
-                ),
-            )
-
         return dict(
             owner=dict(service_id=owner_service_id, username=res["project"]["key"]),
             repo=dict(
@@ -267,7 +247,6 @@ class BitbucketServer(TorngitBaseAdapter):
                 language=None,
                 private=(not res.get("public", res.get("origin", {}).get("public"))),
                 branch="master",
-                fork=fork,
                 name=res["slug"],
             ),
         )
@@ -522,28 +501,6 @@ class BitbucketServer(TorngitBaseAdapter):
                 if repo["project"]["type"] == "PERSONAL":
                     ownerid = "U" + str(repo["project"]["owner"]["id"])
 
-                fork = None
-                if repo.get("origin"):
-                    _fork_owner_service_id = str(repo["origin"]["project"]["id"])
-                    if repo["origin"]["project"]["type"] == "PERSONAL":
-                        _fork_owner_service_id = (
-                            "U%d" % repo["origin"]["project"]["owner"]["id"]
-                        )
-
-                    fork = dict(
-                        owner=dict(
-                            service_id=_fork_owner_service_id,
-                            username=repo["origin"]["project"]["key"],
-                        ),
-                        repo=dict(
-                            service_id=repo["origin"]["id"],
-                            language=None,
-                            private=(not repo["origin"]["public"]),
-                            branch="master",
-                            name=repo["origin"]["slug"],
-                        ),
-                    )
-
                 data.append(
                     dict(
                         owner=dict(
@@ -560,7 +517,6 @@ class BitbucketServer(TorngitBaseAdapter):
                                 )
                             ),
                             branch="master",
-                            fork=fork,
                         ),
                     )
                 )

--- a/shared/torngit/bitbucket_server.py
+++ b/shared/torngit/bitbucket_server.py
@@ -240,6 +240,27 @@ class BitbucketServer(TorngitBaseAdapter):
         if res["project"]["type"] == "PERSONAL":
             owner_service_id = "U%d" % res["project"]["owner"]["id"]
 
+        fork = None
+        if res.get("origin"):
+            _fork_owner_service_id = res["origin"]["project"]["id"]
+            if res["origin"]["project"]["type"] == "PERSONAL":
+                _fork_owner_service_id = "U%d" % res["origin"]["project"]["owner"]["id"]
+
+            fork = dict(
+                owner=dict(
+                    service_id=_fork_owner_service_id,
+                    username=res["origin"]["project"]["key"],
+                ),
+                repo=dict(
+                    service_id=res["origin"]["id"],
+                    language=None,
+                    private=(not res["origin"]["public"]),
+                    branch="master",
+                    fork=fork,
+                    name=res["origin"]["slug"],
+                ),
+            )
+
         return dict(
             owner=dict(service_id=owner_service_id, username=res["project"]["key"]),
             repo=dict(

--- a/shared/torngit/github.py
+++ b/shared/torngit/github.py
@@ -320,6 +320,24 @@ class Github(TorngitBaseAdapter):
                 )
 
         username, repo = tuple(res["full_name"].split("/", 1))
+        parent = res.get("parent")
+
+        if parent:
+            fork = dict(
+                owner=dict(
+                    service_id=parent["owner"]["id"], username=parent["owner"]["login"]
+                ),
+                repo=dict(
+                    service_id=parent["id"],
+                    name=parent["name"],
+                    language=self._validate_language(parent["language"]),
+                    private=parent["private"],
+                    branch=parent["default_branch"],
+                ),
+            )
+        else:
+            fork = None
+
         return dict(
             owner=dict(service_id=res["owner"]["id"], username=username),
             repo=dict(
@@ -327,6 +345,7 @@ class Github(TorngitBaseAdapter):
                 name=repo,
                 language=self._validate_language(res["language"]),
                 private=res["private"],
+                fork=fork,
                 branch=res["default_branch"] or "master",
             ),
         )

--- a/shared/torngit/github.py
+++ b/shared/torngit/github.py
@@ -320,24 +320,6 @@ class Github(TorngitBaseAdapter):
                 )
 
         username, repo = tuple(res["full_name"].split("/", 1))
-        parent = res.get("parent")
-
-        if parent:
-            fork = dict(
-                owner=dict(
-                    service_id=parent["owner"]["id"], username=parent["owner"]["login"]
-                ),
-                repo=dict(
-                    service_id=parent["id"],
-                    name=parent["name"],
-                    language=self._validate_language(parent["language"]),
-                    private=parent["private"],
-                    branch=parent["default_branch"],
-                ),
-            )
-        else:
-            fork = None
-
         return dict(
             owner=dict(service_id=res["owner"]["id"], username=username),
             repo=dict(
@@ -345,7 +327,6 @@ class Github(TorngitBaseAdapter):
                 name=repo,
                 language=self._validate_language(res["language"]),
                 private=res["private"],
-                fork=fork,
                 branch=res["default_branch"] or "master",
             ),
         )
@@ -406,34 +387,7 @@ class Github(TorngitBaseAdapter):
                     )
 
                 for repo in repos:
-                    _o, _r, parent = repo["owner"]["login"], repo["name"], None
-                    if repo["fork"]:
-                        # need to get its source
-                        # https://developer.github.com/v3/repos/#get
-                        try:
-                            parent = await self.api(
-                                client, "get", "/repos/%s/%s" % (_o, _r), token=token
-                            )
-                            parent = parent["source"]
-                        except Exception:
-                            parent = None
-
-                    if parent:
-                        fork = dict(
-                            owner=dict(
-                                service_id=parent["owner"]["id"],
-                                username=parent["owner"]["login"],
-                            ),
-                            repo=dict(
-                                service_id=parent["id"],
-                                name=parent["name"],
-                                language=self._validate_language(parent["language"]),
-                                private=parent["private"],
-                                branch=parent["default_branch"],
-                            ),
-                        )
-                    else:
-                        fork = None
+                    _o, _r = repo["owner"]["login"], repo["name"]
 
                     data.append(
                         dict(
@@ -444,7 +398,6 @@ class Github(TorngitBaseAdapter):
                                 language=self._validate_language(repo["language"]),
                                 private=repo["private"],
                                 branch=repo["default_branch"],
-                                fork=fork,
                             ),
                         )
                     )
@@ -488,7 +441,7 @@ class Github(TorngitBaseAdapter):
                                 username=organization["login"],
                             )
                         )
-                    except (TorngitClientGeneralError):
+                    except TorngitClientGeneralError:
                         log.exception(
                             "Unable to load organization",
                             extra=dict(url=organization["url"]),

--- a/shared/torngit/gitlab.py
+++ b/shared/torngit/gitlab.py
@@ -67,7 +67,6 @@ class Gitlab(TorngitBaseAdapter):
         version=4,
         **args,
     ):
-
         if url_path.startswith("/"):
             _log = dict(
                 event="api",
@@ -409,35 +408,6 @@ class Gitlab(TorngitBaseAdapter):
                         owner_username,
                     ) = await self.get_owner_info_from_repo(repo, token)
 
-                    if repo.get("forked_from_project"):
-                        parent = repo.get("forked_from_project")
-                        (
-                            parent_service_id,
-                            parent_username,
-                        ) = await self.get_owner_info_from_repo(parent, token)
-                        parent_info = await self.api(
-                            "get", "/projects/{}".format(parent["id"]), token=token
-                        )
-                        if "default_branch" not in parent:
-                            log.warning(
-                                "Forked repo doesn't have default_branch, using master instead",
-                                extra=dict(repo=repo),
-                            )
-                        fork = dict(
-                            owner=dict(
-                                service_id=parent_service_id, username=parent_username
-                            ),
-                            repo=dict(
-                                service_id=parent["id"],
-                                name=parent["name"],
-                                language=None,
-                                private=(parent_info["visibility"] != "public"),
-                                branch=parent.get("default_branch", "master"),
-                            ),
-                        )
-                    else:
-                        fork = None
-
                     # Gitlab API will return a repo with one of: no default branch key, default_branch: None, or default_branch: 'some_branch'
                     branch = "master"
                     if "default_branch" in repo and repo["default_branch"] is not None:
@@ -456,7 +426,6 @@ class Gitlab(TorngitBaseAdapter):
                             repo=dict(
                                 service_id=repo["id"],
                                 name=repo["path"],
-                                fork=fork,
                                 private=(repo["visibility"] != "public"),
                                 language=None,
                                 branch=branch,

--- a/tests/integration/test_bitbucket.py
+++ b/tests/integration/test_bitbucket.py
@@ -594,7 +594,6 @@ class TestBitbucketTestCase(object):
         expected_result = [
             {
                 "repo": {
-                    "fork": None,
                     "name": "ci-repo",
                     "language": None,
                     "branch": "master",
@@ -608,7 +607,6 @@ class TestBitbucketTestCase(object):
             },
             {
                 "repo": {
-                    "fork": None,
                     "name": "private",
                     "language": "python",
                     "branch": "master",
@@ -622,7 +620,6 @@ class TestBitbucketTestCase(object):
             },
             {
                 "repo": {
-                    "fork": None,
                     "name": "coverage.py",
                     "language": "python",
                     "branch": "master",
@@ -636,7 +633,6 @@ class TestBitbucketTestCase(object):
             },
             {
                 "repo": {
-                    "fork": None,
                     "name": "integration-test-repo",
                     "language": "python",
                     "branch": "master",
@@ -650,7 +646,6 @@ class TestBitbucketTestCase(object):
             },
             {
                 "repo": {
-                    "fork": None,
                     "name": "test-bb-integration-public",
                     "language": None,
                     "branch": "master",
@@ -948,7 +943,6 @@ class TestBitbucketTestCase(object):
         expected_result = [
             {
                 "repo": {
-                    "fork": None,
                     "name": "example-python",
                     "language": None,
                     "branch": "master",

--- a/tests/integration/test_github.py
+++ b/tests/integration/test_github.py
@@ -810,6 +810,16 @@ class TestGithubTestCase(object):
                 "name": "example-python",
                 "language": "shell",
                 "private": False,
+                "fork": {
+                    "owner": {"service_id": 8226205, "username": "codecov"},
+                    "repo": {
+                        "service_id": 24344106,
+                        "name": "example-python",
+                        "language": "python",
+                        "private": False,
+                        "branch": "master",
+                    },
+                },
                 "branch": "master",
             },
         }

--- a/tests/integration/test_github.py
+++ b/tests/integration/test_github.py
@@ -810,16 +810,6 @@ class TestGithubTestCase(object):
                 "name": "example-python",
                 "language": "shell",
                 "private": False,
-                "fork": {
-                    "owner": {"service_id": 8226205, "username": "codecov"},
-                    "repo": {
-                        "service_id": 24344106,
-                        "name": "example-python",
-                        "language": "python",
-                        "private": False,
-                        "branch": "master",
-                    },
-                },
                 "branch": "master",
             },
         }
@@ -888,16 +878,6 @@ class TestGithubTestCase(object):
                 "name": "example-python",
                 "language": "shell",
                 "private": False,
-                "fork": {
-                    "owner": {"service_id": 8226205, "username": "codecov"},
-                    "repo": {
-                        "service_id": 24344106,
-                        "name": "example-python",
-                        "language": "python",
-                        "private": False,
-                        "branch": "master",
-                    },
-                },
                 "branch": "master",
             },
         }

--- a/tests/integration/test_gitlab.py
+++ b/tests/integration/test_gitlab.py
@@ -577,7 +577,6 @@ class TestGitlabTestCase(object):
                 "owner": {"service_id": 189208, "username": "morerunes"},
                 "repo": {
                     "branch": "master",
-                    "fork": None,
                     "language": None,
                     "name": "delectamentum-mud-server",
                     "private": False,
@@ -588,7 +587,6 @@ class TestGitlabTestCase(object):
                 "owner": {"service_id": 109640, "username": "codecov"},
                 "repo": {
                     "branch": "master",
-                    "fork": None,
                     "language": None,
                     "name": "example-python",
                     "private": False,
@@ -599,7 +597,6 @@ class TestGitlabTestCase(object):
                 "owner": {"service_id": 109640, "username": "codecov"},
                 "repo": {
                     "branch": "master",
-                    "fork": None,
                     "language": None,
                     "name": "ci-private",
                     "private": True,
@@ -610,7 +607,6 @@ class TestGitlabTestCase(object):
                 "owner": {"service_id": 109640, "username": "codecov"},
                 "repo": {
                     "branch": "master",
-                    "fork": None,
                     "language": None,
                     "name": "ci-repo",
                     "private": False,
@@ -629,16 +625,6 @@ class TestGitlabTestCase(object):
                 "repo": {
                     "service_id": 9715886,
                     "name": "flake8",
-                    "fork": {
-                        "owner": {"service_id": 61704, "username": "pycqa"},
-                        "repo": {
-                            "service_id": 88891,
-                            "name": "flake8",
-                            "language": None,
-                            "private": False,
-                            "branch": "master",
-                        },
-                    },
                     "private": True,
                     "language": None,
                     "branch": "master",
@@ -649,7 +635,6 @@ class TestGitlabTestCase(object):
                 "repo": {
                     "service_id": 9715862,
                     "name": "inf-proj",
-                    "fork": None,
                     "private": True,
                     "language": None,
                     "branch": "master",
@@ -660,7 +645,6 @@ class TestGitlabTestCase(object):
                 "repo": {
                     "service_id": 9715859,
                     "name": "loop-proj",
-                    "fork": None,
                     "private": True,
                     "language": None,
                     "branch": "master",
@@ -671,7 +655,6 @@ class TestGitlabTestCase(object):
                 "repo": {
                     "service_id": 9715852,
                     "name": "proj-a",
-                    "fork": None,
                     "private": True,
                     "language": None,
                     "branch": "master",
@@ -694,7 +677,6 @@ class TestGitlabTestCase(object):
                 "owner": {"service_id": 4037482, "username": "codecov-organization"},
                 "repo": {
                     "branch": "master",
-                    "fork": None,
                     "language": None,
                     "name": "demo-gitlab",
                     "private": True,
@@ -705,7 +687,6 @@ class TestGitlabTestCase(object):
                 "owner": {"service_id": 4037482, "username": "codecov-organization"},
                 "repo": {
                     "branch": "master",
-                    "fork": None,
                     "language": None,
                     "name": "codecov-assume-flag-test",
                     "private": True,
@@ -716,7 +697,6 @@ class TestGitlabTestCase(object):
                 "owner": {"service_id": 4037482, "username": "codecov-organization"},
                 "repo": {
                     "branch": "master",
-                    "fork": None,
                     "language": None,
                     "name": "migration-tests",
                     "private": True,
@@ -730,19 +710,6 @@ class TestGitlabTestCase(object):
                 },
                 "repo": {
                     "branch": "master",
-                    "fork": {
-                        "owner": {
-                            "service_id": 2351283,
-                            "username": "gitlab-org:release",
-                        },
-                        "repo": {
-                            "branch": "master",
-                            "language": None,
-                            "name": "tasks",
-                            "private": False,
-                            "service_id": 5064907,
-                        },
-                    },
                     "language": None,
                     "name": "tasks",
                     "private": True,
@@ -756,7 +723,6 @@ class TestGitlabTestCase(object):
                 },
                 "repo": {
                     "branch": "master",
-                    "fork": None,
                     "language": None,
                     "name": "grouptestprojecttrr",
                     "private": True,

--- a/tests/unit/torngit/test_bitbucket.py
+++ b/tests/unit/torngit/test_bitbucket.py
@@ -341,7 +341,6 @@ class TestUnitBitbucket(object):
                     "language": "python",
                     "private": True,
                     "branch": "master",
-                    "fork": None,
                 },
             },
             {
@@ -352,7 +351,6 @@ class TestUnitBitbucket(object):
                     "language": "python",
                     "private": True,
                     "branch": "master",
-                    "fork": None,
                 },
             },
         ]


### PR DESCRIPTION
`list_repos()` returns a list of repos, and if a repo is a fork, it will have a `fork` key pointing to its source. the torngit github implementation of `list_repos()` will perform an extra API request for each fork to fill out the source's information, and these requests aren't batched/parallelized so if an org has many forks it could substantially bog down syncing. the other implementations don't do an extra network request but do populate the `fork` key

`sync_repos` only does a couple things with that `fork` key:
- upsert the forked repo and its owner to the db
- if the forked repo is private, add its ID to the list of repos the current user can see

if the forked repo is visible to the current user, it'll be in the list that `list_repos()` returns and will be handled in `sync_repos` anyway. if the forked repo is *not* visible to the current user, then it's incorrect to add it to the list of repos the current user can see.

no relationship between a repo and the repo it was forked from is saved in the db here. `list_repos()` is not used anywhere else. this PR also removes the `fork` key from the return format of torngit's `get_repository()`, but i can't find any usages of that function in the first place

(also i added vim swapfiles to gitignore)

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.