### PR TITLE
fix: make sure EditableReport is merged with EditableReportFile

### DIFF
--- a/tests/unit/test_report.py
+++ b/tests/unit/test_report.py
@@ -1,6 +1,7 @@
 import pytest
 from mock import PropertyMock
 
+from shared.reports.editable import EditableReport, EditableReportFile
 from shared.reports.resources import Report, ReportFile, _encode_chunk
 from shared.reports.types import (
     LineSession,
@@ -340,6 +341,21 @@ def test_merge(files, chunks, new_report, manifest):
     assert list(r.files) == ["file.py"]
     r.merge(new_report)
     assert list(r.files) == manifest
+
+
+def test_merge_into_editable_report():
+    editable_report = EditableReport(
+        files={"file.py": [1, ReportTotals(2)]},
+        chunks="null\n[1]\n[1]\n[1]\n<<<<< end_of_chunk >>>>>\nnull\n[1]\n[1]\n[1]",
+    )
+    new_report = Report(
+        files={"other-file.py": [1, ReportTotals(2)]},
+        chunks="null\n[1]\n[1]\n[1]\n<<<<< end_of_chunk >>>>>\nnull\n[1]\n[1]\n[1]",
+    )
+    editable_report.merge(new_report)
+    assert list(editable_report.files) == ["file.py", "other-file.py"]
+    for file in editable_report:
+        assert isinstance(file, EditableReportFile)
 
 
 @pytest.mark.unit


### PR DESCRIPTION
When processing reports (more than 1 per `UploadProcessor` task) it's possible
that we will merge a `Report` into a `EditableReport` (the original).
This is fine, but we were not respecting the fact that files inside
`EditableReport` should be `EditableReportFile`.

These changes force all files merged into an `EditableReport` to be
of type `EditableReportFile`. Merge is left unchanged, cause it seems
complex. Instead we just run an extra check and cast to `EditableReportFile`
if needed.

closes: codecov/internal-issues#nternal-issues#138

<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.