### PR TITLE
Add slack_app field to user yaml schema

### DIFF
--- a/shared/config/__init__.py
+++ b/shared/config/__init__.py
@@ -48,6 +48,7 @@ default_config = {
             "behavior": "default",
             "show_carryforward_flags": False,
         },
+        "slack_app": True,
         "github_checks": {"annotations": True},
     },
     "setup": {

--- a/shared/validation/user_schema.py
+++ b/shared/validation/user_schema.py
@@ -459,6 +459,10 @@ schema = {
             "hide_project_coverage": {"type": "boolean"},
         },
     },
+    "slack_app": {
+        "type": ["dict", "boolean"],
+        "schema": {"enabled": {"type": "boolean"}},
+    },
     "github_checks": {
         "type": ["dict", "boolean"],
         "schema": {"annotations": {"type": "boolean"}},

--- a/tests/unit/validation/test_validation.py
+++ b/tests/unit/validation/test_validation.py
@@ -849,6 +849,7 @@ class TestValidationConfig(object):
                 "show_carryforward_flags": False,
             },
             "github_checks": {"annotations": True},
+            "slack_app": True,
         }
         res = validate_yaml(
             get_config("site", default={}),
@@ -1318,4 +1319,16 @@ def test_cli_validation():
     }
     result = validate_yaml(user_input)
     # There's no change on the valid yaml
+    assert result == user_input
+
+
+def test_slack_app_validation():
+    user_input = {"slack_app": {"enabled": True}}
+    result = validate_yaml(user_input)
+    assert result == user_input
+
+
+def test_slack_app_validation_boolean():
+    user_input = {"slack_app": True}
+    result = validate_yaml(user_input)
     assert result == user_input


### PR DESCRIPTION
This field can be either a boolean or a dict
with that contains the key enabled which is
a boolean.

This change was made to support toggling the codecov slack app notification.