### PR TITLE
feat: create Feature class for handling feature rollouts

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
         "oauthlib",
         "redis",
         "typing",
+        "mmh3",
         "typing_extensions",
         "google-auth==2.21.0",
         "google-cloud-pubsub>=2.13.6",

--- a/shared/rollouts/__init__.py
+++ b/shared/rollouts/__init__.py
@@ -1,0 +1,150 @@
+from functools import cached_property, lru_cache
+
+import mmh3
+
+
+class FeatureVariant:
+    """
+    Represents a variant of the feature being rolled out and the proportion of
+    the test population it should be rolled out to. The proportion should be a
+    float between 0 and 1. A proportion of 0.5 means 50% of the test population
+    should receive this variant.
+
+    A simple on/off feature rollout will have one variant:
+        {"enabled": FeatureVariant(True, 1.0)}
+
+    A simple A/B test will have two variants:
+        {
+            "test": FeatureVariant(True, 0.5),
+            "control": FeatureVariant(False, 0.5),
+        }
+    """
+
+    def __init__(self, value, proportion):
+        assert proportion > 0 and proportion <= 1.0
+        self.value = value
+        self.proportion = proportion
+
+
+class Feature:
+    """
+    Represents a feature and its rollout parameters. Given an identifier, it can
+    decide which variant of a feature (if any) should be enabled for the
+    request.
+
+    A simple on/off feature rolled out to 20% of repos:
+        # By default, features have a single variant:
+        #   {"enabled": FeatureVariant(True, 1.0)}
+        MY_FEATURE_BY_REPO = Feature("my_feature", 0.2)
+
+    A simple A/B test rolled out to 10% of users (5% test, 5% control):
+        MY_EXPERIMENT_BY_USER = Feature(
+            "my_experiment",
+            0.1,
+            variants={
+                "test": FeatureVariant(True, 0.5),
+                "control": FeatureVariant(False, 0.5),
+            },
+        )
+
+    After creating a feature, you can check it in code like so:
+        from shared.rollouts.features import MY_FEATURE
+        if MY_FEATURE.check_value(user_id, default=False):
+            new_behavior()
+
+    You can roll a feature out to different populations by passing in different
+    identifiers:
+    - pass in a user id to roll out to X% of users
+    - pass in a repo id to roll out to X% of repos
+    - pass in an org id to roll out to X% of orgs
+    - pass in a sentry trace id or similar to roll out to X% of requests
+
+    Try to be consistent - if you pass a repo id in one place, pass a repo id
+    everywhere (including in overrides).
+
+    Parameters:
+    - `name`: a unique name for the experiment.
+    - `proportion`: a float between 0 and 1 representing how much of the
+      population should get a variant of the feature. 0.5 means 50%.
+    - `variants`: a dictionary {name: FeatureVariant()}. The default value works
+      for a simple on/off feature rollout.
+    - `salt`: a way to effectively re-shuffle which bucket each id falls into
+    - `overrides`: a dictionary {id: variant name}. Used to opt specific repos
+      into a specific feature variant for example.
+
+    If you discover a bug and roll back your feature, it's good practice to
+    change the salt to any other string before restarting the rollout. Changing
+    the salt basically reassigns every id to a new bucket so the same users
+    don't feel churned by our rocky rollout.
+    """
+
+    HASHSPACE = 2**128
+
+    def __init__(
+        self,
+        name,
+        proportion,
+        variants={"enabled": FeatureVariant(True, 1.0)},
+        salt="",
+        overrides={},
+    ):
+        assert sum(map(lambda x: x.proportion, variants.values())) == 1.0
+        assert proportion > 0 and proportion <= 1.0
+        self.name = name
+        self.proportion = proportion
+        self.variants = variants
+        self.salt = salt
+        self.overrides = overrides
+
+    @cached_property
+    def _buckets(self):
+        """
+        Calculates the bucket boundaries for feature variants. Simple logic but
+        the use of floats and int casting may introduce error.
+
+        To check if a feature should be enabled for a specific repo (for instance)
+        this class will compute a hash including:
+        - The experiment's name
+        - The repo's id
+        - (Optional) A unique salt
+
+        The range of possible hash values is divvied up into buckets based on the
+        `proportion` and `variants` members. The hash for this repo will fall into
+        one of those buckets and the corresponding variant (or default value) will
+        be returned.
+        """
+        test_population = int(self.proportion * Feature.HASHSPACE)
+
+        buckets = []
+        quantile = 0
+        for variant in self.variants.values():
+            quantile += variant.proportion
+            buckets.append((int(quantile * test_population), variant))
+
+        return buckets
+
+    # NOTE: `@lru_cache` on instance methods is ordinarily a bad idea:
+    # - the cache is not per-instance; it's shared by all class instances
+    # - by holding references to function arguments in the cache, it prolongs
+    #   their lifetimes. Since `self` is a function argument, the cache will
+    #   prevent any instance from getting freed until it is evicted from the
+    #   cache which could be a significant memory leak.
+    # In this case, we are okay with sharing a cache across instances, and the
+    # instances are all global constants so they won't be torn down anyway.
+    @lru_cache(maxsize=50)
+    def check_value(self, identifier, default=None):
+        identifer = str(identifier)  # just in case
+        if identifier in self.overrides:
+            override_variant = self.overrides[identifier]
+            return self.variants[override_variant].value
+        elif self.proportion == 1.0 and len(self.variants) == 1:
+            # This feature is fully rolled out, since it only has one variant,
+            # we can skip the hashing and just return its value.
+            return next(iter(self.variants.values())).value
+
+        key = mmh3.hash128(self.name + identifier + self.salt)
+        for bucket, variant in self._buckets:
+            if key <= bucket:
+                return variant.value
+
+        return default

--- a/shared/rollouts/__init__.py
+++ b/shared/rollouts/__init__.py
@@ -21,7 +21,7 @@ class FeatureVariant:
     """
 
     def __init__(self, value, proportion):
-        assert proportion > 0 and proportion <= 1.0
+        assert proportion >= 0 and proportion <= 1.0
         self.value = value
         self.proportion = proportion
 
@@ -89,7 +89,7 @@ class Feature:
         overrides={},
     ):
         assert sum(map(lambda x: x.proportion, variants.values())) == 1.0
-        assert proportion > 0 and proportion <= 1.0
+        assert proportion >= 0 and proportion <= 1.0
         self.name = name
         self.proportion = proportion
         self.variants = variants

--- a/shared/rollouts/features.py
+++ b/shared/rollouts/features.py
@@ -1,3 +1,14 @@
-PARALLEL_UPLOAD_PROCESSING_BY_ORG = Feature(
-    "parllel_upload_processing", 0.2, overrides={"codecov's id": True}
-)
+# This file "defines" features which actually should live in the worker. It
+# serves as a model for how this feature flag utility is recommended to be used
+# in other repositories: with a central file in which all experiments are
+# declared so that it's easier to see how much runtime variability there is in
+# the way our service behaves. Unreproducible bug report from a customer? Check
+# if there have been any recent feature changes that sound related.
+#
+# PARALLEL_UPLOAD_PROCESSING_BY_ORG = Feature(
+#     "parllel_upload_processing", 0.2, overrides={"codecov's id": True}
+# )
+#
+# LIST_REPOS_GENERATOR_BY_ORG = Feature(
+#     "list_repos_generator", 0.5, overrides={"codecov's id": True)
+# )

--- a/shared/rollouts/features.py
+++ b/shared/rollouts/features.py
@@ -1,0 +1,3 @@
+PARALLEL_UPLOAD_PROCESSING_BY_ORG = Feature(
+    "parllel_upload_processing", 0.2, overrides={"codecov's id": True}
+)

--- a/tests/unit/test_rollouts.py
+++ b/tests/unit/test_rollouts.py
@@ -1,0 +1,82 @@
+from shared.rollouts import Feature, FeatureVariant
+
+
+class TestFeature(object):
+    def test_buckets(self, mocker):
+        complex_feature = Feature(
+            "complex",
+            0.5,
+            variants={
+                "a": FeatureVariant(1, 1 / 3),
+                "b": FeatureVariant(2, 1 / 3),
+                "c": FeatureVariant(3, 1 / 3),
+            },
+        )
+        # To make the math simpler, let's pretend our hash function can only
+        # return 200 different values.
+        mocker.patch.object(Feature, "HASHSPACE", 200)
+
+        # Because the top-level feature proportion is 0.5, we are only using the
+        # first 50% of our 200 hash values as our test population: [0..100]
+        # Each feature variant has a proportion of 1/3, so our three buckets
+        # should be [0..33], [34..66], and [67..100]. Anything from [101..200]
+        # is not part of the rollout yet.
+        buckets = complex_feature._buckets
+        assert list(map(lambda x: x[0], buckets)) == [33, 66, 100]
+
+    def test_fully_rolled_out(self, mocker):
+        # If the feature is 100% rolled out and only has one variant, then we
+        # should skip the hashing and bucket stuff and just return the single
+        # possible value.
+        feature = Feature(
+            "rolled_out", 1.0, variants={"enabled": FeatureVariant(True, 1.0)}
+        )
+        mock_buckets = mocker.patch.object(feature, "_buckets")
+
+        assert feature.check_value("any", default=False) == True
+        assert not mock_buckets.called
+
+    def test_overrides(self, mocker):
+        # If an identifier was manually opted into a specific variant, skip the
+        # hashing and just return the value for that variant.
+        feature = Feature(
+            "overrides",
+            1.0,
+            variants={"a": FeatureVariant(1, 0.5), "b": FeatureVariant(2, 0.5)},
+            overrides={"overridden": "b"},
+        )
+        mock_buckets = mocker.patch.object(feature, "_buckets")
+
+        assert feature.check_value("overridden", default=1) == 2
+        assert not mock_buckets.called
+
+    def test_not_in_test_gets_default(self, mocker):
+        feature = Feature(
+            "not_in_test", 0.1, variants={"enabled": FeatureVariant(True, 1.0)}
+        )
+        # If the feature is only 10% rolled out, 2**128-1 is way past the end of
+        # the test population and should get a default value back.
+        mocker.patch("mmh3.hash128", return_value=2**128 - 1)
+
+        assert feature.check_value("not in test", default="default") == "default"
+
+    def test_return_values_for_each_bucket(self, mocker):
+        feature = Feature(
+            "return_values_for_each_bucket",
+            1.0,
+            variants={
+                "a": FeatureVariant("first bucket", 0.5),
+                "b": FeatureVariant("second bucket", 0.5),
+            },
+        )
+        # To make the math simpler, let's pretend our hash function can only
+        # return 100 different values.
+        mocker.patch.object(Feature, "HASHSPACE", 100)
+
+        # The feature is 100% rolled out and has two variants at 50% each. So,
+        # the buckets are [0..50] and [51..100]. Mock the hash function to
+        # return a value in the first bucket and then a value in the second.
+        mocker.patch("mmh3.hash128", side_effect=[33, 66])
+
+        assert feature.check_value("any1", default="c") == "first bucket"
+        assert feature.check_value("any2", default="c") == "second bucket"


### PR DESCRIPTION
this came up on slack yesterday and i thought it'd be fun to throw something together. let me know if you have any feedback or if we want to use a Real Product for this instead

notes:
- it can nominally support A/B tests, but our data isn't prepared to support analysis. mostly meant for simple rollouts at the moment
- increasing a rollout requires a code change and new deploy which is not ideal. an alternative could be to read the rollout proportions from redis and cache for, say, 4h,  if we have a good way to update values in production redis
- i used the 128-bit hash because it was there, but at our volumes we are probably safe from the birthday problem with 64 bits? i didn't crunch the numbers though, just going on vibes
- the bucketing logic uses floats with int truncation which a serious statistician may find introduces biases but it should hold up for now

```
# Simple feature rolled out to 20% of repos
# Override codecov repos into the feature early
# By default, features have a single variant:
#   {"enabled": FeatureVariant(True, 1.0)}
MY_FEATURE_BY_REPO = Feature(
    "my_feature",
    0.2,
    overrides={
        "{shared repo id}": "enabled",
        "{worker repo id}": "enabled",
        "{codecov-api repo id}": "enabled",
        "{gazebo repo id}": "enabled",
        "{codecov-cli repo id}": "enabled",
)
if MY_FEATURE_BY_REPO.check_value(repo_id, default=False):
    new_behavior()

# Simple A/B test rolled out to 10% of users (5% control, 5% test)
MY_EXPERIMENT_BY_USER = Feature(
    "my_experiment",
    0.1,
    variants={
        "test": FeatureVariant(True, 0.5),
        "control": FeatureVariant(False, 0.5),
    },
)
if MY_EXPERIMENT_BY_USER.check_value(user_id, default=False):
    new_behavior()
```

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.