### PR TITLE
feat: add mock_config_helper and mock_metrics test utils

### DIFF
--- a/shared/utils/test_utils/__init__.py
+++ b/shared/utils/test_utils/__init__.py
@@ -1,0 +1,2 @@
+from .mock_config_helper import mock_config_helper
+from .mock_metrics import mock_metrics

--- a/shared/utils/test_utils/mock_config_helper.py
+++ b/shared/utils/test_utils/mock_config_helper.py
@@ -1,0 +1,39 @@
+from shared.config import ConfigHelper
+
+
+def mock_config_helper(mocker, configs={}, file_configs={}):
+    """
+    Generic utility for mocking two functions on `ConfigHelper`:
+    - `get()`, which takes a config key and returns its value
+    - `load_filename_from_path()`, which takes a config key, treats its value as
+      a file path, and returns the contents of the file.
+
+    These functions underpin the non-method APIs of the config module.
+
+    Example:
+        configs = {"github.client_id": "testvalue"}
+        file_configs = {"github.integration.pem": "--------BEGIN RSA PRIVATE KEY-----..."}
+        mock_config_helper(mocker, configs, file_configs)
+
+        assert "testvalue" == get_config("github", "client_id")
+        assert "BEGIN RSA" in load_file_from_path_at_config("github", "integration", "pem")
+    """
+    orig_get = ConfigHelper.get
+    orig_load_file = ConfigHelper.load_filename_from_path
+
+    def mock_get(obj, *args, **kwargs):
+        conf_key = ".".join(args)
+        if conf_key in configs:
+            return configs.get(conf_key)
+        else:
+            return orig_get(obj, *args, **kwargs)
+
+    def mock_load_file(obj, *args, **kwargs):
+        conf_key = ".".join(args)
+        if conf_key in file_configs:
+            return file_configs.get(conf_key)
+        else:
+            return orig_load_file(obj, *args, **kwargs)
+
+    mocker.patch.object(ConfigHelper, "get", mock_get)
+    mocker.patch.object(ConfigHelper, "load_filename_from_path", mock_load_file)

--- a/shared/utils/test_utils/mock_metrics.py
+++ b/shared/utils/test_utils/mock_metrics.py
@@ -1,0 +1,20 @@
+from collections import defaultdict
+
+from shared.metrics import metrics as orig_metrics
+
+
+class MockMetrics:
+    def __init__(self, mocker):
+        self.data = defaultdict(int)
+        mocker.patch.object(orig_metrics, "incr", self._incr)
+        mocker.patch.object(orig_metrics, "decr", self._decr)
+
+    def _incr(self, stat, count=1, rate=1):
+        self.data[stat] += count
+
+    def _decr(self, stat, count=1, rate=1):
+        self.data[stat] -= count
+
+
+def mock_metrics(mocker):
+    return MockMetrics(mocker)

--- a/tests/unit/utils/test_utils/test_mock_config_helper.py
+++ b/tests/unit/utils/test_utils/test_mock_config_helper.py
@@ -1,0 +1,12 @@
+from shared.config import get_config, load_file_from_path_at_config
+from shared.utils.test_utils import mock_config_helper
+
+
+class TestMockConfigHelper(object):
+    def test_mock_config_helper_get(self, mocker):
+        mock_config_helper(mocker, configs={"foo.bar": "baz"})
+        assert get_config("foo", "bar", default="not baz") == "baz"
+
+    def test_mock_config_helper_load_file(self, mocker):
+        mock_config_helper(mocker, file_configs={"foo.bar": "baz"})
+        assert load_file_from_path_at_config("foo", "bar") == "baz"

--- a/tests/unit/utils/test_utils/test_mock_metrics.py
+++ b/tests/unit/utils/test_utils/test_mock_metrics.py
@@ -1,0 +1,13 @@
+from shared.metrics import metrics
+from shared.utils.test_utils import mock_metrics
+
+
+class TestMockMetrics(object):
+    def test_mock_metrics_incr_decr(self, mocker):
+        m = mock_metrics(mocker)
+
+        metrics.incr("foo", count=33)
+        assert m.data["foo"] == 33
+
+        metrics.decr("foo", count=15)
+        assert m.data["foo"] == 33 - 15


### PR DESCRIPTION
i've already copypasted these in a couple places in `worker` and `codecov-api` so i'm just putting them here

#### `mock_config_helper`
lets you mock only specific configs. if a different config is requested, it's passed through.

```python
configs = {"github.client_id": "test value"}
file_configs = {"github.integration.pem": "RSA key"}
mock_config_helper(mocker, configs, file_configs)

assert get_config("github", "client_id") == "test value"
assert load_file_from_path_at_config("github", "integratoin", "pem") == "RSA key"
```

#### `mock_metrics`
intercepts `metrics.incr()` and `metrics.decr()` so you can:
- test your instrumentation
- maybe observe internal branching

```python
m = mock_metrics(mocker)

metrics.incr("foo", count=33)
assert m.data["foo"] == 33

metrics.decr("foo", count=15)
assert m.data["foo"] == 33 - 15
```

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.