### PR TITLE
Remove ssl from smtp config and make smtp field optional

### DIFF
--- a/shared/validation/install.py
+++ b/shared/validation/install.py
@@ -301,15 +301,8 @@ config_schema = {
                     "port": {"type": "integer"},
                     "username": {"type": "string", "required": False},
                     "password": {"type": "string", "required": False},
-                    "ssl": {
-                        "type": "dict",
-                        "schema": {
-                            "keyfile": {"type": "string", "required": False},
-                            "certfile": {"type": "string", "required": False},
-                        },
-                        "required": False,
-                    },
                 },
+                "required": False,
             },
         },
     },


### PR DESCRIPTION
Don't really need the ssl field and I want to make the SMTP field optional in order to have sending email be optional