### PR TITLE
Fix BB get_branch, omit indexing into values

### DIFF
--- a/shared/torngit/bitbucket.py
+++ b/shared/torngit/bitbucket.py
@@ -711,8 +711,8 @@ class Bitbucket(TorngitBaseAdapter):
                 token=token,
             )
             return {
-                "name": res["values"]["name"],
-                "sha": res["values"]["target"]["hash"],
+                "name": res["name"],
+                "sha": res["target"]["hash"],
             }
 
     async def get_pull_requests(self, state="open", token=None):


### PR DESCRIPTION
Was a bug where we were indexing into values in the return from the BB API call in get_branch but that key doesn't exist for the singular branch API call