### PR TITLE
fix: replace bitbucket_server hardcoded signing key with user config

### DIFF
--- a/shared/config/__init__.py
+++ b/shared/config/__init__.py
@@ -166,7 +166,7 @@ class ConfigHelper(object):
                     self.loaded_files[args] = _file.read()
             except FileNotFoundError:
                 log.exception(
-                    "Unable to read filepath for install YAML",
+                    "Unable to read file specified in config",
                     extra=dict(file_location=location, path_args=list(args)),
                 )
                 raise

--- a/tests/integration/test_bitbucket_server.py
+++ b/tests/integration/test_bitbucket_server.py
@@ -1,9 +1,27 @@
 from asyncio import Future
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 
-from shared.torngit.bitbucket_server import BitbucketServer
+from shared.config import ConfigHelper, MissingConfigException
+from shared.torngit.bitbucket_server import BitbucketServer, _Signature
+
+# NOT A REAL KEY; this was generated for use in tests
+mock_private_key = """-----BEGIN RSA PRIVATE KEY-----
+MIICXAIBAAKBgQDCFqq2ygFh9UQU/6PoDJ6L9e4ovLPCHtlBt7vzDwyfwr3XGxln
+0VbfycVLc6unJDVEGZ/PsFEuS9j1QmBTTEgvCLR6RGpfzmVuMO8wGVEO52pH73h9
+rviojaheX/u3ZqaA0di9RKy8e3L+T0ka3QYgDx5wiOIUu1wGXCs6PhrtEwICBAEC
+gYBu9jsi0eVROozSz5dmcZxUAzv7USiUcYrxX007SUpm0zzUY+kPpWLeWWEPaddF
+VONCp//0XU8hNhoh0gedw7ZgUTG6jYVOdGlaV95LhgY6yXaQGoKSQNNTY+ZZVT61
+zvHOlPynt3GZcaRJOlgf+3hBF5MCRoWKf+lDA5KiWkqOYQJBAMQp0HNVeTqz+E0O
+6E0neqQDQb95thFmmCI7Kgg4PvkS5mz7iAbZa5pab3VuyfmvnVvYLWejOwuYSp0U
+9N8QvUsCQQD9StWHaVNM4Lf5zJnB1+lJPTXQsmsuzWvF3HmBkMHYWdy84N/TdCZX
+Cxve1LR37lM/Vijer0K77wAx2RAN/ppZAkB8+GwSh5+mxZKydyPaPN29p6nC6aLx
+3DV2dpzmhD0ZDwmuk8GN+qc0YRNOzzJ/2UbHH9L/lvGqui8I6WLOi8nDAkEA9CYq
+ewfdZ9LcytGz7QwPEeWVhvpm0HQV9moetFWVolYecqBP4QzNyokVnpeUOqhIQAwe
+Z0FJEQ9VWsG+Df0noQJBALFjUUZEtv4x31gMlV24oiSWHxIRX4fEND/6LpjleDZ5
+C/tY+lZIEO1Gg/FxSMB+hwwhwfSuE3WohZfEcSy+R48=
+-----END RSA PRIVATE KEY-----"""
 
 
 def valid_handler():
@@ -15,7 +33,121 @@ def valid_handler():
     )
 
 
+def mock_config_get(configs, mocker):
+    orig_get = ConfigHelper.get
+
+    def mock_get(obj, *args, **kwargs):
+        conf_key = ".".join(args)
+        if conf_key in configs:
+            return configs.get(conf_key)
+        else:
+            return orig_get(obj, *args, **kwargs)
+
+    m = mocker.patch.object(ConfigHelper, "get", mock_get)
+    return m
+
+
+def mock_config_load_file(configs, mocker):
+    orig_load_file = ConfigHelper.load_filename_from_path
+
+    def mock_load_file(obj, *args):
+        conf_key = ".".join(args)
+        if conf_key in configs:
+            return configs.get(conf_key)
+        else:
+            return orig_load_file(obj, *args)
+
+    m = mocker.patch.object(ConfigHelper, "load_filename_from_path", mock_load_file)
+    return m
+
+
 class TestBitbucketTestCase(object):
+    def test_signature_without_config(self, mocker):
+        def raise_missing_config(obj, *args, **kwargs):
+            raise MissingConfigException(args)
+
+        mocker.patch.object(ConfigHelper, "get", side_effect=raise_missing_config)
+
+        signature = _Signature()
+
+        mock_req = Mock(
+            method="get", normalized_url="", get_normalized_parameters=lambda: ""
+        )
+        mock_token = Mock(secret="")
+        mock_consumer = Mock(secret="")
+
+        try:
+            signature.sign(mock_req, mock_consumer, mock_token)
+        except MissingConfigException as e:
+            assert True
+        else:
+            assert False, "MissingConfigException should have been thrown"
+
+    def test_signature_with_invalid_config(self, mocker):
+        mock_config_get({"bitbucket_server.pemfile": "/invalid"}, mocker)
+
+        signature = _Signature()
+        mock_req = Mock(
+            method="get", normalized_url="", get_normalized_parameters=lambda: ""
+        )
+        mock_token = Mock(secret="")
+        mock_consumer = Mock(secret="")
+
+        try:
+            signature.sign(mock_req, mock_consumer, mock_token)
+        except FileNotFoundError:
+            assert True
+        else:
+            assert False, "FileNotFoundError should have been thrown"
+
+    def test_signature_with_invalid_pemfile(self, mocker):
+        mock_config_load_file({"bitbucket_server.pemfile": "invalid pemfile"}, mocker)
+
+        signature = _Signature()
+        mock_req = Mock(
+            method="get", normalized_url="", get_normalized_parameters=lambda: ""
+        )
+        mock_token = Mock(secret="")
+        mock_consumer = Mock(secret="")
+
+        try:
+            signature.sign(mock_req, mock_consumer, mock_token)
+        except SyntaxError:
+            assert True
+        else:
+            assert False, "SyntaxError should have been thrown"
+
+    def test_signature_with_valid_pemfile(self, mocker):
+        assert not _Signature.privkey, "Test should start without a parsed privkey"
+
+        mock_config_load_file({"bitbucket_server.pemfile": mock_private_key}, mocker)
+
+        signature = _Signature()
+        mock_req = Mock(
+            method="get", normalized_url="", get_normalized_parameters=lambda: ""
+        )
+        mock_token = Mock(secret="")
+        mock_consumer = Mock(secret="")
+
+        try:
+            signature.sign(mock_req, mock_consumer, mock_token)
+        except Exception:
+            assert False, "This operation should have succeeded"
+        else:
+            assert True
+
+    """
+    def test_signature_without_pemfile(self, mocker):
+        mock_config_factory({"bitbucket_server.pemfile": None}, mocker)
+
+        self.assertRaises(
+
+
+
+        signature = _Signature()
+        handler = valid_handler()
+    """
+
     @pytest.mark.asyncio
     async def test_find_pull_request_found(self, mocker):
         api_result = {


### PR DESCRIPTION
we missed a spot when scrubbing secrets from our repo history

this private key is used to sign requests between self-hosted codecov and instances of bitbucket enterprise. this PR removes the hardcoded key and instead looks for a path to a pemfile in `bitbucket_server.pemfile`. the user is to supply their own keypair

the pemfile is read/parsed on first attempt to sign a request to bitbucket so non-bitbucket self-hosted users don't have to provide a stub value or anything

IMPORTANT: need to update docs https://docs.codecov.com/docs/set-up-oauth-login#step-1---create-a-new-application-link

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.