### PR TITLE
renaming events based on data team request

### DIFF
--- a/shared/analytics_tracking/events.py
+++ b/shared/analytics_tracking/events.py
@@ -14,12 +14,12 @@ log = logging.getLogger("__name__")
 
 class Events(Enum):
     ACCOUNT_ACTIVATED_REPOSITORY_ON_UPLOAD = (
-        "Codecov - Account Activated Repository On Upload"
+        "codecov.account.activated_repository_on_upload"
     )
-    ACCOUNT_ACTIVATED_REPOSITORY = "Codecov - Account Activated Repository"
-    ACCOUNT_UPLOADED_COVERAGE_REPORT = "Codecov - Account Uploaded Coverage Report"
-    USER_SIGNED_IN = "Codecov - User Signed In"
-    USER_SIGNED_UP = "Codecov - User Signed Up"
+    ACCOUNT_ACTIVATED_REPOSITORY = "codecov.account.activated_repository"
+    ACCOUNT_UPLOADED_COVERAGE_REPORT = "codecov.account.uploaded_coverage_report"
+    USER_SIGNED_IN = "codecov.user.signed_in"
+    USER_SIGNED_UP = "codecov.user.signed_up"
 
 
 class Event:

--- a/tests/unit/test_analytics_tracking.py
+++ b/tests/unit/test_analytics_tracking.py
@@ -169,7 +169,7 @@ class TestEvent(object):
         assert event.serialize() == {
             "uuid": "AAEC",
             "timestamp": 1694476800.0,
-            "type": "codecov.account.activated_repository_on_upload",
+            "type": "codecov.account.activated_repository",
             "data": {"user_id": "1234", "repo_id": "1234", "branch": "test_branch"},
         }
 

--- a/tests/unit/test_analytics_tracking.py
+++ b/tests/unit/test_analytics_tracking.py
@@ -88,7 +88,7 @@ def test_track_event_is_enterprise(mock_segment, mocker):
     mock_track = mocker.patch("shared.analytics_tracking.segment.analytics.track")
     analytics_tool = get_tools_manager()
     analytics_tool.track_event(
-        "Codecov - Account Uploaded Coverage Report",
+        "codecov.account.uploaded_coverage_report",
         is_enterprise=True,
         event_data={"test": True},
     )
@@ -169,7 +169,7 @@ class TestEvent(object):
         assert event.serialize() == {
             "uuid": "AAEC",
             "timestamp": 1694476800.0,
-            "type": "Codecov - Account Activated Repository",
+            "type": "codecov.account.activated_repository_on_upload",
             "data": {"user_id": "1234", "repo_id": "1234", "branch": "test_branch"},
         }
 


### PR DESCRIPTION
<!-- Describe your PR here. -->
Renaming events based on data team request 


<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.