### PR TITLE
fix: workaround for ats failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,6 +46,10 @@ jobs:
             pip install -r tests/requirements.txt
             pip install setuptools_rust
             python setup.py develop
+            pip install --ignore-installed google-cloud-iam-logging
+            pip install --ignore-installed google-cloud
+            pip install --ignore-installed google-cloud-storage
+            pip install --ignore-installed google-cloud-pubsub        
       - run:
           name: Install CLI
           command: |

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
         "redis",
         "typing",
         "typing_extensions",
-        "google-auth==2.21.0",
+        "google-auth>=2.21.0",
         "google-cloud-pubsub>=2.13.6",
         "pytz",
     ],


### PR DESCRIPTION
There's some strange env config issue around the google packages that I couldn't
quite figure out or fix.

Through many envs being built and destroyed I made this workaround locally work.
Hopefully it works in CI as well.

context (and my adventures investigating this): codecov/engineering-team#536

<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.