### PR TITLE
WIP handle github refresh failure

### DIFF
--- a/shared/torngit/base.py
+++ b/shared/torngit/base.py
@@ -6,7 +6,7 @@ import httpx
 
 from shared.torngit.cache import torngit_cache
 from shared.torngit.enums import Endpoints
-from shared.typings.oauth_token_types import OauthConsumerToken, OnRefreshCallback
+from shared.typings.oauth_token_types import OauthConsumerToken, OnRefreshCallback, PossiblyRefreshTokenFromDbCallback
 
 get_start_of_line = re.compile(r"@@ \-(\d+),?(\d*) \+(\d+),?(\d*).*").match
 
@@ -24,6 +24,7 @@ class TorngitBaseAdapter(object):
     _aws_key = None
     _oauth: OauthConsumerToken = None
     _on_token_refresh: OnRefreshCallback = None
+    _possibly_refresh_token_from_db = None
     _token = None
     verify_ssl = None
 
@@ -81,12 +82,14 @@ class TorngitBaseAdapter(object):
         token=None,
         token_type_mapping: Dict[TokenType, Dict] = None,
         on_token_refresh: OnRefreshCallback = None,
+        possibly_refresh_token_from_db: PossiblyRefreshTokenFromDbCallback = None,
         verify_ssl=None,
         **kwargs,
     ):
         self._timeouts = timeouts or [10, 30]
         self._token = token
         self._on_token_refresh = on_token_refresh
+        self._possibly_refresh_token_from_db = possibly_refresh_token_from_db
         self._token_type_mapping = token_type_mapping or {}
         self._oauth = oauth_consumer_token
         self.data = {"owner": {}, "repo": {}}

--- a/shared/typings/oauth_token_types.py
+++ b/shared/typings/oauth_token_types.py
@@ -8,3 +8,5 @@ class OauthConsumerToken(TypedDict):
 
 
 OnRefreshCallback = Optional[Callable[[OauthConsumerToken], Awaitable[None]]]
+
+PossiblyRefreshTokenFromDbCallback = Optional[Callable[[OauthConsumerToken], Awaitable[Optional[OauthConsumerToken]]]]


### PR DESCRIPTION
I still need to add tests and everything to this PR, I just wanted quick feedback if the team is fine going this route or I'm way in over my head.

# Context 
This happened after we have issues with some refresh failures.

The context is a batch job requesting a bunch of stuff from the API. As we knew it could happen there's some race condition or missed update and we start to fail subsequent update attempts. This bubbles up `TorngitRefreshTokenFailedError` and the api returns many 500s.

After trying locally I nailed it down to the following response (if you try to use a refresh token that is not up-to-date anymore)
```
Raw response <Response [200 OK]>
Session parsed {'error': ['bad_refresh_token'], 'error_description': ['The refresh token passed is incorrect or expired.'], 'error_uri': ['https://docs.github.com/apps/managing-oauth-apps/troubleshooting-oauth-app-access-token-request-errors/#bad-verification-code']}
```

# Proposed solution

The "definitely let's do this" part is simple: improve the output of this failure case so we know why we're failing (following the docs attached there) and STOP raising an error. If we return None it's the same as doing nothing and the code can handle the 401 or 404 it got gracefully.

The more exciting and complicated part is that it's very possible that some other worker did successfully refresh this token prior, so we can try to fallback to the (possibly) updated token saved in the DB. This is where `_possibly_refresh_token_from_db` comes in.

For perspective (I did tested this locally and it _did_ work), the worker version of this callback can look something like this:

```python
def get_owner_current_token_callback(owner: Owner) -> Callable[[int], Optional[Dict]]:
    """
    Produces a callback function that will fetch and return a owner's token from the DB.
    This callback is passed to the TorngitAdapter for the service.
    It's used to try and recover from the situation in which N refresh request have been made
    roughly at the same time. 1 request will have succeeded and updated the token, the other N-1
    will fail and not be able to make new requests, unless they get the new value saved in DB.
    """
    # Some tokens don't have to be refreshed (GH integration, default bots)
    # They don't belong to any owners.
    if owner is None:
        return None

    service = owner.service
    if service == "bitbucket" or service == "bitbucket_server":
        return None

    async def callback(old_token: Dict) -> Optional[Dict]:
        log.info("Attempting to get freshest token for owner in DB")
        dbsession = get_db_session()
        fresh_owner = (
            dbsession.query(Owner).filter(Owner.ownerid == owner.ownerid).first()
        )
        if fresh_owner is None:
            log.warning(
                "Failed to fetch owner when trying to get freshest token for owner in DB"
            )
            return None

        freshest_token = encryptor.decrypt_token(fresh_owner.oauth_token)
        if freshest_token.get("key") == old_token.get("key"):
            log.warning("Freshest token is the same as current token")
            return None
        return freshest_token

    return callback
```