### PR TITLE
ref: Filtered Report to not recompute lines when already called (#729)

### DIFF
--- a/shared/reports/filtered.py
+++ b/shared/reports/filtered.py
@@ -220,8 +220,6 @@ class FilteredReport(object):
                 yield fname, make_network_file(file.totals)
 
     def get(self, filename, _else=None):
-        if filename in self.report_file_cache:
-            return self.report_file_cache[filename]
         if not self.should_include(filename):
             return _else
         if not self.flags:
@@ -229,9 +227,12 @@ class FilteredReport(object):
         r = self.report.get(filename)
         if r is None:
             return None
-        filtered_report_file = FilteredReportFile(r, self.session_ids_to_include)
-        self.report_file_cache[filename] = filtered_report_file
-        return filtered_report_file
+
+        if filename not in self.report_file_cache:
+            self.report_file_cache[filename] = FilteredReportFile(
+                r, self.session_ids_to_include
+            )
+        return self.report_file_cache[filename]
 
     @property
     def files(self):

--- a/shared/reports/filtered.py
+++ b/shared/reports/filtered.py
@@ -1,8 +1,6 @@
 import dataclasses
 import logging
 import os
-import time
-import traceback
 
 from shared.config import get_config
 from shared.helpers.numeric import ratio

--- a/tests/unit/reports/samples/test_filtered.py
+++ b/tests/unit/reports/samples/test_filtered.py
@@ -1,4 +1,5 @@
 import os
+from unittest.mock import patch
 
 from shared.reports.filtered import FilteredReport, FilteredReportFile
 from shared.reports.resources import (
@@ -24,6 +25,23 @@ class TestFilteredReportFile(object):
         f = FilteredReportFile(first_file, [1])
         assert f.eof == 1
         assert f.eof == first_file.eof
+
+    @patch("shared.reports.filtered.FilteredReportFile.line_modifier")
+    def test_lines_cached(self, line_modifier_mock):
+        line_modifier_mock.return_value = True
+
+        first_file = ReportFile("file_1.go")
+        first_file.append(
+            1,
+            ReportLine.create(
+                coverage=1,
+                sessions=[LineSession(0, 1), LineSession(1, 1), LineSession(2, 1)],
+            ),
+        )
+        filtered_report_file = FilteredReportFile(first_file, [1])
+
+        assert filtered_report_file.lines == filtered_report_file.lines
+        assert line_modifier_mock.call_count == 1
 
     def test_totals(self):
         first_file = ReportFile("file_1.go")
@@ -215,6 +233,14 @@ class TestFilteredReport(object):
             sample_report.filter(paths=[".*.go"], flags=["simple"]).get("myfile.go")
             is None
         )
+
+    def test_get_cached(self, sample_report):
+        filtered_report = sample_report.filter(paths=[".*.go"], flags=["simple"])
+        filtered_report_file_1 = filtered_report.get("file_1.go")
+        assert isinstance(filtered_report_file_1, FilteredReportFile)
+        filtered_report_file_2 = filtered_report.get("file_1.go")
+        assert isinstance(filtered_report_file_2, FilteredReportFile)
+        assert filtered_report_file_1 == filtered_report_file_2
 
     def test_normal_totals(self, sample_report):
         assert sample_report.totals == ReportTotals(


### PR DESCRIPTION
In Filtered Report, line modifiers can take a long time to compute, that's called by `lines` property. We will cache the computation so that when that property is called more than once it would return the cached value. This will speedup the public reports API endpoint as it currently references `lines` three separate times in its serializers.
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.