### PR TITLE
chore: update gh refresh heuristic

### DIFF
--- a/tests/integration/test_github.py
+++ b/tests/integration/test_github.py
@@ -14,6 +14,7 @@ def valid_handler():
         repo=dict(name="example-python"),
         owner=dict(username="ThiagoCodecov"),
         token=dict(key=10 * "a280"),
+        on_token_refresh=lambda token: token,
     )
 
 
@@ -24,6 +25,7 @@ def generic_valid_handler():
         repo=dict(name="example-python"),
         owner=dict(username="codecove2e"),
         token=dict(key=10 * "a280", refresh_token=10 * "a180"),
+        on_token_refresh=lambda token: token,
     )
 
 
@@ -385,24 +387,20 @@ class TestGithubTestCase(object):
     async def test_get_commit_no_permissions(
         self, valid_but_no_permissions_handler, codecov_vcr, mocker
     ):
-        mock_refresh = mocker.patch.object(Github, "refresh_token", return_value=None)
         commitid = "bbe3e94949d11471cc4e054f822d222254a4a4f8"
         with pytest.raises(TorngitRepoNotFoundError):
             await valid_but_no_permissions_handler.get_commit(commitid)
-        mock_refresh.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_get_commit_repo_doesnt_exist(
         self, repo_doesnt_exist_handler, codecov_vcr, mocker
     ):
-        mock_refresh = mocker.patch.object(Github, "refresh_token", return_value=None)
         commitid = "bbe3e94949d11471cc4e054f822d222254a4a4f8"
         with pytest.raises(TorngitRepoNotFoundError) as ex:
             await repo_doesnt_exist_handler.get_commit(commitid)
         expected_response = '{"message":"Not Found","documentation_url":"https://docs.github.com/rest/reference/repos#get-a-commit"}'
         exc = ex.value
         assert exc.response_data == expected_response
-        mock_refresh.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_get_commit_diff(self, valid_handler, codecov_vcr):


### PR DESCRIPTION
Yes I know, this should have been part of codecov.shared#27

I decided to come back and restrict the requests we will try to refresh a little.
By checking the callable first we avoid app-to-server requests, which should
represent a considerable portion of requests to github, in fact.

So here's a rough list of requests that wi will NOT try to refresh:
* check if user is a student
* any request made by the codecov github app
* any request made by a repo bot
* requests for repo information made in `sync_repos` or `sync_teams`

hopefully by restricting the attempts at refreshing info we avoid unecessary reqeusts to gh.

context codecov/engineering-team#162

<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.