### PR TITLE
[wip] convert list_repos to a generator that yields pages

### DIFF
--- a/shared/torngit/bitbucket.py
+++ b/shared/torngit/bitbucket.py
@@ -299,7 +299,7 @@ class Bitbucket(TorngitBaseAdapter):
         Once we have all orgs/teams and owner's usernames we should call "/repositories/{username}" endpoint
         for each of the orgs/teams and owner's usernames.
         """
-        data, page = [], 0
+        page = 0
         # if username is not provided, list all repos
         repos_to_log = []
         if username is None:
@@ -328,6 +328,7 @@ class Bitbucket(TorngitBaseAdapter):
             for team in usernames:
                 try:
                     while True:
+                        data = []
                         page += 1
                         # https://confluence.atlassian.com/display/BITBUCKET/repositories+Endpoint#repositoriesEndpoint-GETalistofrepositoriesforanaccount
                         res = await self.api(
@@ -361,6 +362,7 @@ class Bitbucket(TorngitBaseAdapter):
                                     ),
                                 )
                             )
+                        yield data
                         if not res.get("next"):
                             page = 0
                             break
@@ -369,7 +371,6 @@ class Bitbucket(TorngitBaseAdapter):
                         "Unable to fetch repos from team on Bitbucket",
                         extra=dict(team_name=team, repository_names=repos_to_log),
                     )
-        return data
 
     async def list_permissions(self, token=None):
         data, page = [], 0

--- a/shared/torngit/bitbucket_server.py
+++ b/shared/torngit/bitbucket_server.py
@@ -526,8 +526,9 @@ class BitbucketServer(TorngitBaseAdapter):
         return [{"path": f, "type": "file"} for f in files]
 
     async def list_repos(self, username=None, token=None):
-        data, start = [], 0
+        start = 0
         while True:
+            data = []
             # https://developer.atlassian.com/static/rest/bitbucket-server/4.0.1/bitbucket-rest.html#idp1847760
             res = await self.api("get", "/repos", start=start, token=token)
             if len(res["values"]) == 0:
@@ -557,12 +558,13 @@ class BitbucketServer(TorngitBaseAdapter):
                         ),
                     )
                 )
+
+            yield data
+
             if res["isLastPage"] or res.get("nextPageStart") is None:
                 break
             else:
                 start = res["nextPageStart"]
-
-        return data
 
     async def list_teams(self, token=None):
         data, start = [], 0

--- a/shared/torngit/github.py
+++ b/shared/torngit/github.py
@@ -355,10 +355,10 @@ class Github(TorngitBaseAdapter):
         """
         returns list of repositories included in this integration
         """
-        repos = []
         page = 0
         async with self.get_client() as client:
             while True:
+                repos = []
                 page += 1
                 # https://docs.github.com/en/rest/apps/installations?apiVersion=2022-11-28
                 res = await self.api(
@@ -366,7 +366,7 @@ class Github(TorngitBaseAdapter):
                     "get",
                     "/installation/repositories?per_page=100&page=%d" % page,
                     headers={
-                        "Accept": "application/vnd.github.machine-man-preview+json"
+                        "Accept": "application/vnd.github.machine-man-preview+json",
                     },
                 )
                 if len(res["repositories"]) == 0:
@@ -389,10 +389,10 @@ class Github(TorngitBaseAdapter):
                         )
                     )
 
-                if len(res["repositories"]) < 100:
-                    break
+                yield repos
 
-            return repos
+                if len(repos) < 100:
+                    break
 
     async def list_repos(self, username=None, token=None):
         """
@@ -401,9 +401,9 @@ class Github(TorngitBaseAdapter):
         """
         token = self.get_token_by_type_if_none(token, TokenType.read)
         page = 0
-        data = []
         async with self.get_client() as client:
             while True:
+                data = []
                 page += 1
                 # https://developer.github.com/v3/repos/#list-your-repositories
                 if username is None:
@@ -439,10 +439,10 @@ class Github(TorngitBaseAdapter):
                         )
                     )
 
+                yield data
+
                 if len(repos) < 100:
                     break
-
-            return data
 
     async def list_teams(self, token=None):
         token = self.get_token_by_type_if_none(token, TokenType.admin)

--- a/tests/integration/test_bitbucket.py
+++ b/tests/integration/test_bitbucket.py
@@ -659,8 +659,9 @@ class TestBitbucketTestCase(object):
             },
         ]
 
-        res = await valid_handler.list_repos("codecov")
-        assert sorted(res, key=lambda x: x["repo"]["service_id"]) == sorted(
+        pages = [page async for page in valid_handler.list_repos("codecov")]
+        repos = [repo for page in pages for repo in page]
+        assert sorted(repos, key=lambda x: x["repo"]["service_id"]) == sorted(
             expected_result, key=lambda x: x["repo"]["service_id"]
         )
 
@@ -955,9 +956,9 @@ class TestBitbucketTestCase(object):
                 },
             }
         ]
-        res = await valid_handler.list_repos()
-        print(res)
-        assert sorted(res, key=lambda x: x["repo"]["service_id"]) == sorted(
+        pages = [page async for page in valid_handler.list_repos()]
+        repos = [repo for page in pages for repo in page]
+        assert sorted(repos, key=lambda x: x["repo"]["service_id"]) == sorted(
             expected_result, key=lambda x: x["repo"]["service_id"]
         )
 

--- a/tests/integration/test_github.py
+++ b/tests/integration/test_github.py
@@ -878,9 +878,13 @@ class TestGithubTestCase(object):
 
     @pytest.mark.asyncio
     async def test_list_repos(self, valid_handler, codecov_vcr):
-        res = await valid_handler.list_repos()
-        assert len(res) == 115
-        assert all(x["owner"]["service_id"] in ["8226205", "44376991"] for x in res)
+        pages = [page async for page in valid_handler.list_repos()]
+        assert len(pages) == 2
+
+        repos = [repo for page in pages for repo in page]
+        assert len(repos) == 115
+
+        assert all(x["owner"]["service_id"] in ["8226205", "44376991"] for x in repos)
         one_expected_result = {
             "owner": {"service_id": "44376991", "username": "ThiagoCodecov"},
             "repo": {
@@ -892,12 +896,17 @@ class TestGithubTestCase(object):
             },
         }
 
-        assert one_expected_result in res
+        assert one_expected_result in repos
 
     @pytest.mark.asyncio
     async def test_list_repos_using_installation(self, valid_handler, codecov_vcr):
-        res = await valid_handler.list_repos_using_installation()
-        assert res == [
+        pages = [page async for page in valid_handler.list_repos_using_installation()]
+        assert len(pages) == 1
+
+        repos = [repo for page in pages for repo in page]
+        assert len(repos) == 1
+
+        assert repos == [
             {
                 "owner": {"service_id": "111885151", "username": "scott-codecov-org"},
                 "repo": {

--- a/tests/integration/test_gitlab.py
+++ b/tests/integration/test_gitlab.py
@@ -614,8 +614,9 @@ class TestGitlabTestCase(object):
                 },
             },
         ]
-        res = await valid_handler.list_repos()
-        assert res == expected_result
+        pages = [page async for page in valid_handler.list_repos()]
+        repos = [repo for page in pages for repo in page]
+        assert repos == expected_result
 
     @pytest.mark.asyncio
     async def test_list_repos_subgroups(self, valid_handler, codecov_vcr):
@@ -667,12 +668,16 @@ class TestGitlabTestCase(object):
                 },
             },
         ]
-        res = await Gitlab(
-            repo=dict(service_id="9715852"),
-            owner=dict(username="1nf1n1t3l00p"),
-            token=dict(key=16 * "f882"),
-        ).list_repos()
-        assert res == expected_result
+        pages = [
+            page
+            async for page in Gitlab(
+                repo=dict(service_id="9715852"),
+                owner=dict(username="1nf1n1t3l00p"),
+                token=dict(key=16 * "f882"),
+            ).list_repos()
+        ]
+        repos = [repo for page in pages for repo in page]
+        assert repos == expected_result
 
     @pytest.mark.asyncio
     async def test_list_repos_subgroups_from_subgroups_username(
@@ -736,12 +741,16 @@ class TestGitlabTestCase(object):
                 },
             },
         ]
-        res = await Gitlab(
-            repo=dict(service_id="5938764"),
-            owner=dict(username="thiagocodecovtestgroup:test-subgroup"),
-            token=dict(key=16 * "f882"),
-        ).list_repos()
-        assert res == expected_result
+        pages = [
+            page
+            async for page in Gitlab(
+                repo=dict(service_id="5938764"),
+                owner=dict(username="thiagocodecovtestgroup:test-subgroup"),
+                token=dict(key=16 * "f882"),
+            ).list_repos()
+        ]
+        repos = [repo for page in pages for repo in page]
+        assert repos == expected_result
 
     @pytest.mark.asyncio
     async def test_list_teams(self, valid_handler, codecov_vcr):

--- a/tests/unit/torngit/test_bitbucket.py
+++ b/tests/unit/torngit/test_bitbucket.py
@@ -331,8 +331,9 @@ class TestUnitBitbucket(object):
         respx.get("https://bitbucket.org/api/2.0/repositories/codecov").respond(
             status_code=404, json={"values": []}
         )
-        res = await valid_handler.list_repos()
-        assert res == [
+        pages = [page async for page in valid_handler.list_repos()]
+        repos = [repo for page in pages for repo in page]
+        assert repos == [
             {
                 "owner": {"service_id": "poilk", "username": "anotherslug"},
                 "repo": {


### PR DESCRIPTION
[UNFINISHED] we apparently need to dedup results for gitlab. i started it but am calling it for the night

https://github.com/codecov/worker/pull/62
https://github.com/codecov/engineering-team/issues/6
https://github.com/codecov/engineering-team/issues/101

per adrian, new customers who have lots of repos between their orgs have an unpleasant first sync: the ui does nothing for potentially minutes until finally all the repos explode into view. instead, he wants the ui to continually refetch the currently-showing set of repos. so initially the user sees 0, and then 13, and then 40, and then 50 + a "load more" button, and so on.

currently we fetch page after page of repos from the git service provider, flatten the list, and return it. we then iterate through the complete set of repos and make db updates. fetching is slow and frontloading all of it before making any db updates undermines adrian's ui tweak, but if we instead alternate fetching a page and updating the db, the initial sync ux should feel more responsive

so, this PR converts `list_repos()` and `list_repos_using_integration()` to python generators which yield page after page. a corresponding change is needed in `worker` to update its usages of these functions from:
```
repos = git.list_repos()
for repo in repos:
    ...
```
to:
```
async for page in git.list_repos():
    for repo in page:
        ...
```

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.