### PR TITLE
fix: reset static variable between test runs to fix tests in CI

### DIFF
--- a/tests/integration/test_bitbucket_server.py
+++ b/tests/integration/test_bitbucket_server.py
@@ -63,6 +63,8 @@ def mock_config_load_file(configs, mocker):
 
 class TestBitbucketTestCase(object):
     def test_signature_without_config(self, mocker):
+        _Signature.privkey = None
+
         def raise_missing_config(obj, *args, **kwargs):
             raise MissingConfigException(args)
 
@@ -84,6 +86,7 @@ class TestBitbucketTestCase(object):
             assert False, "MissingConfigException should have been thrown"
 
     def test_signature_with_invalid_config(self, mocker):
+        _Signature.privkey = None
         mock_config_get({"bitbucket_server.pemfile": "/invalid"}, mocker)
 
         signature = _Signature()
@@ -101,6 +104,7 @@ class TestBitbucketTestCase(object):
             assert False, "FileNotFoundError should have been thrown"
 
     def test_signature_with_invalid_pemfile(self, mocker):
+        _Signature.privkey = None
         mock_config_load_file({"bitbucket_server.pemfile": "invalid pemfile"}, mocker)
 
         signature = _Signature()
@@ -118,7 +122,7 @@ class TestBitbucketTestCase(object):
             assert False, "SyntaxError should have been thrown"
 
     def test_signature_with_valid_pemfile(self, mocker):
-        assert not _Signature.privkey, "Test should start without a parsed privkey"
+        _Signature.privkey = None
 
         mock_config_load_file({"bitbucket_server.pemfile": mock_private_key}, mocker)
 


### PR DESCRIPTION
should have spotted this issue, my bad!

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.