### PR TITLE
fix: don't pop meta info

### DIFF
--- a/shared/reports/types.py
+++ b/shared/reports/types.py
@@ -225,11 +225,15 @@ class SessionTotalsArray(object):
                 sessions_array["meta"] = {
                     "session_count": int(max(sessions_array.keys())) + 1
                 }
-            meta_info = sessions_array.pop("meta")
+            meta_info = sessions_array.get("meta")
             session_count = meta_info["session_count"]
             # Force keys to be integers for standarization.
             # It probably becomes a strong when going to the database
-            non_null_items = {int(key): value for key, value in sessions_array.items()}
+            non_null_items = {
+                int(key): value
+                for key, value in sessions_array.items()
+                if key != "meta"
+            }
             return cls(session_count=session_count, non_null_items=non_null_items)
         elif isinstance(sessions_array, list):
             session_count = len(sessions_array)


### PR DESCRIPTION
recently we had [issues](https://github.com/codecov/engineering-team/issues/119) with meta info missing from the encoded data
of sessions array. After much investigation and head scratching the reason is that moving data to GCS and *caching* the data
causes us to re-use the dictionary instance of files_array.

Why does this matter? because dictionaries are passed via *reference*. This means that if you change the dict reference it will
change in all pointers to that dictionary (read the *cached value* in `ArchiveField`).
So basically we were shooting ourselves in the foot.

The good news is that data is being saved and fetched correctly. We just need to not make destructive changes to the encoded data,
because it might be reused in the future.

The current changes address that, making the building of `SessionTotalArray` not destructive for the encoded data.

closes codecov/engineering-team#119

<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.