### PR TITLE
feat: github app refresh tokens

### DIFF
--- a/shared/encryption/token.py
+++ b/shared/encryption/token.py
@@ -20,10 +20,9 @@ def decode_token(_oauth: str) -> OauthConsumerToken:
     This function decrypts a oauth_token into its different parts.
     At the moment it does different things depending on the provider.
 
-    - github
-        Only stores the "key" as the entire token
     - bitbucket
         Encodes the token as f"{key}:{secret}"
+    - github
     - gitlab
         Encodes the token as f"{key}: :{refresh_token}"
         (notice the space where {secret} should go to avoid having '::', used by decode function)
@@ -31,7 +30,7 @@ def decode_token(_oauth: str) -> OauthConsumerToken:
     token = {}
     colon_count = _oauth.count(":")
     if colon_count > 1:
-        # Gitlab (after refresh tokens)
+        # Github + Gitlab  (post refresh tokens)
         token["key"], token["secret"], token["refresh_token"] = _oauth.split(":", 2)
         if token["secret"] == " ":
             # We remove the secret if it's our placeholder value
@@ -40,7 +39,7 @@ def decode_token(_oauth: str) -> OauthConsumerToken:
         # Bitbucket
         token["key"], token["secret"] = _oauth.split(":", 1)
     else:
-        # Github (and Gitlab pre refresh tokens)
+        # Github + Gitlab (pre refresh tokens)
         token["key"] = _oauth
         token["secret"] = None
     return token

--- a/tests/integration/cassetes/test_github/TestGithubTestCase/test_delete_comment_not_found.yaml
+++ b/tests/integration/cassetes/test_github/TestGithubTestCase/test_delete_comment_not_found.yaml
@@ -13,16 +13,17 @@ interactions:
       user-agent:
       - Default
     method: DELETE
-    uri: https://api.github.com/repos/ThiagoCodecov/example-python/issues/comments/113977999
+    uri: https://api.github.com/repos/codecove2e/example-python/issues/comments/113977999
   response:
-    content: '{"message":"Not Found","documentation_url":"https://docs.github.com/rest/reference/issues#delete-an-issue-comment"}'
+    content: '{"message":"Not Found","documentation_url":"https://docs.github.com/rest/issues/comments#delete-an-issue-comment"}'
     headers:
       Access-Control-Allow-Origin:
       - '*'
       Access-Control-Expose-Headers:
       - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
-        X-RateLimit-Used, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
-        X-Poll-Interval, X-GitHub-Media-Type, Deprecation, Sunset
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset
       Content-Encoding:
       - gzip
       Content-Security-Policy:
@@ -30,13 +31,11 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 14 Oct 2020 17:32:05 GMT
+      - Fri, 18 Aug 2023 20:21:33 GMT
       Referrer-Policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
       Server:
       - GitHub.com
-      Status:
-      - 404 Not Found
       Strict-Transport-Security:
       - max-age=31536000; includeSubdomains; preload
       Transfer-Encoding:
@@ -52,19 +51,25 @@ interactions:
       X-GitHub-Media-Type:
       - github.v3
       X-GitHub-Request-Id:
-      - CFD5:28F4:6EFC5:10D0CF:5F873614
+      - E311:1DAF:190B798:1A7AF87:64DFD2CD
       X-OAuth-Scopes:
-      - admin:org, admin:public_key, admin:repo_hook, repo, user, write:discussion
+      - repo, user
       X-RateLimit-Limit:
       - '5000'
       X-RateLimit-Remaining:
-      - '4995'
+      - '4996'
       X-RateLimit-Reset:
-      - '1602700322'
+      - '1692393273'
+      X-RateLimit-Resource:
+      - core
       X-RateLimit-Used:
-      - '5'
+      - '4'
       X-XSS-Protection:
-      - 1; mode=block
+      - '0'
+      github-authentication-token-expiration:
+      - 2023-08-25 20:13:04 UTC
+      x-github-api-version-selected:
+      - '2022-11-28'
     http_version: HTTP/1.1
     status_code: 404
 version: 1

--- a/tests/integration/cassetes/test_github/TestGithubTestCase/test_edit_comment_not_found.yaml
+++ b/tests/integration/cassetes/test_github/TestGithubTestCase/test_edit_comment_not_found.yaml
@@ -17,16 +17,17 @@ interactions:
       user-agent:
       - Default
     method: PATCH
-    uri: https://api.github.com/repos/ThiagoCodecov/example-python/issues/comments/113979999
+    uri: https://api.github.com/repos/codecove2e/example-python/issues/comments/113979999
   response:
-    content: '{"message":"Not Found","documentation_url":"https://docs.github.com/rest/reference/issues#update-an-issue-comment"}'
+    content: '{"message":"Not Found","documentation_url":"https://docs.github.com/rest/issues/comments#update-an-issue-comment"}'
     headers:
       Access-Control-Allow-Origin:
       - '*'
       Access-Control-Expose-Headers:
       - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
-        X-RateLimit-Used, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
-        X-Poll-Interval, X-GitHub-Media-Type, Deprecation, Sunset
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset
       Content-Encoding:
       - gzip
       Content-Security-Policy:
@@ -34,13 +35,11 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 14 Oct 2020 17:32:04 GMT
+      - Fri, 18 Aug 2023 20:21:33 GMT
       Referrer-Policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
       Server:
       - GitHub.com
-      Status:
-      - 404 Not Found
       Strict-Transport-Security:
       - max-age=31536000; includeSubdomains; preload
       Transfer-Encoding:
@@ -56,19 +55,25 @@ interactions:
       X-GitHub-Media-Type:
       - github.v3
       X-GitHub-Request-Id:
-      - CFD3:2B25:1F7F33:344F30:5F873613
+      - E310:1725:17B63EA:1925BB4:64DFD2CD
       X-OAuth-Scopes:
-      - admin:org, admin:public_key, admin:repo_hook, repo, user, write:discussion
+      - repo, user
       X-RateLimit-Limit:
       - '5000'
       X-RateLimit-Remaining:
       - '4997'
       X-RateLimit-Reset:
-      - '1602700322'
+      - '1692393273'
+      X-RateLimit-Resource:
+      - core
       X-RateLimit-Used:
       - '3'
       X-XSS-Protection:
-      - 1; mode=block
+      - '0'
+      github-authentication-token-expiration:
+      - 2023-08-25 20:13:04 UTC
+      x-github-api-version-selected:
+      - '2022-11-28'
     http_version: HTTP/1.1
     status_code: 404
 version: 1

--- a/tests/integration/cassetes/test_github/TestGithubTestCase/test_get_authenticated_user.yaml
+++ b/tests/integration/cassetes/test_github/TestGithubTestCase/test_get_authenticated_user.yaml
@@ -15,7 +15,7 @@ interactions:
     method: GET
     uri: https://github.com/login/oauth/access_token?code=dc38acf492b071cc4dce&client_id=999247146557c3ba045c&client_secret=testo8lnq6ihj7zsf896r15yxujnl06og9o0fqiu
   response:
-    content: '{"access_token":"testw5efy5qccduniyucsk5tesu08s4640xtoymv","token_type":"bearer","scope":"read:org,repo:status,user:email,write:repo_hook"}'
+    content: '{"refresh_token": "testblahblahblahblahsfas", "access_token":"testw5efy5qccduniyucsk5tesu08s4640xtoymv","token_type":"bearer","scope":"read:org,repo:status,user:email,write:repo_hook"}'
     headers:
       Cache-Control:
       - max-age=0, private, must-revalidate

--- a/tests/integration/cassetes/test_github/TestGithubTestCase/test_get_authenticated_user_no_refresh_token.yaml
+++ b/tests/integration/cassetes/test_github/TestGithubTestCase/test_get_authenticated_user_no_refresh_token.yaml
@@ -1,0 +1,218 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - github.com
+      user-agent:
+      - Default
+    method: GET
+    uri: https://github.com/login/oauth/access_token?code=dc38acf492b071cc4dce&client_id=999247146557c3ba045c&client_secret=testo8lnq6ihj7zsf896r15yxujnl06og9o0fqiu
+  response:
+    content: '{"access_token":"testw5efy5qccduniyucsk5tesu08s4640xtoymv","token_type":"bearer","scope":"read:org,repo:status,user:email,write:repo_hook"}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - 'default-src ''none''; base-uri ''self''; block-all-mixed-content; connect-src
+        ''self'' uploads.github.com www.githubstatus.com collector.githubapp.com api.github.com
+        www.google-analytics.com github-cloud.s3.amazonaws.com github-production-repository-file-5c1aeb.s3.amazonaws.com
+        github-production-upload-manifest-file-7fdce7.s3.amazonaws.com github-production-user-asset-6210df.s3.amazonaws.com
+        cdn.optimizely.com logx.optimizely.com/v1/events wss://alive.github.com; font-src
+        github.githubassets.com; form-action ''self'' github.com gist.github.com;
+        frame-ancestors ''none''; frame-src render.githubusercontent.com; img-src
+        ''self'' data: github.githubassets.com identicons.github.com collector.githubapp.com
+        github-cloud.s3.amazonaws.com *.githubusercontent.com; manifest-src ''self'';
+        media-src ''none''; script-src github.githubassets.com; style-src ''unsafe-inline''
+        github.githubassets.com; worker-src github.com/socket-worker.js gist.github.com/socket-worker.js'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 14 Oct 2020 19:03:09 GMT
+      ETag:
+      - W/"f7010df29ae7de00c6f093b748234cb0"
+      Expect-CT:
+      - max-age=2592000, report-uri="https://api.github.com/_private/browser/errors"
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Server:
+      - GitHub.com
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - X-PJAX
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-GitHub-Request-Id:
+      - D324:2F20:1EA2E95:32133F8:5F874B6C
+      X-XSS-Protection:
+      - 1; mode=block
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.github.com
+      user-agent:
+      - Default
+    method: GET
+    uri: https://api.github.com/user
+  response:
+    content: '{"login":"ThiagoCodecov","id":44376991,"node_id":"MDQ6VXNlcjQ0Mzc2OTkx","avatar_url":"https://avatars3.githubusercontent.com/u/44376991?v=4","gravatar_id":"","url":"https://api.github.com/users/ThiagoCodecov","html_url":"https://github.com/ThiagoCodecov","followers_url":"https://api.github.com/users/ThiagoCodecov/followers","following_url":"https://api.github.com/users/ThiagoCodecov/following{/other_user}","gists_url":"https://api.github.com/users/ThiagoCodecov/gists{/gist_id}","starred_url":"https://api.github.com/users/ThiagoCodecov/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/ThiagoCodecov/subscriptions","organizations_url":"https://api.github.com/users/ThiagoCodecov/orgs","repos_url":"https://api.github.com/users/ThiagoCodecov/repos","events_url":"https://api.github.com/users/ThiagoCodecov/events{/privacy}","received_events_url":"https://api.github.com/users/ThiagoCodecov/received_events","type":"User","site_admin":false,"name":"Thiago","company":"@codecov
+      ","blog":"","location":null,"email":null,"hireable":null,"bio":null,"twitter_username":null,"public_repos":3,"public_gists":0,"followers":0,"following":0,"created_at":"2018-10-22T17:51:44Z","updated_at":"2020-10-14T17:58:13Z"}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+        X-Poll-Interval, X-GitHub-Media-Type, Deprecation, Sunset
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 14 Oct 2020 19:03:09 GMT
+      ETag:
+      - W/"3b03bdc732212d313b16662cf09edbbcf4fa403246b6b1da4419b4967f65dad6"
+      Last-Modified:
+      - Wed, 14 Oct 2020 17:58:13 GMT
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Server:
+      - GitHub.com
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Accepted-OAuth-Scopes:
+      - ''
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-GitHub-Media-Type:
+      - github.v3
+      X-GitHub-Request-Id:
+      - D325:2B25:2B2F90:47EA57:5F874B6D
+      X-OAuth-Client-Id:
+      - 999247146557c3ba045c
+      X-OAuth-Scopes:
+      - read:org, repo:status, user:email, write:repo_hook
+      X-RateLimit-Limit:
+      - '5000'
+      X-RateLimit-Remaining:
+      - '4998'
+      X-RateLimit-Reset:
+      - '1602705580'
+      X-RateLimit-Used:
+      - '2'
+      X-XSS-Protection:
+      - 1; mode=block
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.github.com
+      user-agent:
+      - Default
+    method: GET
+    uri: https://api.github.com/user/emails
+  response:
+    content: '[{"email":"thiago@codecov.io","primary":true,"verified":true,"visibility":"private"},{"email":"44376991+ThiagoCodecov@users.noreply.github.com","primary":false,"verified":true,"visibility":null},{"email":"abcdefg@domain.qwertyuiopas.com","primary":false,"verified":true,"visibility":null}]'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+        X-Poll-Interval, X-GitHub-Media-Type, Deprecation, Sunset
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 18 Mar 2021 23:58:18 GMT
+      ETag:
+      - W/"1ede8842545047586cb0de28048ca55b6f90555a35fdd69e0237830f407fb408"
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Server:
+      - GitHub.com
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Accepted-OAuth-Scopes:
+      - user, user:email
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-GitHub-Media-Type:
+      - github.v3
+      X-GitHub-Request-Id:
+      - C29D:7BB6:5422A0B:898EB76:6053E91A
+      X-OAuth-Scopes:
+      - read:org, repo:status, user:email, write:repo_hook
+      X-RateLimit-Limit:
+      - '5000'
+      X-RateLimit-Remaining:
+      - '4999'
+      X-RateLimit-Reset:
+      - '1616115498'
+      X-RateLimit-Used:
+      - '1'
+      X-XSS-Protection:
+      - '0'
+      x-oauth-client-id:
+      - 999247146557c3ba045c
+    http_version: HTTP/1.1
+    status_code: 200
+version: 1

--- a/tests/integration/cassetes/test_github/TestGithubTestCase/test_get_pull_request_fail.yaml
+++ b/tests/integration/cassetes/test_github/TestGithubTestCase/test_get_pull_request_fail.yaml
@@ -13,16 +13,17 @@ interactions:
       user-agent:
       - Default
     method: GET
-    uri: https://api.github.com/repos/ThiagoCodecov/example-python/pulls/100
+    uri: https://api.github.com/repos/codecove2e/example-python/pulls/100
   response:
-    content: '{"message":"Not Found","documentation_url":"https://docs.github.com/rest/reference/pulls#get-a-pull-request"}'
+    content: '{"message":"Not Found","documentation_url":"https://docs.github.com/rest/pulls/pulls#get-a-pull-request"}'
     headers:
       Access-Control-Allow-Origin:
       - '*'
       Access-Control-Expose-Headers:
       - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
-        X-RateLimit-Used, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
-        X-Poll-Interval, X-GitHub-Media-Type, Deprecation, Sunset
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset
       Content-Encoding:
       - gzip
       Content-Security-Policy:
@@ -30,13 +31,11 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 14 Oct 2020 17:32:07 GMT
+      - Fri, 18 Aug 2023 20:27:44 GMT
       Referrer-Policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
       Server:
       - GitHub.com
-      Status:
-      - 404 Not Found
       Strict-Transport-Security:
       - max-age=31536000; includeSubdomains; preload
       Transfer-Encoding:
@@ -52,87 +51,25 @@ interactions:
       X-GitHub-Media-Type:
       - github.v3
       X-GitHub-Request-Id:
-      - CFD7:6F03:BE6C12:1CD66AF:5F873617
+      - E3BB:25EE:12C1DB4:13EE268:64DFD440
       X-OAuth-Scopes:
-      - admin:org, admin:public_key, admin:repo_hook, repo, user, write:discussion
+      - repo, user
       X-RateLimit-Limit:
       - '5000'
       X-RateLimit-Remaining:
-      - '4994'
+      - '4995'
       X-RateLimit-Reset:
-      - '1602700322'
+      - '1692393273'
+      X-RateLimit-Resource:
+      - core
       X-RateLimit-Used:
-      - '6'
+      - '5'
       X-XSS-Protection:
-      - 1; mode=block
-    http_version: HTTP/1.1
-    status_code: 404
-- request:
-    body: ''
-    headers:
-      accept:
-      - application/json
-      accept-encoding:
-      - gzip, deflate
-      connection:
-      - keep-alive
-      host:
-      - api.github.com
-      user-agent:
-      - Default
-    method: GET
-    uri: https://api.github.com/repos/ThiagoCodecov/example-python/pulls/100/commits?per_page=250
-  response:
-    content: '{"message":"Not Found","documentation_url":"https://docs.github.com/rest/reference/pulls#list-commits-on-a-pull-request"}'
-    headers:
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
-        X-RateLimit-Used, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
-        X-Poll-Interval, X-GitHub-Media-Type, Deprecation, Sunset
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 14 Oct 2020 17:32:07 GMT
-      Referrer-Policy:
-      - origin-when-cross-origin, strict-origin-when-cross-origin
-      Server:
-      - GitHub.com
-      Status:
-      - 404 Not Found
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubdomains; preload
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding, Accept, X-Requested-With
-      X-Accepted-OAuth-Scopes:
-      - repo
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - deny
-      X-GitHub-Media-Type:
-      - github.v3
-      X-GitHub-Request-Id:
-      - CFD7:6F03:BE6C27:1CD66BF:5F873617
-      X-OAuth-Scopes:
-      - admin:org, admin:public_key, admin:repo_hook, repo, user, write:discussion
-      X-RateLimit-Limit:
-      - '5000'
-      X-RateLimit-Remaining:
-      - '4993'
-      X-RateLimit-Reset:
-      - '1602700322'
-      X-RateLimit-Used:
-      - '7'
-      X-XSS-Protection:
-      - 1; mode=block
+      - '0'
+      github-authentication-token-expiration:
+      - 2023-08-25 20:13:04 UTC
+      x-github-api-version-selected:
+      - '2022-11-28'
     http_version: HTTP/1.1
     status_code: 404
 version: 1

--- a/tests/integration/cassetes/test_github/TestGithubTestCase/test_is_student_not_capable_app.yaml
+++ b/tests/integration/cassetes/test_github/TestGithubTestCase/test_is_student_not_capable_app.yaml
@@ -21,32 +21,35 @@ interactions:
       - no-cache
       Content-Security-Policy:
       - 'default-src ''self'' dwa5x7aod66zk.cloudfront.net; object-src ''self''; frame-src
-        *.vimeo.com platform.twitter.com connect.facebook.net *.facebook.com speakerdeck.com
-        *.youtube.com embed.twitch.tv; connect-src ''self'' github-education-web.s3.amazonaws.com
-        *.mapbox.com *.clearbit.com www.google.com *.githubusercontent.com geoip-js.com;
-        img-src ''self'' blob: dwa5x7aod66zk.cloudfront.net data: github.com *.mapbox.com
-        *.clearbit.com avatars.githubusercontent.com user-images.githubusercontent.com
-        github-education-web.s3.amazonaws.com analytics.twitter.com t.com *.facebook.com
-        *.twitter.com *.youtube.com raw.githubusercontent.com static-cdn.jtvnw.net;
-        font-src ''self'' dwa5x7aod66zk.cloudfront.net; script-src ''self'' dwa5x7aod66zk.cloudfront.net
-        ''unsafe-eval'' ''unsafe-inline'' www.google.com api.demandbase.com speakerdeck.com
-        platform.twitter.com connect.facebook.net *.facebook.com s3-eu-west-1.amazonaws.com/share.typeform.com/*
+        *.vimeo.com platform.twitter.com connect.facebook.net cdn.usefathom.com *.facebook.com
+        speakerdeck.com *.youtube.com *.youtube-nocookie.com embed.twitch.tv player.twitch.tv;
+        connect-src ''self'' github-education-web.s3.amazonaws.com *.clearbit.com
+        www.google.com *.githubusercontent.com geoip-js.com *.virtualearth.net *.bing.com
+        *.virtualearth.net api.github.com atlas.microsoft.com; img-src ''self'' blob:
+        dwa5x7aod66zk.cloudfront.net data: github.com blobaccountproduction.blob.core.windows.net
+        cdn.usefathom.com *.clearbit.com avatars.githubusercontent.com user-images.githubusercontent.com
+        github-education-web.s3.amazonaws.com analytics.twitter.com t.co t.com *.facebook.com
+        *.twitter.com *.youtube.com raw.githubusercontent.com static-cdn.jtvnw.net
+        dl.airtable.com *.bing.com *.virtualearth.net atlas.microsoft.com; font-src
+        ''self'' dwa5x7aod66zk.cloudfront.net atlas.microsoft.com; script-src ''self''
+        dwa5x7aod66zk.cloudfront.net www.google.com cdn.usefathom.com api.demandbase.com
+        speakerdeck.com platform.twitter.com connect.facebook.net *.facebook.com s3-eu-west-1.amazonaws.com/share.typeform.com/*
         *.github.com *.githubassets.com js.maxmind.com static.ads-twitter.com snap.licdn.com
-        geoip-js.com embed.twitch.tv; style-src ''self'' dwa5x7aod66zk.cloudfront.net
-        ''unsafe-inline'' www.google.com ajax.googleapis.com *.github.com'
+        geoip-js.com embed.twitch.tv analytics.twitter.com *.bing.com *.virtualearth.net
+        *.jquery.com *.cloudflare.com *.bootstrapcdn.com unpkg.com ''nonce-9d92aIH0h3eHkrivYZlcWg=='';
+        style-src ''self'' dwa5x7aod66zk.cloudfront.net ''unsafe-inline'' www.google.com
+        ajax.googleapis.com *.github.com *.bing.com *.virtualearth.net unpkg.com'
       Content-Type:
       - application/json
       Date:
-      - Fri, 21 May 2021 18:04:32 GMT
+      - Wed, 16 Aug 2023 17:44:54 GMT
       Referrer-Policy:
       - strict-origin-when-cross-origin
       Server:
-      - nginx/1.15.12
+      - nginx/1.25.1
       Set-Cookie:
-      - _octo=GH1.1.282664351.1621620272; domain=.github.com; path=/; expires=Sat,
-        21 May 2022 18:04:32 GMT
-      - _education_session=ZnNualVUSGRtbFlkZkFzZXBLd254SkR3M2xZM2tOaTBYdmJQQ091Q3ExTGZqZGFCV1B6R1R1c1cwQjIxTG1zOXd3L1hiY011c0V0dlVpenZySFcvUVE9PS0tbGo2OWMxU3ZyWmNxSDFMazI5TjZodz09--665bc5b6df3bdd5d371ece9f8f778b6d0e4cc19b;
-        path=/; secure; HttpOnly
+      - _octo=GH1.1.373487652.1692207893; domain=.github.com; path=/; expires=Fri,
+        16 Aug 2024 17:44:53 GMT
       Transfer-Encoding:
       - chunked
       X-Content-Type-Options:
@@ -54,9 +57,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-GitHub-Request-Id:
-      - 1874:6016:894CB:6BE870:60A7F630
+      - E02C:4EEA:7A50D:105E79:64DD0B15
       X-Runtime:
-      - '0.040949'
+      - '0.167302'
       X-XSS-Protection:
       - 1; mode=block
       x-download-options:
@@ -65,8 +68,76 @@ interactions:
       - Kubernetes
       x-permitted-cross-domain-policies:
       - none
-      x-request-id:
-      - e943af0f-689a-4302-9ab2-34011a25d603
+    http_version: HTTP/1.1
+    status_code: 401
+- request:
+    body: ''
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      cookie:
+      - _octo=GH1.1.373487652.1692207893
+      host:
+      - education.github.com
+      user-agent:
+      - Default
+    method: GET
+    uri: https://education.github.com/api/user
+  response:
+    content: ''
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Security-Policy:
+      - 'default-src ''self'' dwa5x7aod66zk.cloudfront.net; object-src ''self''; frame-src
+        *.vimeo.com platform.twitter.com connect.facebook.net cdn.usefathom.com *.facebook.com
+        speakerdeck.com *.youtube.com *.youtube-nocookie.com embed.twitch.tv player.twitch.tv;
+        connect-src ''self'' github-education-web.s3.amazonaws.com *.clearbit.com
+        www.google.com *.githubusercontent.com geoip-js.com *.virtualearth.net *.bing.com
+        *.virtualearth.net api.github.com atlas.microsoft.com; img-src ''self'' blob:
+        dwa5x7aod66zk.cloudfront.net data: github.com blobaccountproduction.blob.core.windows.net
+        cdn.usefathom.com *.clearbit.com avatars.githubusercontent.com user-images.githubusercontent.com
+        github-education-web.s3.amazonaws.com analytics.twitter.com t.co t.com *.facebook.com
+        *.twitter.com *.youtube.com raw.githubusercontent.com static-cdn.jtvnw.net
+        dl.airtable.com *.bing.com *.virtualearth.net atlas.microsoft.com; font-src
+        ''self'' dwa5x7aod66zk.cloudfront.net atlas.microsoft.com; script-src ''self''
+        dwa5x7aod66zk.cloudfront.net www.google.com cdn.usefathom.com api.demandbase.com
+        speakerdeck.com platform.twitter.com connect.facebook.net *.facebook.com s3-eu-west-1.amazonaws.com/share.typeform.com/*
+        *.github.com *.githubassets.com js.maxmind.com static.ads-twitter.com snap.licdn.com
+        geoip-js.com embed.twitch.tv analytics.twitter.com *.bing.com *.virtualearth.net
+        *.jquery.com *.cloudflare.com *.bootstrapcdn.com unpkg.com ''nonce-ntysTM3E0mxWir4S9dFfuw=='';
+        style-src ''self'' dwa5x7aod66zk.cloudfront.net ''unsafe-inline'' www.google.com
+        ajax.googleapis.com *.github.com *.bing.com *.virtualearth.net unpkg.com'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 16 Aug 2023 17:44:54 GMT
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - nginx/1.25.1
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-GitHub-Request-Id:
+      - E02C:4EEA:7A526:105EAC:64DD0B16
+      X-Runtime:
+      - '0.089019'
+      X-XSS-Protection:
+      - 1; mode=block
+      x-download-options:
+      - noopen
+      x-github-backend:
+      - Kubernetes
+      x-permitted-cross-domain-policies:
+      - none
     http_version: HTTP/1.1
     status_code: 401
 version: 1

--- a/tests/integration/test_github.py
+++ b/tests/integration/test_github.py
@@ -140,6 +140,58 @@ class TestGithubTestCase(object):
         }
 
     @pytest.mark.asyncio
+    async def test_get_authenticated_user_no_refresh_token(self, codecov_vcr):
+        # To regenerate this test, go to
+        # https://github.com/login/oauth/authorize?response_type=code&scope=user%3Aemail%2Cread%3Aorg%2Crepo%3Astatus%2Cwrite%3Arepo_hook&client_id=999247146557c3ba045c
+        # get the code and paste it here below
+        code = "dc38acf492b071cc4dce"
+        handler = Github(
+            oauth_consumer_token=dict(
+                key="999247146557c3ba045c",
+                secret="testo8lnq6ihj7zsf896r15yxujnl06og9o0fqiu",
+            )
+        )
+        res = await handler.get_authenticated_user(code)
+        print(res)
+        assert res == {
+            "login": "ThiagoCodecov",
+            "id": 44376991,
+            "node_id": "MDQ6VXNlcjQ0Mzc2OTkx",
+            "avatar_url": "https://avatars3.githubusercontent.com/u/44376991?v=4",
+            "gravatar_id": "",
+            "url": "https://api.github.com/users/ThiagoCodecov",
+            "html_url": "https://github.com/ThiagoCodecov",
+            "followers_url": "https://api.github.com/users/ThiagoCodecov/followers",
+            "following_url": "https://api.github.com/users/ThiagoCodecov/following{/other_user}",
+            "gists_url": "https://api.github.com/users/ThiagoCodecov/gists{/gist_id}",
+            "starred_url": "https://api.github.com/users/ThiagoCodecov/starred{/owner}{/repo}",
+            "subscriptions_url": "https://api.github.com/users/ThiagoCodecov/subscriptions",
+            "organizations_url": "https://api.github.com/users/ThiagoCodecov/orgs",
+            "repos_url": "https://api.github.com/users/ThiagoCodecov/repos",
+            "events_url": "https://api.github.com/users/ThiagoCodecov/events{/privacy}",
+            "received_events_url": "https://api.github.com/users/ThiagoCodecov/received_events",
+            "type": "User",
+            "site_admin": False,
+            "name": "Thiago",
+            "company": "@codecov ",
+            "blog": "",
+            "location": None,
+            "email": "thiago@codecov.io",
+            "hireable": None,
+            "bio": None,
+            "twitter_username": None,
+            "public_repos": 3,
+            "public_gists": 0,
+            "followers": 0,
+            "following": 0,
+            "created_at": "2018-10-22T17:51:44Z",
+            "updated_at": "2020-10-14T17:58:13Z",
+            "access_token": "testw5efy5qccduniyucsk5tesu08s4640xtoymv",
+            "token_type": "bearer",
+            "scope": "read:org,repo:status,user:email,write:repo_hook",
+        }
+
+    @pytest.mark.asyncio
     async def test_edit_comment(self, valid_handler, codecov_vcr):
         res = await valid_handler.edit_comment(
             "1", "436811257", "Hello world numbah 2 my friendo"
@@ -149,18 +201,28 @@ class TestGithubTestCase(object):
         assert res["body"] == "Hello world numbah 2 my friendo"
 
     @pytest.mark.asyncio
-    async def test_edit_comment_not_found(self, valid_handler, codecov_vcr):
+    async def test_edit_comment_not_found(
+        self, generic_valid_handler, codecov_vcr, mocker
+    ):
+        mock_refresh = mocker.patch.object(Github, "refresh_token", return_value=None)
         with pytest.raises(TorngitObjectNotFoundError):
-            await valid_handler.edit_comment("1", "113979999", "Hello world number 2")
+            await generic_valid_handler.edit_comment(
+                "1", "113979999", "Hello world number 2"
+            )
+        mock_refresh.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_delete_comment(self, valid_handler, codecov_vcr):
         assert await valid_handler.delete_comment("1", "708545249") is True
 
     @pytest.mark.asyncio
-    async def test_delete_comment_not_found(self, valid_handler, codecov_vcr):
+    async def test_delete_comment_not_found(
+        self, generic_valid_handler, codecov_vcr, mocker
+    ):
+        mock_refresh = mocker.patch.object(Github, "refresh_token", return_value=None)
         with pytest.raises(TorngitObjectNotFoundError):
-            await valid_handler.delete_comment("1", 113977999)
+            await generic_valid_handler.delete_comment("1", 113977999)
+        mock_refresh.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_find_pull_request_nothing_found(
@@ -179,9 +241,13 @@ class TestGithubTestCase(object):
         assert await generic_valid_handler.find_pull_request(commitid) == 1
 
     @pytest.mark.asyncio
-    async def test_get_pull_request_fail(self, valid_handler, codecov_vcr):
+    async def test_get_pull_request_fail(
+        self, generic_valid_handler, codecov_vcr, mocker
+    ):
+        mock_refresh = mocker.patch.object(Github, "refresh_token", return_value=None)
         with pytest.raises(TorngitObjectNotFoundError):
-            await valid_handler.get_pull_request("100")
+            await generic_valid_handler.get_pull_request("100")
+        mock_refresh.assert_called_once()
 
     get_pull_request_test_data = [
         (
@@ -317,22 +383,26 @@ class TestGithubTestCase(object):
 
     @pytest.mark.asyncio
     async def test_get_commit_no_permissions(
-        self, valid_but_no_permissions_handler, codecov_vcr
+        self, valid_but_no_permissions_handler, codecov_vcr, mocker
     ):
+        mock_refresh = mocker.patch.object(Github, "refresh_token", return_value=None)
         commitid = "bbe3e94949d11471cc4e054f822d222254a4a4f8"
         with pytest.raises(TorngitRepoNotFoundError):
             await valid_but_no_permissions_handler.get_commit(commitid)
+        mock_refresh.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_get_commit_repo_doesnt_exist(
-        self, repo_doesnt_exist_handler, codecov_vcr
+        self, repo_doesnt_exist_handler, codecov_vcr, mocker
     ):
+        mock_refresh = mocker.patch.object(Github, "refresh_token", return_value=None)
         commitid = "bbe3e94949d11471cc4e054f822d222254a4a4f8"
         with pytest.raises(TorngitRepoNotFoundError) as ex:
             await repo_doesnt_exist_handler.get_commit(commitid)
         expected_response = '{"message":"Not Found","documentation_url":"https://docs.github.com/rest/reference/repos#get-a-commit"}'
         exc = ex.value
         assert exc.response_data == expected_response
+        mock_refresh.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_get_commit_diff(self, valid_handler, codecov_vcr):
@@ -626,9 +696,11 @@ class TestGithubTestCase(object):
         assert res is True
 
     @pytest.mark.asyncio
-    async def test_delete_webhook_not_found(self, valid_handler, codecov_vcr):
+    async def test_delete_webhook_not_found(self, valid_handler, codecov_vcr, mocker):
+        mock_refresh = mocker.patch.object(Github, "refresh_token", return_value=None)
         with pytest.raises(TorngitObjectNotFoundError):
             await valid_handler.delete_webhook("4742f011-8397-aa77-8876-5e9a06f10f98")
+        mock_refresh.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_get_authenticated(self, valid_handler, codecov_vcr):
@@ -869,13 +941,17 @@ class TestGithubTestCase(object):
         assert res == expected_result
 
     @pytest.mark.asyncio
-    async def test_get_source_random_commit_not_found(self, valid_handler, codecov_vcr):
+    async def test_get_source_random_commit_not_found(
+        self, valid_handler, codecov_vcr, mocker
+    ):
+        mock_refresh = mocker.patch.object(Github, "refresh_token", return_value=None)
         path, ref = (
             "awesome/non_exising_file.py",
             "96492d409fc86aa7ae31b214dfe6b08ae860458a",
         )
         with pytest.raises(TorngitObjectNotFoundError):
             await valid_handler.get_source(path, ref)
+        mock_refresh.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_list_repos(self, valid_handler, codecov_vcr):

--- a/tests/integration/test_github.py
+++ b/tests/integration/test_github.py
@@ -23,7 +23,7 @@ def generic_valid_handler():
     return Github(
         repo=dict(name="example-python"),
         owner=dict(username="codecove2e"),
-        token=dict(key=10 * "a280"),
+        token=dict(key=10 * "a280", refresh_token=10 * "a180"),
     )
 
 
@@ -134,6 +134,7 @@ class TestGithubTestCase(object):
             "created_at": "2018-10-22T17:51:44Z",
             "updated_at": "2020-10-14T17:58:13Z",
             "access_token": "testw5efy5qccduniyucsk5tesu08s4640xtoymv",
+            "refresh_token": "testblahblahblahblahsfas",
             "token_type": "bearer",
             "scope": "read:org,repo:status,user:email,write:repo_hook",
         }
@@ -1307,9 +1308,13 @@ class TestGithubTestCase(object):
         assert not res
 
     @pytest.mark.asyncio
-    async def test_is_student_not_capable_app(self, valid_handler, codecov_vcr):
-        res = await valid_handler.is_student()
+    async def test_is_student_not_capable_app(
+        self, generic_valid_handler, codecov_vcr, mocker
+    ):
+        mock_refresh = mocker.patch.object(Github, "refresh_token")
+        res = await generic_valid_handler.is_student()
         assert not res
+        assert mock_refresh.call_count == 0
 
     @pytest.mark.asyncio
     async def test_is_student_github_education_503(self, valid_handler, codecov_vcr):

--- a/tests/unit/torngit/test_github.py
+++ b/tests/unit/torngit/test_github.py
@@ -1,17 +1,21 @@
+import asyncio
 import pickle
-from urllib.parse import parse_qsl, urlparse
+from urllib.parse import parse_qs, parse_qsl, urlparse
 
 import httpx
 import pytest
 import respx
+from mock import MagicMock
 
 from shared.torngit.base import TokenType
 from shared.torngit.exceptions import (
+    TorngitCantRefreshTokenError,
     TorngitClientError,
     TorngitClientGeneralError,
     TorngitMisconfiguredCredentials,
     TorngitObjectNotFoundError,
     TorngitRateLimitError,
+    TorngitRefreshTokenFailedError,
     TorngitServer5xxCodeError,
     TorngitServerUnreachableError,
     TorngitUnauthorizedError,
@@ -31,7 +35,11 @@ def valid_handler():
     return Github(
         repo=dict(name="example-python"),
         owner=dict(username="ThiagoCodecov"),
-        token=dict(key="some_key"),
+        token=dict(key="some_key", refresh_token="refresh_token"),
+        oauth_consumer_token=dict(
+            key="client_id",
+            secret="client_secret",
+        ),
     )
 
 
@@ -44,6 +52,7 @@ def ghapp_handler():
         oauth_consumer_token=dict(
             key="client_id",
             secret="client_secret",
+            refresh_token="refresh_token",
         ),
     )
 
@@ -54,20 +63,24 @@ class TestUnitGithub(object):
         client = mocker.MagicMock(
             request=mocker.AsyncMock(return_value=mocker.MagicMock(status_code=599))
         )
+        mock_refresh = mocker.patch.object(Github, "refresh_token")
         method = "GET"
         url = "random_url"
         with pytest.raises(TorngitServerUnreachableError):
             await valid_handler.api(client, method, url)
+        assert mock_refresh.call_count == 0
 
     @pytest.mark.asyncio
     async def test_api_client_error_unauthorized(self, valid_handler, mocker):
         client = mocker.MagicMock(
             request=mocker.AsyncMock(return_value=mocker.MagicMock(status_code=401))
         )
+        mock_refresh = mocker.patch.object(Github, "refresh_token")
         method = "GET"
-        url = "random_url"
+        url = "https://api.github.com/some_endpoint"
         with pytest.raises(TorngitUnauthorizedError):
             await valid_handler.api(client, method, url)
+        assert mock_refresh.call_count == 1
 
     @pytest.mark.asyncio
     async def test_api_client_error_ratelimit_reached(self):
@@ -210,10 +223,12 @@ class TestUnitGithub(object):
                 ]
             )
         )
+        mock_refresh = mocker.patch.object(Github, "refresh_token")
         method = "GET"
-        url = "random_url"
+        url = "https://api.github.com/some_endpoint"
         res = await valid_handler.api(client, method, url, statuses_to_retry=[401])
         assert res == "FOUND"
+        assert mock_refresh.call_count == 1
 
     @pytest.mark.asyncio
     async def test_api_almost_too_many_retries(self, valid_handler, mocker):
@@ -226,10 +241,12 @@ class TestUnitGithub(object):
                 ]
             )
         )
+        mock_refresh = mocker.patch.object(Github, "refresh_token")
         method = "GET"
-        url = "random_url"
+        url = "https://api.github.com/some_endpoint"
         res = await valid_handler.api(client, method, url, statuses_to_retry=[401])
         assert res == "FOUND"
+        assert mock_refresh.call_count == 1
 
     @pytest.mark.asyncio
     async def test_api_too_many_retries(self, valid_handler, mocker):
@@ -243,10 +260,12 @@ class TestUnitGithub(object):
                 ]
             )
         )
+        mock_refresh = mocker.patch.object(Github, "refresh_token")
         method = "GET"
-        url = "random_url"
+        url = "https://api.github.com/some_endpoint"
         with pytest.raises(TorngitClientError):
             await valid_handler.api(client, method, url, statuses_to_retry=[401])
+        assert mock_refresh.call_count == 1
 
     def test_get_token_by_type_if_none(self):
         instance = Github(
@@ -1174,3 +1193,147 @@ class TestUnitGithub(object):
                 == "Github API rate limit error: secondary rate limit"
             )
             assert excinfo.value.retry_after == 60
+
+    @pytest.mark.asyncio
+    async def test_github_refresh_fail_terminates_unavailable(
+        self, mocker, valid_handler
+    ):
+        with pytest.raises(TorngitRefreshTokenFailedError) as exp:
+            with respx.mock:
+                mocked_refresh = respx.post(
+                    "https://github.com/login/oauth/access_token"
+                ).mock(
+                    return_value=httpx.Response(
+                        status_code=502, content="Service unavailable try again later"
+                    )
+                )
+                await valid_handler.refresh_token(valid_handler.get_client())
+            assert exp.code == 555
+        mocked_refresh.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_github_refresh_fail_terminates_unauthorized(
+        self, mocker, valid_handler
+    ):
+        with pytest.raises(TorngitRefreshTokenFailedError) as exp:
+            with respx.mock:
+                mocked_refresh = respx.post(
+                    "https://github.com/login/oauth/access_token"
+                ).mock(
+                    return_value=httpx.Response(
+                        status_code=403, content='{"error": "unauthorized"}'
+                    )
+                )
+                await valid_handler.refresh_token(valid_handler.get_client())
+            assert exp.code == 555
+        mocked_refresh.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_github_refresh_fail_terminates_bad_request(
+        self, mocker, valid_handler
+    ):
+        old_token = valid_handler._token
+        valid_handler._token = {"access_token": "old_token_without_refresh"}
+        with pytest.raises(TorngitCantRefreshTokenError) as exp:
+            with respx.mock:
+                mocked_refresh = respx.post(
+                    "https://github.com/login/oauth/access_token"
+                ).mock(
+                    return_value=httpx.Response(
+                        status_code=403, content='{"error": "unauthorized"}'
+                    )
+                )
+                await valid_handler.refresh_token(valid_handler.get_client())
+            assert exp.code == 555
+            assert exp.response_data is None
+        mocked_refresh.call_count == 1
+        valid_handler._token = old_token
+
+    @pytest.mark.asyncio
+    async def test_gihub_double_refresh(self, mocker, valid_handler):
+        def side_effect(request, *args, **kwargs):
+            url_parts = urlparse(str(request.url))
+            query = url_parts.query
+            params = parse_qs(query)
+            refresh_token = params["refresh_token"][0]
+            if refresh_token == "refresh_token":
+                return httpx.Response(
+                    status_code=200,
+                    headers={"Content-Type": "application/x-www-form-urlencoded"},
+                    text="access_token=new_access_token&token_type=bearer&refresh_token=new_refresh_token",
+                )
+            elif refresh_token == "new_refresh_token":
+                return httpx.Response(
+                    status_code=200,
+                    headers={"Content-Type": "application/x-www-form-urlencoded"},
+                    text="access_token=newer_access_token&token_type=bearer&refresh_token=newer_refresh_token",
+                )
+            pytest.fail(f"Wrong token received")
+
+        assert valid_handler._oauth == dict(key="client_id", secret="client_secret")
+
+        with respx.mock:
+            mocked_refresh = respx.post(
+                "https://github.com/login/oauth/access_token"
+            ).mock(side_effect=side_effect)
+            await valid_handler.refresh_token(valid_handler.get_client())
+            assert mocked_refresh.call_count == 1
+            assert valid_handler._token == dict(
+                key="new_access_token", refresh_token="new_refresh_token"
+            )
+
+            await valid_handler.refresh_token(valid_handler.get_client())
+            assert mocked_refresh.call_count == 2
+            assert valid_handler._token == dict(
+                key="newer_access_token", refresh_token="newer_refresh_token"
+            )
+
+        # Make sure that changing the token doesn't change the _oauth
+        assert valid_handler._oauth == dict(key="client_id", secret="client_secret")
+
+    @pytest.mark.asyncio
+    async def test_github_refresh_after_failed_request(self, mocker, valid_handler):
+        def side_effect(request, *args, **kwargs):
+            print(f"Received request with headers {request.headers['Authorization']}")
+            token = request.headers["Authorization"]
+            if token == "token some_key":
+                return httpx.Response(
+                    status_code=401,
+                    content='{"message":"Bad Request"}',
+                )
+            elif token == "token new_access_token":
+                return httpx.Response(
+                    status_code=200, json={"state": "active", "role": "admin"}
+                )
+            pytest.fail(f"Wrong token received ({token})")
+
+        f = asyncio.Future()
+        f.set_result(True)
+        mock_refresh_callback: MagicMock = mocker.patch.object(
+            valid_handler, "_on_token_refresh", create=True, return_value=f
+        )
+        with respx.mock:
+            mocked_route = respx.get(
+                "https://api.github.com/orgs/ThiagoCodecov/memberships/John%20Doe"
+            ).mock(side_effect=side_effect)
+            mocked_refresh = respx.post(
+                "https://github.com/login/oauth/access_token"
+            ).mock(
+                return_value=httpx.Response(
+                    status_code=200,
+                    headers={"Content-Type": "application/x-www-form-urlencoded"},
+                    text="access_token=new_access_token&token_type=bearer&refresh_token=new_refresh_token",
+                )
+            )
+            await valid_handler.get_is_admin(user={"username": "John Doe"})
+        assert mocked_route.call_count == 2
+        assert mocked_refresh.call_count == 1
+        assert valid_handler._token["key"] == "new_access_token"
+        assert valid_handler._token["refresh_token"] == "new_refresh_token"
+        assert mock_refresh_callback.call_count == 1
+        assert mock_refresh_callback.called_with(
+            {
+                "access_token": "new_access_token",
+                "refresh_token": "new_refresh_token",
+            }
+        )


### PR DESCRIPTION
Adding support for github app refresh tokens.
This is currently an opt-in feature for github apps (what we use to auth users).

closes codecov/engineering-team#163

<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.