### PR TITLE
Add minio port in install config schema

### DIFF
--- a/shared/validation/install.py
+++ b/shared/validation/install.py
@@ -216,6 +216,7 @@ config_schema = {
                 "type": "dict",
                 "schema": {
                     "host": {"type": "string"},
+                    "port": {"type": "integer"},
                     "hash_key": {"type": "string"},
                     "iam_auth": {"type": "boolean"},
                     "iam_endpoint": {"type": "string", "nullable": True},


### PR DESCRIPTION
<!-- Describe your PR here. -->
Adds port field to minio object in install yaml schema, since its being used in `services/storage.py` in tha api

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.