### PR TITLE
chore: remove python 3.7 from CI and some >=3.7-specific code

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ jobs:
             codecovcli --codecov-yml-path=codecov_cli.yml do-upload --plugin pycoverage --plugin compress-pycoverage --flag smart-labels --fail-on-error
   linter:
     docker:
-      - image: circleci/python:3.7.6
+      - image: circleci/python:3.10.1
     working_directory: ~/repo
     steps:
       - checkout
@@ -81,7 +81,7 @@ jobs:
             isort --profile black --check .
   mutations:
     docker:
-      - image: circleci/python:3.7.9
+      - image: circleci/python:3.10.1
     working_directory: ~/repo
     steps:
       - checkout
@@ -208,7 +208,7 @@ workflows:
             - codecovstartup
           matrix:
             parameters:
-              imagename: ["3.7.13", "3.8.13", "3.9.12", "3.10.5"]
+              imagename: ["3.8.13", "3.9.12", "3.10.5"]
           filters:
             tags:
               only: /.*/

--- a/shared/celery_router.py
+++ b/shared/celery_router.py
@@ -7,11 +7,7 @@ from shared.billing import BillingPlan, is_enterprise_cloud_plan
 from shared.celery_config import BaseCeleryConfig, get_task_group
 from shared.config import get_config
 
-try:
-    Pattern = re._pattern_type
-except AttributeError:  # pragma: no cover
-    # for Python 3.7 support
-    Pattern = re.Pattern
+Pattern = re.Pattern
 
 
 # based on code from https://github.com/celery/celery/blob/main/celery/app/routes.py

--- a/shared/typings/oauth_token_types.py
+++ b/shared/typings/oauth_token_types.py
@@ -1,12 +1,10 @@
-from typing import Any, Awaitable, Callable, Optional
+from typing import Any, Awaitable, Callable, Optional, TypedDict
 
-# FIXME: This is actually a TypedDict
-# But our CircleCI currently doesn't support Python 3.8, needed for TypedDicts
-# So this will seat here until we update it
-# OauthConsumerToken(TypedDict):
-#   key: str
-#   secret: str
-#   refresh_token: str
-OauthConsumerToken = Any
+
+class OauthConsumerToken(TypedDict):
+    key: str
+    secret: str
+    refresh_token: str
+
 
 OnRefreshCallback = Optional[Callable[[OauthConsumerToken], Awaitable[None]]]


### PR DESCRIPTION
python 3.7 is EOL and there are some 3.8 features we want to use. this PR removes 3.7 from CI as well as 3.7 compat things that i found via grep. tests pass

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.