### PR TITLE
ref: Include GitHub app token code from worker

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
         "google-auth>=2.21.0",
         "google-cloud-pubsub>=2.13.6",
         "urllib3>=1.25.4,<1.27",
+        "pyjwt",
         "pytz",
     ],
 )

--- a/shared/github/__init__.py
+++ b/shared/github/__init__.py
@@ -1,0 +1,88 @@
+import logging
+from datetime import datetime
+from time import time
+from typing import Optional
+
+import jwt
+import requests
+
+import shared.torngit as torngit
+from shared.config import get_config, load_file_from_path_at_config
+
+log = logging.getLogger(__name__)
+
+loaded_pems = None
+
+pem_paths = {
+    "github": ("github", "integration", "pem"),
+    "github_enterprise": ("github_enterprise", "integration", "pem"),
+}
+
+
+def get_pem(pem_name: str) -> str:
+    path = pem_paths[pem_name]
+    return load_file_from_path_at_config(*path)
+
+
+class InvalidInstallationError(Exception):
+    pass
+
+
+def get_github_integration_token(service, integration_id=None) -> Optional[str]:
+    # https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/
+    now = int(time())
+    payload = {
+        # issued at time
+        "iat": now,
+        # JWT expiration time (max 10 minutes)
+        "exp": now + int(get_config(service, "integration", "expires", default=500)),
+        # Integration's GitHub identifier
+        "iss": get_config(service, "integration", "id"),
+    }
+    token = jwt.encode(payload, get_pem(service), algorithm="RS256")
+    if integration_id:
+        api_endpoint = (
+            torngit.Github.api_url
+            if service == "github"
+            else torngit.GithubEnterprise.get_api_url()
+        )
+        headers = {
+            "Accept": "application/vnd.github.machine-man-preview+json",
+            "User-Agent": "Codecov",
+            "Authorization": "Bearer %s" % token,
+        }
+        url = "%s/app/installations/%s/access_tokens" % (api_endpoint, integration_id)
+        res = requests.post(url, headers=headers)
+        if res.status_code in (404, 403):
+            log.warning(
+                "Integration could not be found to fetch token from or unauthorized",
+                extra=dict(
+                    git_service=service,
+                    integration_id=integration_id,
+                    api_endpoint=api_endpoint,
+                ),
+            )
+            raise InvalidInstallationError()
+        try:
+            res.raise_for_status()
+        except requests.exceptions.HTTPError:
+            log.exception(
+                "Github Integration Error on service %s",
+                service,
+                extra=dict(code=res.status_code, text=res.text),
+            )
+            raise
+        res_json = res.json()
+        log.info(
+            "Requested and received a Github Integration token",
+            extra=dict(
+                valid_from=datetime.fromtimestamp(payload["iat"]).isoformat(),
+                expires_at=res_json.get("expires_at"),
+                permissions=res_json.get("permissions"),
+                repository_selection=res_json.get("repository_selection"),
+                integration_id=integration_id,
+            ),
+        )
+        return res_json["token"]
+    else:
+        return token

--- a/tests/unit/test_github.py
+++ b/tests/unit/test_github.py
@@ -1,0 +1,99 @@
+import pytest
+
+from shared.github import InvalidInstallationError, get_github_integration_token
+
+# DONT WORRY, this is generated for the purposes of validation, and is not the real
+# one on which the code ran
+fake_private_key = """-----BEGIN RSA PRIVATE KEY-----
+MIICXAIBAAKBgQDCFqq2ygFh9UQU/6PoDJ6L9e4ovLPCHtlBt7vzDwyfwr3XGxln
+0VbfycVLc6unJDVEGZ/PsFEuS9j1QmBTTEgvCLR6RGpfzmVuMO8wGVEO52pH73h9
+rviojaheX/u3ZqaA0di9RKy8e3L+T0ka3QYgDx5wiOIUu1wGXCs6PhrtEwICBAEC
+gYBu9jsi0eVROozSz5dmcZxUAzv7USiUcYrxX007SUpm0zzUY+kPpWLeWWEPaddF
+VONCp//0XU8hNhoh0gedw7ZgUTG6jYVOdGlaV95LhgY6yXaQGoKSQNNTY+ZZVT61
+zvHOlPynt3GZcaRJOlgf+3hBF5MCRoWKf+lDA5KiWkqOYQJBAMQp0HNVeTqz+E0O
+6E0neqQDQb95thFmmCI7Kgg4PvkS5mz7iAbZa5pab3VuyfmvnVvYLWejOwuYSp0U
+9N8QvUsCQQD9StWHaVNM4Lf5zJnB1+lJPTXQsmsuzWvF3HmBkMHYWdy84N/TdCZX
+Cxve1LR37lM/Vijer0K77wAx2RAN/ppZAkB8+GwSh5+mxZKydyPaPN29p6nC6aLx
+3DV2dpzmhD0ZDwmuk8GN+qc0YRNOzzJ/2UbHH9L/lvGqui8I6WLOi8nDAkEA9CYq
+ewfdZ9LcytGz7QwPEeWVhvpm0HQV9moetFWVolYecqBP4QzNyokVnpeUOqhIQAwe
+Z0FJEQ9VWsG+Df0noQJBALFjUUZEtv4x31gMlV24oiSWHxIRX4fEND/6LpjleDZ5
+C/tY+lZIEO1Gg/FxSMB+hwwhwfSuE3WohZfEcSy+R48=
+-----END RSA PRIVATE KEY-----"""
+
+
+class TestGithubSpecificLogic(object):
+    def test_get_github_integration_token_enterprise(self, mocker, mock_configuration):
+        service = "github_enterprise"
+        mock_configuration._params[service] = {"url": "http://legit-github"}
+        integration_id = 1
+        mocked_post = mocker.patch("shared.github.requests.post")
+        mocked_post.return_value.json.return_value = {"token": "arriba"}
+        mocker.patch("shared.github.get_pem", return_value=fake_private_key)
+        assert get_github_integration_token(service, integration_id) == "arriba"
+        mocked_post.assert_called_with(
+            "http://legit-github/api/v3/app/installations/1/access_tokens",
+            headers={
+                "Accept": "application/vnd.github.machine-man-preview+json",
+                "Authorization": mocker.ANY,
+                "User-Agent": "Codecov",
+            },
+        )
+
+    def test_get_github_integration_token_production(self, mocker, mock_configuration):
+        service = "github"
+        mock_configuration._params["github_enterprise"] = {"url": "http://legit-github"}
+        integration_id = 1
+        mocked_post = mocker.patch("shared.github.requests.post")
+        mocked_post.return_value.json.return_value = {"token": "arriba"}
+        mocker.patch("shared.github.get_pem", return_value=fake_private_key)
+        assert get_github_integration_token(service, integration_id) == "arriba"
+        mocked_post.assert_called_with(
+            "https://api.github.com/app/installations/1/access_tokens",
+            headers={
+                "Accept": "application/vnd.github.machine-man-preview+json",
+                "Authorization": mocker.ANY,
+                "User-Agent": "Codecov",
+            },
+        )
+
+    def test_get_github_integration_token_not_found(self, mocker, mock_configuration):
+        service = "github"
+        mock_configuration._params["github_enterprise"] = {"url": "http://legit-github"}
+        integration_id = 1
+        mocked_post = mocker.patch("shared.github.requests.post")
+        mocked_post.return_value.status_code = 404
+        mocker.patch("shared.github.get_pem", return_value=fake_private_key)
+        with pytest.raises(InvalidInstallationError):
+            get_github_integration_token(service, integration_id)
+        mocked_post.assert_called_with(
+            "https://api.github.com/app/installations/1/access_tokens",
+            headers={
+                "Accept": "application/vnd.github.machine-man-preview+json",
+                "Authorization": mocker.ANY,
+                "User-Agent": "Codecov",
+            },
+        )
+
+    def test_get_github_integration_token_unauthorized(
+        self, mocker, mock_configuration
+    ):
+        service = "github"
+        mock_configuration._params["github_enterprise"] = {"url": "http://legit-github"}
+        integration_id = 1
+        mocked_post = mocker.patch("shared.github.requests.post")
+        mocked_post.return_value.status_code = 403
+        mocked_post.return_value.json.return_value = {
+            "message": "This installation has been suspended",
+            "documentation_url": "https://docs.github.com/rest/reference/apps#create-an-installation-access-token-for-an-app",
+        }
+        mocker.patch("shared.github.get_pem", return_value=fake_private_key)
+        with pytest.raises(InvalidInstallationError):
+            get_github_integration_token(service, integration_id)
+        mocked_post.assert_called_with(
+            "https://api.github.com/app/installations/1/access_tokens",
+            headers={
+                "Accept": "application/vnd.github.machine-man-preview+json",
+                "Authorization": mocker.ANY,
+                "User-Agent": "Codecov",
+            },
+        )


### PR DESCRIPTION
We need the `get_github_integration_token` in `codecov-api`

No new code here - just pulled things from the following `worker` sources:

* https://github.com/codecov/worker/blob/main/services/github.py
* https://github.com/codecov/worker/blob/main/services/pem.py
* https://github.com/codecov/worker/blob/main/services/tests/test_github.py