### PR TITLE
fix: use committer date in github

### DIFF
--- a/shared/torngit/github.py
+++ b/shared/torngit/github.py
@@ -987,7 +987,7 @@ class Github(TorngitBaseAdapter):
             commitid=commit,
             parents=[p["sha"] for p in res["parents"]],
             message=res["commit"]["message"],
-            timestamp=res["commit"]["author"].get("date"),
+            timestamp=res["commit"]["committer"].get("date"),
         )
 
     # Pull Requests

--- a/tests/integration/test_github.py
+++ b/tests/integration/test_github.py
@@ -369,7 +369,7 @@ class TestGithubTestCase(object):
             "commitid": "75f355d8d14ba3d7761c728b4d2607cde0eef065",
             "parents": ["f0895290dc26668faeeb20ee5ccd4cc995925775"],
             "message": "Adding README\n\nsurpriseaAKDS\n\nddkokgfnskfds\n\nBanana\n\nYallow\n\nABG",
-            "timestamp": "2020-05-18T03:16:22Z",
+            "timestamp": "2020-10-13T15:15:31Z",
         }
 
         commit = await valid_handler.get_commit(


### PR DESCRIPTION
context: codecov/codecov-api#97

Recently we had a situation in which a commit with a future date was not handled
properly by the system.

After some investigation the issue (obviously) was around the date. Turns out
we only update the HEAD commit of a PR if the candidate's timestamp is newer
than the HEAD's timestamp. For a commit in the future that poses a problem
because it will never be replaced with another HEAD (unless the future becomes present)

Git declares 2 different dates for commits, AuthorDate and CommitDate [read more](https://stackoverflow.com/questions/11856983/why-is-git-authordate-different-from-commitdate/11857467#11857467).
With GitHub we were usign the AuthorDate (which can be changed by `--date` arg).

My understanding is that the `CommitDate` is not user-configured (usually, but apparently there's an env var for that),
HOWEVER it get's updated by rebases, amends, force-pushes, etc.

We _only_ set the commit date when we first receive an upload for it, and never again.
In most cases this will be equal to the author date.
In the particular case of a future AuthorDate it will be the present-ish date when the commit was made.
I do believe that even with the changes to CommitDate using that instead of AuthorDate will
give us more confidence of a linear branch history.

In fact, we use the CommitDate with [gitlab](https://github.com/codecov/shared/blob/acd92377ff0085e83bb921ec59284cad2c5254b6/shared/torngit/gitlab.py#L747)

I do believe that using this date will fix the PR Head update issue that we had,
without introducing new bugs to that logic,
and would have handled the force-push correctly and then not merged that future commit.

fix codecov/codecov-api#97

<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.