### PR TITLE
fix: normalize repo language in list_repos_using_installation

### DIFF
--- a/shared/torngit/github.py
+++ b/shared/torngit/github.py
@@ -376,6 +376,7 @@ class Github(TorngitBaseAdapter):
 
             for repo in repos:
                 repo["id"] = str(repo["id"])
+                repo["language"] = self._validate_language(repo["language"])
             return repos
 
     async def list_repos(self, username=None, token=None):


### PR DESCRIPTION
`list_repos_using_installation()` was changed to return full repo dicts rather than just `service_id`. the format of the return was not made to match that of `list_repos()` and didn't include some of the same normalization which caused errors

this PR is a quick fix

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.