### PR TITLE
prepend Codecov to event names 

### DIFF
--- a/shared/analytics_tracking/events.py
+++ b/shared/analytics_tracking/events.py
@@ -13,11 +13,13 @@ log = logging.getLogger("__name__")
 
 
 class Events(Enum):
-    ACCOUNT_ACTIVATED_REPOSITORY_ON_UPLOAD = "Account Activated Repository On Upload"
-    ACCOUNT_ACTIVATED_REPOSITORY = "Account Activated Repository"
-    ACCOUNT_UPLOADED_COVERAGE_REPORT = "Account Uploaded Coverage Report"
-    USER_SIGNED_IN = "User Signed In"
-    USER_SIGNED_UP = "User Signed Up"
+    ACCOUNT_ACTIVATED_REPOSITORY_ON_UPLOAD = (
+        "Codecov - Account Activated Repository On Upload"
+    )
+    ACCOUNT_ACTIVATED_REPOSITORY = "Codecov - Account Activated Repository"
+    ACCOUNT_UPLOADED_COVERAGE_REPORT = "Codecov - Account Uploaded Coverage Report"
+    USER_SIGNED_IN = "Codecov - User Signed In"
+    USER_SIGNED_UP = "Codecov - User Signed Up"
 
 
 class Event:

--- a/tests/unit/test_analytics_tracking.py
+++ b/tests/unit/test_analytics_tracking.py
@@ -88,7 +88,7 @@ def test_track_event_is_enterprise(mock_segment, mocker):
     mock_track = mocker.patch("shared.analytics_tracking.segment.analytics.track")
     analytics_tool = get_tools_manager()
     analytics_tool.track_event(
-        "Account Uploaded Coverage Report",
+        "Codecov - Account Uploaded Coverage Report",
         is_enterprise=True,
         event_data={"test": True},
     )
@@ -169,7 +169,7 @@ class TestEvent(object):
         assert event.serialize() == {
             "uuid": "AAEC",
             "timestamp": 1694476800.0,
-            "type": "Account Activated Repository",
+            "type": "Codecov - Account Activated Repository",
             "data": {"user_id": "1234", "repo_id": "1234", "branch": "test_branch"},
         }
 


### PR DESCRIPTION
since we're now sending events to Sentry's pubsub, we want to append all event names with codecov, to differentiate between codecov events and sentry's ones

You can see event names listed here https://l.codecov.dev/twR2yU 

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.