### PR TITLE
return bacl valid yaml fields

### DIFF
--- a/shared/validation/helpers.py
+++ b/shared/validation/helpers.py
@@ -325,6 +325,7 @@ class LayoutStructure(object):
 
     acceptable_objects = set(
         [
+            "changes",
             "diff",
             "file",
             "files",
@@ -334,10 +335,14 @@ class LayoutStructure(object):
             "header",
             "reach",
             "components",
+            "suggestions",
             "betaprofiling",
+            "sunburst",
             "tree",
+            "uncovered",
             "newheader",
             "newfooter",
+            "feedback",
             "newfiles",
         ]
     )


### PR DESCRIPTION
<!-- Describe your PR here. -->
I've realised that other parts of the code -not only the PR comment- uses these fields that I've removed before. Returning them back 


<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.