### PR TITLE
add config value to hide project coverage

### DIFF
--- a/shared/validation/user_schema.py
+++ b/shared/validation/user_schema.py
@@ -459,6 +459,7 @@ schema = {
             "after_n_builds": {"type": "integer", "min": 0},
             "show_carryforward_flags": {"type": "boolean"},
             "hide_comment_details": {"type": "boolean"},
+            "hide_project_coverage": {"type": "boolean"},
         },
     },
     "github_checks": {

--- a/tests/unit/validation/test_validation.py
+++ b/tests/unit/validation/test_validation.py
@@ -114,6 +114,7 @@ class TestUserYamlValidation(BaseTestCase):
                         "branches": ["master"],
                         "behavior": "once",
                         "after_n_builds": 6,
+                        "hide_project_coverage": True,
                     },
                     "coverage": {
                         "status": {
@@ -138,6 +139,7 @@ class TestUserYamlValidation(BaseTestCase):
                         "branches": ["^master$"],
                         "behavior": "once",
                         "after_n_builds": 6,
+                        "hide_project_coverage": True,
                     },
                     "coverage": {
                         "status": {


### PR DESCRIPTION
Add config option to the codecov yaml to exclude project coverage

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.