### PR TITLE
fix: Route all archive tasks to archive queue

### DIFF
--- a/shared/celery_config.py
+++ b/shared/celery_config.py
@@ -268,7 +268,7 @@ class BaseCeleryConfig(object):
                 default=task_default_queue,
             )
         },
-        archive_task_name: {
+        f"app.tasks.{TaskConfigGroup.archive.value}.*": {
             "queue": get_config(
                 "setup",
                 "tasks",

--- a/tests/unit/test_celery_config.py
+++ b/tests/unit/test_celery_config.py
@@ -28,7 +28,7 @@ def test_celery_config():
         "app.cron.healthcheck.HealthCheckTask",
         "app.cron.profiling.*",
         "app.tasks.add_to_sendgrid_list.AddToSendgridList",
-        "app.tasks.archive.MigrateToArchive",
+        "app.tasks.archive.*",
         "app.tasks.comment.Comment",
         "app.tasks.commit_update.CommitUpdate",
         "app.tasks.compute_comparison.ComputeComparison",


### PR DESCRIPTION
We'd like to route the new `app.tasks.archive.BackfillCommitDataToStorage` task to the `archive` queue.