### PR TITLE
extending yaml to have pubsub config values

### DIFF
--- a/shared/validation/install.py
+++ b/shared/validation/install.py
@@ -128,6 +128,14 @@ config_schema = {
                 "type": "dict",
                 "schema": {"key": {"type": "string"}, "enabled": {"type": "boolean"}},
             },
+            "pubsub": {
+                "type": "dict",
+                "schema": {
+                    "project_id": {"type": "string"},
+                    "topic": {"type": "string"},
+                    "enabled": {"type": "boolean"},
+                },
+            },
             "http": {
                 "type": "dict",
                 "schema": {

--- a/tests/unit/validation/test_install_validation.py
+++ b/tests/unit/validation/test_install_validation.py
@@ -381,6 +381,28 @@ def test_validate_install_configuration_with_additional_yamls():
     }
 
 
+def test_pubsub_config(mocker):
+    assert validate_install_configuration(
+        {
+            "setup": {
+                "pubsub": {
+                    "project_id": "1234",
+                    "topic": "codecov",
+                    "enabled": True,
+                }
+            },
+        }
+    ) == {
+        "setup": {
+            "pubsub": {
+                "project_id": "1234",
+                "topic": "codecov",
+                "enabled": True,
+            }
+        },
+    }
+
+
 def test_validate_install_configuration_raise_warning(mocker):
     mock_warning = mocker.patch.object(install_log, "warning")
     input = {


### PR DESCRIPTION
<!-- Describe your PR here. -->
This is needed to add pubsub configurations


<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.