### PR TITLE
chore: Extend visibility_timeout

### DIFF
--- a/shared/celery_config.py
+++ b/shared/celery_config.py
@@ -98,7 +98,7 @@ class BaseCeleryConfig(object):
         "services", "redis_url"
     )
 
-    broker_transport_options = {"visibility_timeout": 60 * 60 * 5}  # 5 hours
+    broker_transport_options = {"visibility_timeout": (60 * 60 * 6)}  # 6 hours
     result_extended = True
     task_default_queue = get_config(
         "setup", "tasks", "celery", "default_queue", default="celery"

--- a/tests/unit/test_celery_config.py
+++ b/tests/unit/test_celery_config.py
@@ -50,7 +50,7 @@ def test_celery_config():
         "app.tasks.upload.*",
         "app.tasks.verify_bot.VerifyBot",
     ]
-    assert config.broker_transport_options == {"visibility_timeout": 18000}
+    assert config.broker_transport_options == {"visibility_timeout": 21600}
     assert config.result_extended is True
     assert config.imports == ("tasks",)
     assert config.task_serializer == "json"


### PR DESCRIPTION
docs say that [visibility_timeout](https://docs.celeryq.dev/en/v4.2.1/getting-started/brokers/redis.html#id1) does:

> If a task isn’t acknowledged within the Visibility Timeout the task will be redelivered to another worker and executed.
> This causes problems with ETA/countdown/retry tasks where the time to execute exceeds the visibility timeout;

Our current visibility timeout is 5h, which matches our longest `countdown` (in the upload_processor task).
Currently all tasks are NOT `acks_late`, so they are ACKed when they start executing. Thus, the visibility timout is OK
as is.

However in codecov/engineering-team#18 we do want to make upload_processor acks_late. So it will only be acked AFTER
executing. This means that if after 5h it starts executing and takes say 10mins to execute, some other worker could
pick up the same task and start executing it again. We don't want that.

(You could argue that the task should be idempotent anyway so it doesn't matter if it's executed twice successfully,
but because it depends on the raw_upload it can only execute once successfully. If it errors than we can execute more than once.)

To prevent this from happening we have to extend the visibility_timeout to take into consideration the time it takes
to execute upload_processor. We know it can take several minutes. I was very generous and gave it 1h.

context: codecov/engineering-team#18

<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.