### PR TITLE
replacing newheader and newfooter with condensed_header and condensed_footer

### DIFF
--- a/shared/validation/helpers.py
+++ b/shared/validation/helpers.py
@@ -344,6 +344,9 @@ class LayoutStructure(object):
             "newfooter",
             "feedback",
             "newfiles",
+            "condensed_header",
+            "condensed_footer",
+            "condensed_files",
         ]
     )
 

--- a/shared/validation/helpers.py
+++ b/shared/validation/helpers.py
@@ -340,10 +340,10 @@ class LayoutStructure(object):
             "sunburst",
             "tree",
             "uncovered",
-            "newheader",
-            "newfooter",
+            "newheader",  # deprecated, keeping it for backward compatibility
+            "newfooter",  # deprecated, keeping it for backward compatibility
             "feedback",
-            "newfiles",
+            "newfiles",  # deprecated, keeping it for backward compatibility
             "condensed_header",
             "condensed_footer",
             "condensed_files",


### PR DESCRIPTION

<!-- Describe your PR here. -->
since newheader, newfooter and newfiles will be outdated names soon, we'll be using condensed_header, condensed_footer and condensed_files instead with keeping the old names valid for backward compatibility 

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.