### PR TITLE
Change "label" in report by "label_id" and have a lookup table

### DIFF
--- a/shared/reports/editable.py
+++ b/shared/reports/editable.py
@@ -49,17 +49,26 @@ class EditableReportFile(ReportFile):
         res["present_sessions"] = sorted(self._details.get("present_sessions"))
         return res
 
-    def delete_labels(self, session_ids_to_delete, labels_to_delete):
+    def delete_labels(
+        self, session_ids_to_delete: List[int], label_ids_to_delete: List[int]
+    ):
+        """Given a list of session_ids and label_ids to delete
+        Remove all datapoints that belong to at least 1 session_ids to delete and include
+        at least 1 of the label_ids to be removed
+        """
         for index, line in self.lines:
             if line.datapoints is not None:
                 if any(
-                    (dp.sessionid in session_ids_to_delete and lb in labels_to_delete)
+                    (
+                        dp.sessionid in session_ids_to_delete
+                        and label_id in label_ids_to_delete
+                    )
                     for dp in line.datapoints
-                    for lb in dp.labels
+                    for label_id in dp.label_ids
                 ):
                     # Line fits change requirements
                     new_line = self.line_without_labels(
-                        line, session_ids_to_delete, labels_to_delete
+                        line, session_ids_to_delete, label_ids_to_delete
                     )
                     if new_line == EMPTY:
                         del self[index]

--- a/shared/reports/exceptions.py
+++ b/shared/reports/exceptions.py
@@ -1,0 +1,6 @@
+class LabelIndexNotLoadedError(Exception):
+    pass
+
+
+class LabelNotFoundError(Exception):
+    pass

--- a/shared/reports/resources.py
+++ b/shared/reports/resources.py
@@ -520,13 +520,15 @@ class ReportFile(object):
             pass
 
     @classmethod
-    def line_without_labels(cls, line, session_ids_to_delete, labels):
+    def line_without_labels(
+        cls, line, session_ids_to_delete: List[int], label_ids_to_delete: List[int]
+    ):
         new_datapoints = (
             [
                 dp
                 for dp in line.datapoints
                 if dp.sessionid not in session_ids_to_delete
-                or all(lb not in labels for lb in dp.labels)
+                or all(lb not in label_ids_to_delete for lb in dp.label_ids)
             ]
             if line.datapoints is not None
             else None

--- a/shared/reports/resources.py
+++ b/shared/reports/resources.py
@@ -587,7 +587,7 @@ class ReportFile(object):
 class Report(object):
     file_class = ReportFile
     _files: Dict[str, ReportFileSummary]
-    _labels_index: Optional[Dict[int, str]] = None
+    labels_index: Optional[Dict[int, str]] = None
 
     @sentry.trace
     def __init__(
@@ -640,18 +640,18 @@ class Report(object):
         self.yaml = yaml  # ignored
 
     def set_label_idx(self, label_idx: Dict[int, str]) -> None:
-        self._labels_index = label_idx
+        self.labels_index = label_idx
 
     def unset_label_idx(self) -> None:
-        self._labels_index = None
+        self.labels_index = None
 
     def lookup_label_by_id(self, label_id: int) -> str:
 
-        if self._labels_index is None:
+        if self.labels_index is None:
             raise LabelIndexNotLoadedError()
-        if label_id not in self._labels_index:
+        if label_id not in self.labels_index:
             raise LabelNotFoundError()
-        return self._labels_index[label_id]
+        return self.labels_index[label_id]
 
     @classmethod
     def from_chunks(cls, *args, **kwargs):

--- a/shared/reports/types.py
+++ b/shared/reports/types.py
@@ -96,17 +96,11 @@ class LineSession(object):
 
 @dataclass
 class CoverageDatapoint(object):
-    # This is commented because having __slots__ would caulse "labels" to not be optional
-    # But because we are giving a default value it should be optional
-    # TODO: Un-comment after "labels" is removed
-    # __slots__ = ("sessionid", "coverage", "coverage_type", "label_ids", "labels")
+    __slots__ = ("sessionid", "coverage", "coverage_type", "label_ids")
     sessionid: int
     coverage: Decimal
     coverage_type: Optional[str]
-    # Optional because old reports still use labels
-    label_ids: Optional[List[int]]
-    # Deprecated. Replaced by label_ids
-    labels: Optional[List[str]] = None
+    label_ids: List[int]
 
     def astuple(self):
         return (
@@ -114,8 +108,14 @@ class CoverageDatapoint(object):
             self.coverage,
             self.coverage_type,
             self.label_ids,
-            self.labels,
         )
+
+    def __post_init__(self):
+        if self.label_ids is not None:
+            possibly_cast_to_int = (
+                lambda el: int(el) if (type(el) == str and el.isnumeric()) else el
+            )
+            self.label_ids = [possibly_cast_to_int(el) for el in self.label_ids]
 
     def key_sorting_tuple(self):
         return (
@@ -123,7 +123,6 @@ class CoverageDatapoint(object):
             str(self.coverage),
             self.coverage_type if self.coverage_type is not None else "",
             self.label_ids if self.label_ids is not None else [],
-            self.labels if self.labels is not None else [],
         )
 
 

--- a/shared/reports/types.py
+++ b/shared/reports/types.py
@@ -96,17 +96,24 @@ class LineSession(object):
 
 @dataclass
 class CoverageDatapoint(object):
-    __slots__ = ("sessionid", "coverage", "coverage_type", "labels")
+    # This is commented because having __slots__ would caulse "labels" to not be optional
+    # But because we are giving a default value it should be optional
+    # TODO: Un-comment after "labels" is removed
+    # __slots__ = ("sessionid", "coverage", "coverage_type", "label_ids", "labels")
     sessionid: int
     coverage: Decimal
     coverage_type: Optional[str]
-    labels: List[str]
+    # Optional because old reports still use labels
+    label_ids: Optional[List[int]]
+    # Deprecated. Replaced by label_ids
+    labels: Optional[List[str]] = None
 
     def astuple(self):
         return (
             self.sessionid,
             self.coverage,
             self.coverage_type,
+            self.label_ids,
             self.labels,
         )
 
@@ -115,6 +122,7 @@ class CoverageDatapoint(object):
             self.sessionid,
             str(self.coverage),
             self.coverage_type if self.coverage_type is not None else "",
+            self.label_ids if self.label_ids is not None else [],
             self.labels if self.labels is not None else [],
         )
 

--- a/tests/unit/reports/samples/test_filtered.py
+++ b/tests/unit/reports/samples/test_filtered.py
@@ -189,13 +189,13 @@ class TestFilteredReportFile(object):
                     LineSession(10, 0, complexity=3),
                 ],
                 datapoints=[
-                    CoverageDatapoint(0, 0, None, [1], None),
-                    CoverageDatapoint(0, 1, None, [2], None),
-                    CoverageDatapoint(1, "1/2", None, [1], None),
-                    CoverageDatapoint(1, 1, None, [2], None),
-                    CoverageDatapoint(2, 0, None, [3], None),
-                    CoverageDatapoint(2, 0, None, [2], None),
-                    CoverageDatapoint(10, 0, None, [2], None),
+                    CoverageDatapoint(0, 0, None, [1]),
+                    CoverageDatapoint(0, 1, None, [2]),
+                    CoverageDatapoint(1, "1/2", None, [1]),
+                    CoverageDatapoint(1, 1, None, [2]),
+                    CoverageDatapoint(2, 0, None, [3]),
+                    CoverageDatapoint(2, 0, None, [2]),
+                    CoverageDatapoint(10, 0, None, [2]),
                 ],
             )
         )
@@ -207,10 +207,10 @@ class TestFilteredReportFile(object):
         ]
         assert res.messages is None
         assert res.datapoints == [
-            CoverageDatapoint(0, 0, None, [1], None),
-            CoverageDatapoint(0, 1, None, [2], None),
-            CoverageDatapoint(1, "1/2", None, [1], None),
-            CoverageDatapoint(1, 1, None, [2], None),
+            CoverageDatapoint(0, 0, None, [1]),
+            CoverageDatapoint(0, 1, None, [2]),
+            CoverageDatapoint(1, "1/2", None, [1]),
+            CoverageDatapoint(1, 1, None, [2]),
         ]
         assert res.complexity == 5
 

--- a/tests/unit/reports/samples/test_filtered.py
+++ b/tests/unit/reports/samples/test_filtered.py
@@ -14,6 +14,14 @@ from shared.reports.types import CoverageDatapoint, NetworkFile
 from shared.utils.sessions import SessionType
 
 
+# temporary
+# This immitates what the Report label_lookup will look like
+# It's an map idx -> label, so we can go from CoverageDatapoint.label_id to the actual label
+def lookup_label(label_id: int) -> str:
+    lookup_table = {1: "simpletest", 2: "complextest", 3: "simple"}
+    return lookup_table[label_id]
+
+
 class TestFilteredReportFile(object):
     def test_name(self):
         first_file = ReportFile("file_1.go")
@@ -181,13 +189,13 @@ class TestFilteredReportFile(object):
                     LineSession(10, 0, complexity=3),
                 ],
                 datapoints=[
-                    CoverageDatapoint(0, 0, None, ["simpletest"]),
-                    CoverageDatapoint(0, 1, None, ["complextest"]),
-                    CoverageDatapoint(1, "1/2", None, ["simpletest"]),
-                    CoverageDatapoint(1, 1, None, ["complextest"]),
-                    CoverageDatapoint(2, 0, None, ["simple"]),
-                    CoverageDatapoint(2, 0, None, ["complextest"]),
-                    CoverageDatapoint(10, 0, None, ["complextest"]),
+                    CoverageDatapoint(0, 0, None, [1], None),
+                    CoverageDatapoint(0, 1, None, [2], None),
+                    CoverageDatapoint(1, "1/2", None, [1], None),
+                    CoverageDatapoint(1, 1, None, [2], None),
+                    CoverageDatapoint(2, 0, None, [3], None),
+                    CoverageDatapoint(2, 0, None, [2], None),
+                    CoverageDatapoint(10, 0, None, [2], None),
                 ],
             )
         )
@@ -199,10 +207,10 @@ class TestFilteredReportFile(object):
         ]
         assert res.messages is None
         assert res.datapoints == [
-            CoverageDatapoint(0, 0, None, ["simpletest"]),
-            CoverageDatapoint(0, 1, None, ["complextest"]),
-            CoverageDatapoint(1, "1/2", None, ["simpletest"]),
-            CoverageDatapoint(1, 1, None, ["complextest"]),
+            CoverageDatapoint(0, 0, None, [1], None),
+            CoverageDatapoint(0, 1, None, [2], None),
+            CoverageDatapoint(1, "1/2", None, [1], None),
+            CoverageDatapoint(1, 1, None, [2], None),
         ]
         assert res.complexity == 5
 

--- a/tests/unit/reports/samples/test_filtered.py
+++ b/tests/unit/reports/samples/test_filtered.py
@@ -14,9 +14,9 @@ from shared.reports.types import CoverageDatapoint, NetworkFile
 from shared.utils.sessions import SessionType
 
 
-# temporary
-# This immitates what the Report label_lookup will look like
+# This immitates what a Report._labels_index looks like
 # It's an map idx -> label, so we can go from CoverageDatapoint.label_id to the actual label
+# typically via Report.lookup_label_by_id
 def lookup_label(label_id: int) -> str:
     lookup_table = {1: "simpletest", 2: "complextest", 3: "simple"}
     return lookup_table[label_id]

--- a/tests/unit/reports/test_editable.py
+++ b/tests/unit/reports/test_editable.py
@@ -19,9 +19,10 @@ from shared.utils.sessions import SessionType
 
 current_file = Path(__file__)
 
-# temporary
-# This immitates what the Report label_lookup will look like
+
+# This immitates what a Report._labels_index looks like
 # It's an map idx -> label, so we can go from CoverageDatapoint.label_id to the actual label
+# typically via Report.lookup_label_by_id
 def lookup_label(label_id: int) -> str:
     lookup_table = {
         1: "simple",

--- a/tests/unit/reports/test_editable.py
+++ b/tests/unit/reports/test_editable.py
@@ -2,6 +2,7 @@ import dataclasses
 from fractions import Fraction
 from json import loads
 from pathlib import Path
+from typing import List
 
 import pytest
 
@@ -18,16 +19,36 @@ from shared.utils.sessions import SessionType
 
 current_file = Path(__file__)
 
+# temporary
+# This immitates what the Report label_lookup will look like
+# It's an map idx -> label, so we can go from CoverageDatapoint.label_id to the actual label
+def lookup_label(label_id: int) -> str:
+    lookup_table = {
+        1: "simple",
+        2: "one_label",
+        3: "another_label",
+        4: "something",
+        5: "label_1",
+        6: "label_2",
+        7: "label_3",
+        8: "label_4",
+        9: "label_5",
+        10: "label_6",
+    }
+    return lookup_table[label_id]
 
-def create_sample_line(*, coverage, sessionid=None, list_of_lists_of_labels=None):
+
+def create_sample_line(
+    *, coverage, sessionid=None, list_of_lists_of_label_ids: List[List[int]] = None
+):
     datapoints = [
         CoverageDatapoint(
             sessionid=sessionid,
             coverage=coverage,
             coverage_type=None,
-            labels=labels,
+            label_ids=label_ids,
         )
-        for labels in (list_of_lists_of_labels or [[]])
+        for label_ids in (list_of_lists_of_label_ids or [[]])
     ]
     return ReportLine.create(
         coverage=coverage,
@@ -70,86 +91,76 @@ class TestEditableReportHelpers(object):
             None,
             [LineSession(1, 0), LineSession(0, 1)],
             datapoints=[
-                CoverageDatapoint(1, 0, None, ["label_1", "label_2"]),
-                CoverageDatapoint(1, 0, None, ["label_3", "label_2"]),
-                CoverageDatapoint(0, 1, None, ["label_1", "label_2"]),
-                CoverageDatapoint(0, "1/2", None, ["label_1", "label_4"]),
-                CoverageDatapoint(0, "1/2", None, ["label_5", "label_6"]),
-                CoverageDatapoint(0, 0, None, ["label_6", "label_4"]),
+                CoverageDatapoint(1, 0, None, [5, 6]),
+                CoverageDatapoint(1, 0, None, [7, 6]),
+                CoverageDatapoint(0, 1, None, [5, 6]),
+                CoverageDatapoint(0, "1/2", None, [5, 8]),
+                CoverageDatapoint(0, "1/2", None, [9, 10]),
+                CoverageDatapoint(0, 0, None, [10, 8]),
             ],
         )
         assert EditableReportFile.line_without_labels(
-            line, [1], ["label_1"]
+            line, [1], [5]
         ) == ReportLine.create(
             "2/2",
             None,
             [LineSession(1, 0), LineSession(0, 1)],
             datapoints=[
-                CoverageDatapoint(1, 0, None, ["label_3", "label_2"]),
-                CoverageDatapoint(0, 1, None, ["label_1", "label_2"]),
-                CoverageDatapoint(0, "1/2", None, ["label_1", "label_4"]),
-                CoverageDatapoint(0, "1/2", None, ["label_5", "label_6"]),
-                CoverageDatapoint(0, 0, None, ["label_6", "label_4"]),
+                CoverageDatapoint(1, 0, None, [7, 6]),
+                CoverageDatapoint(0, 1, None, [5, 6]),
+                CoverageDatapoint(0, "1/2", None, [5, 8]),
+                CoverageDatapoint(0, "1/2", None, [9, 10]),
+                CoverageDatapoint(0, 0, None, [10, 8]),
             ],
         )
         assert EditableReportFile.line_without_labels(
-            line, [1, 0], ["label_1"]
+            line, [1, 0], [5]
         ) == ReportLine.create(
             "1/2",
             None,
             [LineSession(1, 0), LineSession(0, 1)],
             datapoints=[
-                CoverageDatapoint(1, 0, None, ["label_3", "label_2"]),
-                CoverageDatapoint(0, "1/2", None, ["label_5", "label_6"]),
-                CoverageDatapoint(0, 0, None, ["label_6", "label_4"]),
+                CoverageDatapoint(1, 0, None, [7, 6]),
+                CoverageDatapoint(0, "1/2", None, [9, 10]),
+                CoverageDatapoint(0, 0, None, [10, 8]),
             ],
         )
         assert EditableReportFile.line_without_labels(
-            line, [1], ["label_1", "label_2"]
+            line, [1], [5, 6]
         ) == ReportLine.create(
             "2/2",
             None,
             [LineSession(0, 1)],
             datapoints=[
-                CoverageDatapoint(0, 1, None, ["label_1", "label_2"]),
-                CoverageDatapoint(0, "1/2", None, ["label_1", "label_4"]),
-                CoverageDatapoint(0, "1/2", None, ["label_5", "label_6"]),
-                CoverageDatapoint(0, 0, None, ["label_6", "label_4"]),
+                CoverageDatapoint(0, 1, None, [5, 6]),
+                CoverageDatapoint(0, "1/2", None, [5, 8]),
+                CoverageDatapoint(0, "1/2", None, [9, 10]),
+                CoverageDatapoint(0, 0, None, [10, 8]),
             ],
         )
         assert EditableReportFile.line_without_labels(
-            line, [0, 1], ["label_1", "label_2"]
+            line, [0, 1], [5, 6]
         ) == ReportLine.create(
             "1/2",
             None,
             [LineSession(0, 1)],
             datapoints=[
-                CoverageDatapoint(0, "1/2", None, ["label_5", "label_6"]),
-                CoverageDatapoint(0, 0, None, ["label_6", "label_4"]),
+                CoverageDatapoint(0, "1/2", None, [9, 10]),
+                CoverageDatapoint(0, 0, None, [10, 8]),
             ],
         )
-        assert (
-            EditableReportFile.line_without_labels(
-                line, [0, 1], ["label_1", "label_2", "label_6"]
-            )
-            == ""
-        )
+        assert EditableReportFile.line_without_labels(line, [0, 1], [5, 6, 10]) == ""
         assert EditableReportFile.line_without_labels(
-            line, [0, 1], ["label_1", "label_2", "label_5"]
+            line, [0, 1], [5, 6, 9]
         ) == ReportLine.create(
             0,
             None,
             [LineSession(0, 1)],
             datapoints=[
-                CoverageDatapoint(0, 0, None, ["label_6", "label_4"]),
+                CoverageDatapoint(0, 0, None, [10, 8]),
             ],
         )
-        assert (
-            EditableReportFile.line_without_labels(
-                line, [0, 1], ["label_1", "label_2", "label_6"]
-            )
-            == ""
-        )
+        assert EditableReportFile.line_without_labels(line, [0, 1], [5, 6, 10]) == ""
 
     def test_delete_labels_session_without_datapoints(self):
         line = ReportLine.create(
@@ -157,18 +168,18 @@ class TestEditableReportHelpers(object):
             None,
             [LineSession(0, 1), LineSession(1, 1), LineSession(2, 0)],
             datapoints=[
-                CoverageDatapoint(1, 1, None, ["label_1", "label_2"]),
-                CoverageDatapoint(1, 0, None, ["label_3", "label_2"]),
-                CoverageDatapoint(2, 0, None, ["label_6"]),
+                CoverageDatapoint(1, 1, None, [5, 6]),
+                CoverageDatapoint(1, 0, None, [7, 6]),
+                CoverageDatapoint(2, 0, None, [10]),
             ],
         )
         assert EditableReportFile.line_without_labels(
-            line, [1], ["label_1", "label_2", "label_6"]
+            line, [1], [5, 6, 10]
         ) == ReportLine.create(
             1,
             None,
             [LineSession(0, 1), LineSession(2, 0)],
-            datapoints=[CoverageDatapoint(2, 0, None, ["label_6"])],
+            datapoints=[CoverageDatapoint(2, 0, None, [10])],
         )
 
 
@@ -257,7 +268,7 @@ class TestEditableReportFile(object):
             create_sample_line(
                 coverage=1,
                 sessionid=2,
-                list_of_lists_of_labels=[["simple"]],
+                list_of_lists_of_label_ids=[[1]],
             ),
         )
         assert list(first_file.lines) == [
@@ -282,13 +293,13 @@ class TestEditableReportFile(object):
                             sessionid=2,
                             coverage=1,
                             coverage_type=None,
-                            labels=["simple"],
+                            label_ids=[1],
                         )
                     ],
                 ),
             )
         ]
-        first_file.delete_labels([2], ["simple"])
+        first_file.delete_labels([2], [1])
         assert list(first_file.lines) == []
 
     def test_merge_not_previously_set_sessions_header(self):
@@ -867,12 +878,12 @@ class TestEditableReport(object):
         )
         first_file = EditableReportFile("first_file.py")
         c = 0
-        for list_of_lists_of_labels in [
-            [["one_label"]],
-            [["another_label"]],
-            [["another_label"], ["one_label"]],
-            [["another_label", "one_label"]],
-            [["something"]],
+        for list_of_lists_of_label_ids in [
+            [[2]],
+            [[3]],
+            [[3], [2]],
+            [[3, 2]],
+            [[4]],
         ]:
             for sessionid in range(4):
                 first_file.append(
@@ -880,7 +891,7 @@ class TestEditableReport(object):
                     create_sample_line(
                         coverage=c,
                         sessionid=sessionid,
-                        list_of_lists_of_labels=list_of_lists_of_labels,
+                        list_of_lists_of_label_ids=list_of_lists_of_label_ids,
                     ),
                 )
                 c += 1
@@ -903,9 +914,9 @@ class TestEditableReport(object):
                     None,
                     None,
                     [
-                        (0, 0, None, ["one_label"]),
-                        (2, 14, None, ["another_label", "one_label"]),
-                        (3, 7, None, ["another_label"]),
+                        (0, 0, None, [2], None),
+                        (2, 14, None, [3, 2], None),
+                        (3, 7, None, [3], None),
                     ],
                 ),
                 (
@@ -920,10 +931,10 @@ class TestEditableReport(object):
                     None,
                     None,
                     [
-                        (0, 8, None, ["another_label"]),
-                        (0, 8, None, ["one_label"]),
-                        (1, 1, None, ["one_label"]),
-                        (3, 15, None, ["another_label", "one_label"]),
+                        (0, 8, None, [2], None),
+                        (0, 8, None, [3], None),
+                        (1, 1, None, [2], None),
+                        (3, 15, None, [3, 2], None),
                     ],
                 ),
                 (
@@ -938,10 +949,10 @@ class TestEditableReport(object):
                     None,
                     None,
                     [
-                        (0, 16, None, ["something"]),
-                        (1, 9, None, ["another_label"]),
-                        (1, 9, None, ["one_label"]),
-                        (2, 2, None, ["one_label"]),
+                        (0, 16, None, [4], None),
+                        (1, 9, None, [2], None),
+                        (1, 9, None, [3], None),
+                        (2, 2, None, [2], None),
                     ],
                 ),
                 (
@@ -956,10 +967,10 @@ class TestEditableReport(object):
                     None,
                     None,
                     [
-                        (1, 17, None, ["something"]),
-                        (2, 10, None, ["another_label"]),
-                        (2, 10, None, ["one_label"]),
-                        (3, 3, None, ["one_label"]),
+                        (1, 17, None, [4], None),
+                        (2, 10, None, [2], None),
+                        (2, 10, None, [3], None),
+                        (3, 3, None, [2], None),
                     ],
                 ),
                 (
@@ -974,10 +985,10 @@ class TestEditableReport(object):
                     None,
                     None,
                     [
-                        (0, 4, None, ["another_label"]),
-                        (2, 18, None, ["something"]),
-                        (3, 11, None, ["another_label"]),
-                        (3, 11, None, ["one_label"]),
+                        (0, 4, None, [3], None),
+                        (2, 18, None, [4], None),
+                        (3, 11, None, [2], None),
+                        (3, 11, None, [3], None),
                     ],
                 ),
                 (
@@ -992,9 +1003,9 @@ class TestEditableReport(object):
                     None,
                     None,
                     [
-                        (0, 12, None, ["another_label", "one_label"]),
-                        (1, 5, None, ["another_label"]),
-                        (3, 19, None, ["something"]),
+                        (0, 12, None, [3, 2], None),
+                        (1, 5, None, [3], None),
+                        (3, 19, None, [4], None),
                     ],
                 ),
                 (
@@ -1005,8 +1016,8 @@ class TestEditableReport(object):
                     None,
                     None,
                     [
-                        (1, 13, None, ["another_label", "one_label"]),
-                        (2, 6, None, ["another_label"]),
+                        (1, 13, None, [3, 2], None),
+                        (2, 6, None, [3], None),
                     ],
                 ),
                 (23, 1, None, [[1, 1, None, None, None]], None, None),
@@ -1025,7 +1036,7 @@ class TestEditableReport(object):
             create_sample_line(
                 coverage=1,
                 sessionid=2,
-                list_of_lists_of_labels=[["simple"]],
+                list_of_lists_of_label_ids=[[1]],
             ),
         )
         report.append(first_file)
@@ -1040,12 +1051,12 @@ class TestEditableReport(object):
                     [[2, 1, None, None, None]],
                     None,
                     None,
-                    [(2, 1, None, ["simple"])],
+                    [(2, 1, None, [1], None)],
                 )
             ],
             "someother.py": [(1, 1, None, [[2, 1, None, None, None]], None, None)],
         }
-        report.delete_labels([2], ["simple"])
+        report.delete_labels([2], [1])
         assert self.convert_report_to_better_readable(report)["archive"] == {
             "someother.py": [(1, 1, None, [[2, 1, None, None, None]], None, None)]
         }
@@ -1897,13 +1908,13 @@ class TestEditableReport(object):
         assert res["totals"] == old_readable["totals"]
 
     def test_delete_labels(self, sample_with_labels_report):
-        sample_with_labels_report.delete_labels([0], ["another_label"])
+        sample_with_labels_report.delete_labels([0], [3])
         for file in sample_with_labels_report:
             for ln, line in file.lines:
                 # some lines previously didnt have datapoints
                 if line.datapoints:
                     for dp in line.datapoints:
-                        assert dp.sessionid != 0 or "another_label" not in dp.labels
+                        assert dp.sessionid != 0 or 3 not in dp.label_ids
         print(sample_with_labels_report)
         print(sample_with_labels_report._files)
         res = self.convert_report_to_better_readable(sample_with_labels_report)
@@ -2012,9 +2023,9 @@ class TestEditableReport(object):
                         None,
                         None,
                         [
-                            (0, 0, None, ["one_label"]),
-                            (2, 14, None, ["another_label", "one_label"]),
-                            (3, 7, None, ["another_label"]),
+                            (0, 0, None, [2], None),
+                            (2, 14, None, [3, 2], None),
+                            (3, 7, None, [3], None),
                         ],
                     ),
                     (
@@ -2029,9 +2040,9 @@ class TestEditableReport(object):
                         None,
                         None,
                         [
-                            (0, 8, None, ["one_label"]),
-                            (1, 1, None, ["one_label"]),
-                            (3, 15, None, ["another_label", "one_label"]),
+                            (0, 8, None, [2], None),
+                            (1, 1, None, [2], None),
+                            (3, 15, None, [3, 2], None),
                         ],
                     ),
                     (
@@ -2046,10 +2057,10 @@ class TestEditableReport(object):
                         None,
                         None,
                         [
-                            (0, 16, None, ["something"]),
-                            (1, 9, None, ["another_label"]),
-                            (1, 9, None, ["one_label"]),
-                            (2, 2, None, ["one_label"]),
+                            (0, 16, None, [4], None),
+                            (1, 9, None, [2], None),
+                            (1, 9, None, [3], None),
+                            (2, 2, None, [2], None),
                         ],
                     ),
                     (
@@ -2064,10 +2075,10 @@ class TestEditableReport(object):
                         None,
                         None,
                         [
-                            (1, 17, None, ["something"]),
-                            (2, 10, None, ["another_label"]),
-                            (2, 10, None, ["one_label"]),
-                            (3, 3, None, ["one_label"]),
+                            (1, 17, None, [4], None),
+                            (2, 10, None, [2], None),
+                            (2, 10, None, [3], None),
+                            (3, 3, None, [2], None),
                         ],
                     ),
                     (
@@ -2078,9 +2089,9 @@ class TestEditableReport(object):
                         None,
                         None,
                         [
-                            (2, 18, None, ["something"]),
-                            (3, 11, None, ["another_label"]),
-                            (3, 11, None, ["one_label"]),
+                            (2, 18, None, [4], None),
+                            (3, 11, None, [2], None),
+                            (3, 11, None, [3], None),
                         ],
                     ),
                     (
@@ -2090,7 +2101,7 @@ class TestEditableReport(object):
                         [[1, 5, None, None, None], [3, 19, None, None, None]],
                         None,
                         None,
-                        [(1, 5, None, ["another_label"]), (3, 19, None, ["something"])],
+                        [(1, 5, None, [3], None), (3, 19, None, [4], None)],
                     ),
                     (
                         7,
@@ -2100,8 +2111,8 @@ class TestEditableReport(object):
                         None,
                         None,
                         [
-                            (1, 13, None, ["another_label", "one_label"]),
-                            (2, 6, None, ["another_label"]),
+                            (1, 13, None, [3, 2], None),
+                            (2, 6, None, [3], None),
                         ],
                     ),
                     (23, 1, None, [[1, 1, None, None, None]], None, None),

--- a/tests/unit/reports/test_editable.py
+++ b/tests/unit/reports/test_editable.py
@@ -915,9 +915,9 @@ class TestEditableReport(object):
                     None,
                     None,
                     [
-                        (0, 0, None, [2], None),
-                        (2, 14, None, [3, 2], None),
-                        (3, 7, None, [3], None),
+                        (0, 0, None, [2]),
+                        (2, 14, None, [3, 2]),
+                        (3, 7, None, [3]),
                     ],
                 ),
                 (
@@ -932,10 +932,10 @@ class TestEditableReport(object):
                     None,
                     None,
                     [
-                        (0, 8, None, [2], None),
-                        (0, 8, None, [3], None),
-                        (1, 1, None, [2], None),
-                        (3, 15, None, [3, 2], None),
+                        (0, 8, None, [2]),
+                        (0, 8, None, [3]),
+                        (1, 1, None, [2]),
+                        (3, 15, None, [3, 2]),
                     ],
                 ),
                 (
@@ -950,10 +950,10 @@ class TestEditableReport(object):
                     None,
                     None,
                     [
-                        (0, 16, None, [4], None),
-                        (1, 9, None, [2], None),
-                        (1, 9, None, [3], None),
-                        (2, 2, None, [2], None),
+                        (0, 16, None, [4]),
+                        (1, 9, None, [2]),
+                        (1, 9, None, [3]),
+                        (2, 2, None, [2]),
                     ],
                 ),
                 (
@@ -968,10 +968,10 @@ class TestEditableReport(object):
                     None,
                     None,
                     [
-                        (1, 17, None, [4], None),
-                        (2, 10, None, [2], None),
-                        (2, 10, None, [3], None),
-                        (3, 3, None, [2], None),
+                        (1, 17, None, [4]),
+                        (2, 10, None, [2]),
+                        (2, 10, None, [3]),
+                        (3, 3, None, [2]),
                     ],
                 ),
                 (
@@ -986,10 +986,10 @@ class TestEditableReport(object):
                     None,
                     None,
                     [
-                        (0, 4, None, [3], None),
-                        (2, 18, None, [4], None),
-                        (3, 11, None, [2], None),
-                        (3, 11, None, [3], None),
+                        (0, 4, None, [3]),
+                        (2, 18, None, [4]),
+                        (3, 11, None, [2]),
+                        (3, 11, None, [3]),
                     ],
                 ),
                 (
@@ -1004,9 +1004,9 @@ class TestEditableReport(object):
                     None,
                     None,
                     [
-                        (0, 12, None, [3, 2], None),
-                        (1, 5, None, [3], None),
-                        (3, 19, None, [4], None),
+                        (0, 12, None, [3, 2]),
+                        (1, 5, None, [3]),
+                        (3, 19, None, [4]),
                     ],
                 ),
                 (
@@ -1017,8 +1017,8 @@ class TestEditableReport(object):
                     None,
                     None,
                     [
-                        (1, 13, None, [3, 2], None),
-                        (2, 6, None, [3], None),
+                        (1, 13, None, [3, 2]),
+                        (2, 6, None, [3]),
                     ],
                 ),
                 (23, 1, None, [[1, 1, None, None, None]], None, None),
@@ -1052,7 +1052,7 @@ class TestEditableReport(object):
                     [[2, 1, None, None, None]],
                     None,
                     None,
-                    [(2, 1, None, [1], None)],
+                    [(2, 1, None, [1])],
                 )
             ],
             "someother.py": [(1, 1, None, [[2, 1, None, None, None]], None, None)],
@@ -2024,9 +2024,9 @@ class TestEditableReport(object):
                         None,
                         None,
                         [
-                            (0, 0, None, [2], None),
-                            (2, 14, None, [3, 2], None),
-                            (3, 7, None, [3], None),
+                            (0, 0, None, [2]),
+                            (2, 14, None, [3, 2]),
+                            (3, 7, None, [3]),
                         ],
                     ),
                     (
@@ -2041,9 +2041,9 @@ class TestEditableReport(object):
                         None,
                         None,
                         [
-                            (0, 8, None, [2], None),
-                            (1, 1, None, [2], None),
-                            (3, 15, None, [3, 2], None),
+                            (0, 8, None, [2]),
+                            (1, 1, None, [2]),
+                            (3, 15, None, [3, 2]),
                         ],
                     ),
                     (
@@ -2058,10 +2058,10 @@ class TestEditableReport(object):
                         None,
                         None,
                         [
-                            (0, 16, None, [4], None),
-                            (1, 9, None, [2], None),
-                            (1, 9, None, [3], None),
-                            (2, 2, None, [2], None),
+                            (0, 16, None, [4]),
+                            (1, 9, None, [2]),
+                            (1, 9, None, [3]),
+                            (2, 2, None, [2]),
                         ],
                     ),
                     (
@@ -2076,10 +2076,10 @@ class TestEditableReport(object):
                         None,
                         None,
                         [
-                            (1, 17, None, [4], None),
-                            (2, 10, None, [2], None),
-                            (2, 10, None, [3], None),
-                            (3, 3, None, [2], None),
+                            (1, 17, None, [4]),
+                            (2, 10, None, [2]),
+                            (2, 10, None, [3]),
+                            (3, 3, None, [2]),
                         ],
                     ),
                     (
@@ -2090,9 +2090,9 @@ class TestEditableReport(object):
                         None,
                         None,
                         [
-                            (2, 18, None, [4], None),
-                            (3, 11, None, [2], None),
-                            (3, 11, None, [3], None),
+                            (2, 18, None, [4]),
+                            (3, 11, None, [2]),
+                            (3, 11, None, [3]),
                         ],
                     ),
                     (
@@ -2102,7 +2102,7 @@ class TestEditableReport(object):
                         [[1, 5, None, None, None], [3, 19, None, None, None]],
                         None,
                         None,
-                        [(1, 5, None, [3], None), (3, 19, None, [4], None)],
+                        [(1, 5, None, [3]), (3, 19, None, [4])],
                     ),
                     (
                         7,
@@ -2112,8 +2112,8 @@ class TestEditableReport(object):
                         None,
                         None,
                         [
-                            (1, 13, None, [3, 2], None),
-                            (2, 6, None, [3], None),
+                            (1, 13, None, [3, 2]),
+                            (2, 6, None, [3]),
                         ],
                     ),
                     (23, 1, None, [[1, 1, None, None, None]], None, None),

--- a/tests/unit/reports/test_types.py
+++ b/tests/unit/reports/test_types.py
@@ -95,20 +95,13 @@ def test_reportline_as_tuple():
 
 def test_coverage_datapoint_as_tuple():
     cd = CoverageDatapoint(
-        sessionid=3, coverage=1, coverage_type="b", label_ids=[1, 2, 3], labels=None
+        sessionid=3, coverage=1, coverage_type="b", label_ids=[1, 2, 3]
     )
-    assert cd.astuple() == (3, 1, "b", [1, 2, 3], None)
-
-
-def test_coverage_datapoint_as_tuple_legacy():
+    assert cd.astuple() == (3, 1, "b", [1, 2, 3])
     cd = CoverageDatapoint(
-        sessionid=3,
-        coverage=1,
-        coverage_type="b",
-        labels=["test_one", "condition_1", "file_1"],
-        label_ids=None,
+        sessionid=3, coverage=1, coverage_type="b", label_ids=["1", "2", "3"]
     )
-    assert cd.astuple() == (3, 1, "b", None, ["test_one", "condition_1", "file_1"])
+    assert cd.astuple() == (3, 1, "b", [1, 2, 3])
 
 
 class TestNetworkFile(object):

--- a/tests/unit/reports/test_types.py
+++ b/tests/unit/reports/test_types.py
@@ -95,12 +95,20 @@ def test_reportline_as_tuple():
 
 def test_coverage_datapoint_as_tuple():
     cd = CoverageDatapoint(
+        sessionid=3, coverage=1, coverage_type="b", label_ids=[1, 2, 3], labels=None
+    )
+    assert cd.astuple() == (3, 1, "b", [1, 2, 3], None)
+
+
+def test_coverage_datapoint_as_tuple_legacy():
+    cd = CoverageDatapoint(
         sessionid=3,
         coverage=1,
         coverage_type="b",
         labels=["test_one", "condition_1", "file_1"],
+        label_ids=None,
     )
-    assert cd.astuple() == (3, 1, "b", ["test_one", "condition_1", "file_1"])
+    assert cd.astuple() == (3, 1, "b", None, ["test_one", "condition_1", "file_1"])
 
 
 class TestNetworkFile(object):

--- a/tests/unit/test_report.py
+++ b/tests/unit/test_report.py
@@ -481,12 +481,12 @@ def test_contains(mocker):
 @pytest.mark.unit
 def test_set_labels_idx():
     report = Report()
-    assert report._labels_index is None
+    assert report.labels_index is None
     label_idx = {0: "Special_global_label", 1: "banana", 2: "cachorro"}
     report.set_label_idx(label_idx)
-    assert report._labels_index == label_idx
+    assert report.labels_index == label_idx
     report.unset_label_idx()
-    assert report._labels_index is None
+    assert report.labels_index is None
 
 
 def test_get_label_from_idx():

--- a/tests/unit/test_report.py
+++ b/tests/unit/test_report.py
@@ -2,6 +2,7 @@ import pytest
 from mock import PropertyMock
 
 from shared.reports.editable import EditableReport, EditableReportFile
+from shared.reports.exceptions import LabelIndexNotLoadedError, LabelNotFoundError
 from shared.reports.resources import Report, ReportFile, _encode_chunk
 from shared.reports.types import (
     CoverageDatapoint,
@@ -517,6 +518,18 @@ def test_get_label_from_idx():
     assert "Special_global_label" in labels_in_report
     assert "cachorro" in labels_in_report
     assert "banana" not in labels_in_report
+
+
+def test_lookup_label_by_id_fails():
+    report = Report()
+    with pytest.raises(LabelIndexNotLoadedError):
+        report.lookup_label_by_id(0)
+
+    label_idx = {0: "Special_global_label", 1: "banana", 2: "cachorro"}
+    report.set_label_idx(label_idx)
+
+    with pytest.raises(LabelNotFoundError):
+        report.lookup_label_by_id(100)
 
 
 @pytest.mark.unit

--- a/tests/unit/utils/test_merge.py
+++ b/tests/unit/utils/test_merge.py
@@ -75,15 +75,9 @@ def lookup_label(label_id: int) -> str:
 
 
 def test_merge_datapoints():
-    c_1 = CoverageDatapoint(
-        sessionid=1, coverage=1, coverage_type=None, labels=None, label_ids=None
-    )
-    c_2 = CoverageDatapoint(
-        sessionid=1, coverage=1, coverage_type=None, labels=[], label_ids=[1]
-    )
-    c_3 = CoverageDatapoint(
-        sessionid=1, coverage=1, coverage_type=None, labels=[], label_ids=[2]
-    )
+    c_1 = CoverageDatapoint(sessionid=1, coverage=1, coverage_type=None, label_ids=None)
+    c_2 = CoverageDatapoint(sessionid=1, coverage=1, coverage_type=None, label_ids=[1])
+    c_3 = CoverageDatapoint(sessionid=1, coverage=1, coverage_type=None, label_ids=[2])
     assert [c_1, c_2] == merge_datapoints(
         [c_1],
         [c_2],
@@ -254,14 +248,12 @@ def test_merge_missed_branches(sessions, res):
                         coverage=1,
                         coverage_type=None,
                         label_ids=[1],
-                        labels=None,
                     ),
                     CoverageDatapoint(
                         sessionid=1,
                         coverage=1,
                         coverage_type="b",
                         label_ids=[3],
-                        labels=None,
                     ),
                 ],
             ),

--- a/tests/unit/utils/test_merge.py
+++ b/tests/unit/utils/test_merge.py
@@ -66,9 +66,9 @@ def test_merge_branch(b1, b2, res):
     )
 
 
-# temporary
-# This immitates what the Report label_lookup will look like
+# This immitates what a Report._labels_index looks like
 # It's an map idx -> label, so we can go from CoverageDatapoint.label_id to the actual label
+# typically via Report.lookup_label_by_id
 def lookup_label(label_id: int) -> str:
     lookup_table = {1: "banana", 2: "apple", 3: "simpletest"}
     return lookup_table[label_id]

--- a/tests/unit/utils/test_merge.py
+++ b/tests/unit/utils/test_merge.py
@@ -66,13 +66,23 @@ def test_merge_branch(b1, b2, res):
     )
 
 
+# temporary
+# This immitates what the Report label_lookup will look like
+# It's an map idx -> label, so we can go from CoverageDatapoint.label_id to the actual label
+def lookup_label(label_id: int) -> str:
+    lookup_table = {1: "banana", 2: "apple", 3: "simpletest"}
+    return lookup_table[label_id]
+
+
 def test_merge_datapoints():
-    c_1 = CoverageDatapoint(sessionid=1, coverage=1, coverage_type=None, labels=None)
+    c_1 = CoverageDatapoint(
+        sessionid=1, coverage=1, coverage_type=None, labels=None, label_ids=None
+    )
     c_2 = CoverageDatapoint(
-        sessionid=1, coverage=1, coverage_type=None, labels=["banana"]
+        sessionid=1, coverage=1, coverage_type=None, labels=[], label_ids=[1]
     )
     c_3 = CoverageDatapoint(
-        sessionid=1, coverage=1, coverage_type=None, labels=["apple"]
+        sessionid=1, coverage=1, coverage_type=None, labels=[], label_ids=[2]
     )
     assert [c_1, c_2] == merge_datapoints(
         [c_1],
@@ -82,7 +92,7 @@ def test_merge_datapoints():
         [c_2],
         [c_1],
     )
-    assert [c_1, c_3, c_2] == merge_datapoints([c_2, c_1], [c_3])
+    assert [c_1, c_2, c_3] == merge_datapoints([c_2, c_1], [c_3])
     assert [c_1, c_2] == merge_datapoints([c_2, c_1], None)
     assert [c_1, c_2] == merge_datapoints([c_2, c_1], [None])
 
@@ -230,8 +240,8 @@ def test_merge_missed_branches(sessions, res):
         # types
         ((1, None, [[1, 1]]), (1, "b", [[1, 1]]), (1, "b", [LineSession(1, 1)])),
         (
-            (1, None, [[1, 1]], None, None, [(1, 1, None, ["banana"])]),
-            (1, "b", [[1, 1]], None, None, [(1, 1, "b", ["simpletest"])]),
+            (1, None, [[1, 1]], None, None, [(1, 1, None, [1])]),
+            (1, "b", [[1, 1]], None, None, [(1, 1, "b", [3])]),
             (
                 1,
                 "b",
@@ -240,13 +250,18 @@ def test_merge_missed_branches(sessions, res):
                 None,  # complexity
                 [
                     CoverageDatapoint(
-                        sessionid=1, coverage=1, coverage_type=None, labels=["banana"]
+                        sessionid=1,
+                        coverage=1,
+                        coverage_type=None,
+                        label_ids=[1],
+                        labels=None,
                     ),
                     CoverageDatapoint(
                         sessionid=1,
                         coverage=1,
                         coverage_type="b",
-                        labels=["simpletest"],
+                        label_ids=[3],
+                        labels=None,
                     ),
                 ],
             ),


### PR DESCRIPTION
# Context
This is a draft pull request, but it's close to what will probably be the final solution.
"label index" and "label ID" are used interchangeably.

Recently we had issues with some large customer using label analysis because the report with labels simply uses too much space. For that particular customer the chunks size was more than 1.5Gb and so worker can't load it into memory. This happens because the labels are saved in their canonical format in `CoverageDatapoint.labels`. These are moderately long strings that are repeated all through the file.

# Solution
To unblock customers wanting to try ATS we will be encoding them. The idea is that the `CoverageDatapoints` will only keep label IDs (which are much smaller than the labels themselves) and `Report` will have a "detachable" label index table.

Detachable in this case means it will live in a separate file (not `chunks.txt`) and we will be able to load and unload it into memory as needed, to further save space.

Notice that it is technically possible to operate over the IDs, so typically we only need to know what the actual labels are when merging a new report and during the `label_analysis` task. That is partly the reason that only the `Report` (top level) has access to the label index table.

# Comments on design choices
The other part is that I'd like to avoid inconsistencies in the index. So the `CoverageDatapoints` shouldn't be able to modify the index at all. In fact for the `CoverageDatapoint` it doesn't matter what the label is, so it can be an index and that's ok.
I purposely didn't add functions to alter the label index table to the report. I think it's better to be more explicit about it and let the worker do that.

So in the case of `Report` all you can do is load or unload a label index table, and look up labels by ID. It panics if it can't find a label, and that's it.
The worker code will make sure that we are using it in the expected way.

The other intentional choice was changing `CoverageDatapoint.labels` to `CoverageDatapoint.label_ids`. I think it's important that the name represents what it actually is. Specially from a maintenance perspective, it's a change that I think it's worth doing now.

Yes it increases the chance of bugs, but we do want things to not fail silently in this case, I'd argue. This is a complex change (when you factor in the worker piece), and the `Report` class is very important for the core product, so it's better to catch bugs fast during testing. Increasing the likelihood of loud bugs and exceptions being raised in this case is actually a good thing, because we can fix the data flows that we missed fast when testing in staging.

