### PR TITLE
Add codeowners, tag data team for changes with analytics tracking

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Data Engineering for event changes
+/shared/analytics_tracking/ @getsentry/data


### PR DESCRIPTION
<!-- Describe your PR here. -->

Adding a CODEOWNERS file to our repo, tagging the Sentry Data Engineering team if we make changes to the analytics events.

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.