### PR TITLE
feat: prepare shared for brolly stats rollup in worker

### DIFF
--- a/shared/celery_config.py
+++ b/shared/celery_config.py
@@ -78,6 +78,9 @@ health_check_task_name = f"app.cron.{TaskConfigGroup.healthcheck.value}.HealthCh
 gh_app_webhook_check_task_name = (
     f"app.cron.{TaskConfigGroup.daily.value}.GitHubAppWebhooksCheckTask"
 )
+brolly_stats_rollup_task_name = (
+    f"app.cron.{TaskConfigGroup.daily.value}.BrollyStatsRollupTask"
+)
 
 
 def get_task_group(task_name: str) -> Optional[str]:

--- a/shared/validation/install.py
+++ b/shared/validation/install.py
@@ -195,6 +195,15 @@ config_schema = {
                 "type": "dict",
                 "schema": {"enabled": {"type": "boolean"}},
             },
+            "telemetry": {
+                "type": "dict",
+                "schema": {
+                    "enabled": {"type": "boolean"},
+                    "admin_email": {"type": "string"},
+                    "anonymous": {"type": "boolean"},
+                    "endpoint_override": {"type": "string"},
+                },
+            },
         },
     },
     "services": {


### PR DESCRIPTION
- add `telemetry` section to codecov yaml validation
- add task name to base celery config

siblings with https://github.com/codecov/worker/pull/39

https://github.com/codecov/platform-team/issues/117

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.