### PR TITLE
perf: provide sentry tracing fns if available, else stub them

### DIFF
--- a/shared/metrics/sentry.py
+++ b/shared/metrics/sentry.py
@@ -1,0 +1,14 @@
+try:
+    """
+    If the library using us depends on Sentry, import it and export its trace
+    decorator.
+    """
+    import sentry_sdk
+
+    trace = sentry_sdk.trace
+except ModuleNotFoundError:
+    """
+    If the library using us doesn't depend on Sentry, just no-op the trace
+    decorator.
+    """
+    trace = lambda f: f

--- a/shared/metrics/sentry.py
+++ b/shared/metrics/sentry.py
@@ -1,3 +1,18 @@
+def noop_trace(func):
+    return func
+
+
+class NoOpSpan:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def __enter__(self):
+        pass
+
+    def __exit__(*args):
+        pass
+
+
 try:
     """
     If the library using us depends on Sentry, import it and export its trace
@@ -6,9 +21,11 @@ try:
     import sentry_sdk
 
     trace = sentry_sdk.trace
+    start_span = sentry_sdk.start_span
 except ModuleNotFoundError:
     """
     If the library using us doesn't depend on Sentry, just no-op the trace
     decorator.
     """
-    trace = lambda f: f
+    trace = noop_trace
+    start_span = NoOpSpan

--- a/shared/reports/resources.py
+++ b/shared/reports/resources.py
@@ -8,6 +8,7 @@ from typing import Dict, List, Optional
 from shared.helpers.flag import Flag
 from shared.helpers.numeric import ratio
 from shared.helpers.yaml import walk
+from shared.metrics import sentry
 from shared.reports.filtered import FilteredReport
 from shared.reports.types import (
     EMPTY,
@@ -147,6 +148,7 @@ class ReportFile(object):
                         continue
                 yield ln, line
 
+    @sentry.trace
     def calculate_diff(self, all_file_segments):
         fg = self.get
         lines = []
@@ -329,6 +331,7 @@ class ReportFile(object):
                         return None
                 return line
 
+    @sentry.trace
     def append(self, ln, line):
         """Append a line to the report
         if the line exists it will merge it
@@ -352,6 +355,7 @@ class ReportFile(object):
             self._lines[ln - 1] = line
         return True
 
+    @sentry.trace
     def merge(self, other_file, joined=True):
         """merges another report chunk
         returning the <dict totals>
@@ -485,6 +489,7 @@ class ReportFile(object):
                     pos += 1
         return False
 
+    @sentry.trace
     def shift_lines_by_diff(self, diff, forward=True) -> None:
         """
         Adjusts report _lines IN PLACE to account for the diff given.
@@ -580,6 +585,7 @@ class Report(object):
     file_class = ReportFile
     _files: Dict[str, ReportFileSummary]
 
+    @sentry.trace
     def __init__(
         self,
         files=None,
@@ -719,6 +725,7 @@ class Report(object):
                 all_flags.update(session.flags)
         return sorted(all_flags)
 
+    @sentry.trace
     def append(self, _file, joined=True):
         """adds or merged a file into the report"""
         if _file is None:
@@ -974,6 +981,7 @@ class Report(object):
     def __contains__(self, filename):
         return filename in self._files
 
+    @sentry.trace
     def merge(self, new_report, joined=True):
         """combine report data from another"""
         if new_report is None:
@@ -1015,6 +1023,7 @@ class Report(object):
     def update_sessions(self, **data):
         pass
 
+    @sentry.trace
     def flare(self, changes=None, color=None):
         if changes is not None:
             """
@@ -1086,6 +1095,7 @@ class Report(object):
 
         return report_to_flare(network, color, classes)
 
+    @sentry.trace
     def filter(self, paths=None, flags=None):
         if paths:
             if not isinstance(paths, (list, set, tuple)):
@@ -1096,6 +1106,7 @@ class Report(object):
             return self
         return FilteredReport(self, path_patterns=paths, flags=flags)
 
+    @sentry.trace
     def does_diff_adjust_tracked_lines(self, diff, future_report, future_diff):
         """
         Returns <boolean> if the diff touches tracked lines
@@ -1156,6 +1167,7 @@ class Report(object):
 
         return False
 
+    @sentry.trace
     def shift_lines_by_diff(self, diff, forward=True):
         """
         [volitile] will permanently adjust repot report
@@ -1179,6 +1191,7 @@ class Report(object):
                         diff_totals=None,
                     )
 
+    @sentry.trace
     def calculate_diff(self, diff: Dict) -> Dict:
         """
             Calculates the per-file totals (and total) of the parts
@@ -1267,6 +1280,7 @@ class Report(object):
                 )
             network_file.diff_totals = file_totals
 
+    @sentry.trace
     def apply_diff(self, diff, _save=True):
         """
         Add coverage details to the diff at ['coverage'] = <ReportTotals>
@@ -1299,6 +1313,7 @@ class Report(object):
             flags.update(k)
         return flags
 
+    @sentry.trace
     def repack(self):
         """Repacks in a more compact format to avoid deleted files and such"""
         if not self._passes_integrity_analysis():


### PR DESCRIPTION
some known-slow transactions in `codecov-api` have huge uninstrumented spans that we want more insight into. the spans are most likely in this range of code https://github.com/codecov/codecov-api/blob/8f09643371c38ef98c713ac3f504a0739e7101ec/services/report.py#L77-L95 where we process the raw chunks/files/sessions data in `shared`.

this PR adds sentry instrumentation to that code, but it doesn't add a dependency on sentry. if sentry is available we use its functions, otherwise we just stub them

`pytest` for `shared` works so the non-sentry path is not broken (assuming we have tests for report code...) and `pytest` + actual usage with a test sentry project show that it works when used in `codecov-api` and `worker`

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.