### PR TITLE
chore: Increase notify default timeout

### DIFF
--- a/shared/celery_config.py
+++ b/shared/celery_config.py
@@ -151,7 +151,7 @@ class BaseCeleryConfig(object):
 
     notify_soft_time_limit = int(
         get_config(
-            "setup", "tasks", TaskConfigGroup.notify.value, "timeout", default=60
+            "setup", "tasks", TaskConfigGroup.notify.value, "timeout", default=120
         )
     )
     timeseries_soft_time_limit = get_config(


### PR DESCRIPTION
These changes increase the notify default timeout to 120s instead of 60s.
I would argue that it's still a sane amount of time for notifications, and would better support customers
that use github checks heavily.

This is proposed after the investigation in codecov/internal-issues#66

EDIT
I did check with infra team that the autoscaling should handle notification queue increase - if it were to happen. I don't think there are other immediate implications...

<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.