### PR TITLE
chore: Handle gh refresh attempt failure more gracefully

### DIFF
--- a/shared/torngit/github.py
+++ b/shared/torngit/github.py
@@ -331,9 +331,17 @@ class Github(TorngitBaseAdapter):
                 }
             )
             return self.token
-        # Not passing the response on purpose in case we are failing to parse it properly
-        # So as to not leak user's tokens by accident
-        raise TorngitRefreshTokenFailedError(dict(error="No access_token in response"))
+        # https://docs.github.com/apps/managing-oauth-apps/troubleshooting-oauth-app-access-token-request-errors
+        log.error(
+            dict(
+                error="No access_token in response",
+                gh_error=session.get("error"),
+                gh_error_description=session.get("error_description"),
+            )
+        )
+        # Retunring None will let the code handle the request failure gracefully
+        # Instead of probably throwing 500
+        return None
 
     # Generic
     # -------


### PR DESCRIPTION
Instead of throwing error we're gonna pretend like it didn't happen.

<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.