### PR TITLE
fix: Consistent return types for list_repos and list_repos_using_installation

### DIFF
--- a/shared/torngit/github.py
+++ b/shared/torngit/github.py
@@ -350,7 +350,7 @@ class Github(TorngitBaseAdapter):
             ),
         )
 
-    async def list_repos_using_installation(self, username):
+    async def list_repos_using_installation(self, username=None):
         """
         returns list of repositories included in this integration
         """
@@ -370,12 +370,27 @@ class Github(TorngitBaseAdapter):
                 )
                 if len(res["repositories"]) == 0:
                     break
-                repos.extend(res["repositories"])
+
+                for repo in res["repositories"]:
+                    repos.append(
+                        dict(
+                            owner=dict(
+                                service_id=repo["owner"]["id"],
+                                username=repo["owner"]["login"],
+                            ),
+                            repo=dict(
+                                service_id=repo["id"],
+                                name=repo["name"],
+                                language=self._validate_language(repo["language"]),
+                                private=repo["private"],
+                                branch=repo["default_branch"] or "master",
+                            ),
+                        )
+                    )
+
                 if len(res["repositories"]) < 100:
                     break
 
-            for repo in repos:
-                repo["id"] = str(repo["id"])
             return repos
 
     async def list_repos(self, username=None, token=None):

--- a/tests/integration/cassetes/test_github/TestGithubTestCase/test_list_repos_using_installation.yaml
+++ b/tests/integration/cassetes/test_github/TestGithubTestCase/test_list_repos_using_installation.yaml
@@ -1,0 +1,74 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      accept:
+      - application/vnd.github.machine-man-preview+json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.github.com
+      user-agent:
+      - Default
+    method: GET
+    uri: https://api.github.com/installation/repositories?page=1&per_page=100
+  response:
+    content: '{"total_count":1,"repository_selection":"selected","repositories":[{"id":610348935,"node_id":"R_kgDOJGEvhw","name":"codecov-test","full_name":"scott-codecov-org/codecov-test","private":true,"owner":{"login":"scott-codecov-org","id":111885151,"node_id":"O_kgDOBqs7Xw","avatar_url":"https://avatars.githubusercontent.com/u/111885151?v=4","gravatar_id":"","url":"https://api.github.com/users/scott-codecov-org","html_url":"https://github.com/scott-codecov-org","followers_url":"https://api.github.com/users/scott-codecov-org/followers","following_url":"https://api.github.com/users/scott-codecov-org/following{/other_user}","gists_url":"https://api.github.com/users/scott-codecov-org/gists{/gist_id}","starred_url":"https://api.github.com/users/scott-codecov-org/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/scott-codecov-org/subscriptions","organizations_url":"https://api.github.com/users/scott-codecov-org/orgs","repos_url":"https://api.github.com/users/scott-codecov-org/repos","events_url":"https://api.github.com/users/scott-codecov-org/events{/privacy}","received_events_url":"https://api.github.com/users/scott-codecov-org/received_events","type":"Organization","site_admin":false},"html_url":"https://github.com/scott-codecov-org/codecov-test","description":null,"fork":false,"url":"https://api.github.com/repos/scott-codecov-org/codecov-test","forks_url":"https://api.github.com/repos/scott-codecov-org/codecov-test/forks","keys_url":"https://api.github.com/repos/scott-codecov-org/codecov-test/keys{/key_id}","collaborators_url":"https://api.github.com/repos/scott-codecov-org/codecov-test/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/scott-codecov-org/codecov-test/teams","hooks_url":"https://api.github.com/repos/scott-codecov-org/codecov-test/hooks","issue_events_url":"https://api.github.com/repos/scott-codecov-org/codecov-test/issues/events{/number}","events_url":"https://api.github.com/repos/scott-codecov-org/codecov-test/events","assignees_url":"https://api.github.com/repos/scott-codecov-org/codecov-test/assignees{/user}","branches_url":"https://api.github.com/repos/scott-codecov-org/codecov-test/branches{/branch}","tags_url":"https://api.github.com/repos/scott-codecov-org/codecov-test/tags","blobs_url":"https://api.github.com/repos/scott-codecov-org/codecov-test/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/scott-codecov-org/codecov-test/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/scott-codecov-org/codecov-test/git/refs{/sha}","trees_url":"https://api.github.com/repos/scott-codecov-org/codecov-test/git/trees{/sha}","statuses_url":"https://api.github.com/repos/scott-codecov-org/codecov-test/statuses/{sha}","languages_url":"https://api.github.com/repos/scott-codecov-org/codecov-test/languages","stargazers_url":"https://api.github.com/repos/scott-codecov-org/codecov-test/stargazers","contributors_url":"https://api.github.com/repos/scott-codecov-org/codecov-test/contributors","subscribers_url":"https://api.github.com/repos/scott-codecov-org/codecov-test/subscribers","subscription_url":"https://api.github.com/repos/scott-codecov-org/codecov-test/subscription","commits_url":"https://api.github.com/repos/scott-codecov-org/codecov-test/commits{/sha}","git_commits_url":"https://api.github.com/repos/scott-codecov-org/codecov-test/git/commits{/sha}","comments_url":"https://api.github.com/repos/scott-codecov-org/codecov-test/comments{/number}","issue_comment_url":"https://api.github.com/repos/scott-codecov-org/codecov-test/issues/comments{/number}","contents_url":"https://api.github.com/repos/scott-codecov-org/codecov-test/contents/{+path}","compare_url":"https://api.github.com/repos/scott-codecov-org/codecov-test/compare/{base}...{head}","merges_url":"https://api.github.com/repos/scott-codecov-org/codecov-test/merges","archive_url":"https://api.github.com/repos/scott-codecov-org/codecov-test/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/scott-codecov-org/codecov-test/downloads","issues_url":"https://api.github.com/repos/scott-codecov-org/codecov-test/issues{/number}","pulls_url":"https://api.github.com/repos/scott-codecov-org/codecov-test/pulls{/number}","milestones_url":"https://api.github.com/repos/scott-codecov-org/codecov-test/milestones{/number}","notifications_url":"https://api.github.com/repos/scott-codecov-org/codecov-test/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/scott-codecov-org/codecov-test/labels{/name}","releases_url":"https://api.github.com/repos/scott-codecov-org/codecov-test/releases{/id}","deployments_url":"https://api.github.com/repos/scott-codecov-org/codecov-test/deployments","created_at":"2023-03-06T15:40:27Z","updated_at":"2023-03-06T15:41:05Z","pushed_at":"2023-05-15T16:35:09Z","git_url":"git://github.com/scott-codecov-org/codecov-test.git","ssh_url":"git@github.com:scott-codecov-org/codecov-test.git","clone_url":"https://github.com/scott-codecov-org/codecov-test.git","svn_url":"https://github.com/scott-codecov-org/codecov-test","homepage":null,"size":39,"stargazers_count":0,"watchers_count":0,"language":"Python","has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":false,"has_pages":false,"has_discussions":false,"forks_count":0,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":0,"license":null,"allow_forking":true,"is_template":false,"web_commit_signoff_required":false,"topics":[],"visibility":"private","forks":0,"open_issues":0,"watchers":0,"default_branch":"master","permissions":{"admin":false,"maintain":false,"push":false,"triage":false,"pull":false}}]}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 28 Jul 2023 16:39:39 GMT
+      ETag:
+      - W/"1d303135692e53dd6692c4e4218f984034396e7b70791e9e65ace6e603473075"
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Server:
+      - GitHub.com
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-GitHub-Media-Type:
+      - github.v3; param=machine-man-preview; format=json
+      X-GitHub-Request-Id:
+      - E28A:2DDC:509D08:A2E450:64C3EF4B
+      X-RateLimit-Limit:
+      - '5000'
+      X-RateLimit-Remaining:
+      - '4998'
+      X-RateLimit-Reset:
+      - '1690565939'
+      X-RateLimit-Resource:
+      - core
+      X-RateLimit-Used:
+      - '2'
+      X-XSS-Protection:
+      - '0'
+      x-github-api-version-selected:
+      - '2022-11-28'
+    http_version: HTTP/1.1
+    status_code: 200
+version: 1

--- a/tests/integration/test_github.py
+++ b/tests/integration/test_github.py
@@ -895,6 +895,22 @@ class TestGithubTestCase(object):
         assert one_expected_result in res
 
     @pytest.mark.asyncio
+    async def test_list_repos_using_installation(self, valid_handler, codecov_vcr):
+        res = await valid_handler.list_repos_using_installation()
+        assert res == [
+            {
+                "owner": {"service_id": 111885151, "username": "scott-codecov-org"},
+                "repo": {
+                    "service_id": 610348935,
+                    "name": "codecov-test",
+                    "language": "python",
+                    "private": True,
+                    "branch": "master",
+                },
+            }
+        ]
+
+    @pytest.mark.asyncio
     async def test_list_top_level_files(self, valid_handler, codecov_vcr):
         expected_result = [
             {"name": ".gitignore", "path": ".gitignore", "type": "file"},


### PR DESCRIPTION
`list_repos_using_installation` was passing data back straight from GitHub.  This change mimics the format returned from `list_repos`.  Note that this is a breaking change for the `worker` - we'll need to make a few updates there when we incorporate this version of `shared`.