### PR TITLE
perf: get_file_totals() to sidestep some extra processing

### DIFF
--- a/shared/reports/filtered.py
+++ b/shared/reports/filtered.py
@@ -226,6 +226,12 @@ class FilteredReport(object):
     def files(self):
         return [f for f in self.report.files if self.should_include(f)]
 
+    def get_file_totals(self, path):
+        if self.should_include(path):
+            return self.report.get_file_totals(path)
+
+        return None
+
     @property
     def manifest(self):
         return self.files

--- a/shared/reports/readonly.py
+++ b/shared/reports/readonly.py
@@ -161,6 +161,9 @@ class ReadOnlyReport(object):
             self._totals = self._process_totals()
         return self._totals
 
+    def get_file_totals(self, path):
+        return self.inner_report.get_file_totals(path)
+
     @sentry.trace
     def filter(self, paths=None, flags=None):
         if paths is None and flags is None:

--- a/shared/reports/resources.py
+++ b/shared/reports/resources.py
@@ -893,7 +893,11 @@ class Report(object):
             )
             return None
 
-        return self._files[path].file_totals
+        totals = self._files[path].file_totals
+        if isinstance(totals, ReportTotals):
+            return totals
+        else:
+            return ReportTotals(*totals)
 
     def get_folder_totals(self, path):
         """

--- a/shared/reports/resources.py
+++ b/shared/reports/resources.py
@@ -878,6 +878,23 @@ class Report(object):
         self._chunks[_file.file_index] = None
         return True
 
+    def get_file_totals(self, path, _else=None):
+        """
+        returns <ReportTotals> for the file if it exists
+        """
+        if self._path_filter and not self._path_filter(filename):
+            # filtered out of report
+            return _else
+
+        if path not in self._files:
+            log.warning(
+                "Fetching file totals for a file that isn't in the report",
+                extra=dict(path=path),
+            )
+            return None
+
+        return self._files[path].file_totals
+
     def get_folder_totals(self, path):
         """
         returns <ReportTotals> for files contained in a folder

--- a/tests/unit/reports/samples/test_filtered.py
+++ b/tests/unit/reports/samples/test_filtered.py
@@ -516,6 +516,19 @@ class TestFilteredReport(object):
             diff=0,
         )
 
+    def test_get_file_totals(self, sample_report):
+        assert "location/file_1.py" in sample_report
+        assert "file_1.go" in sample_report
+        filtered_report = FilteredReport(sample_report, ["location/file_1.py"], [])
+
+        # Go file exists in the raw report but is not included in the filters
+        assert sample_report.get_file_totals("file_1.go") is not None
+        assert filtered_report.get_file_totals("file_1.go") is None
+
+        # Python file exists in the raw report and is included in the filters
+        py_file_totals = sample_report.get_file_totals("location/file_1.py")
+        assert filtered_report.get_file_totals("location/file_1.py") == py_file_totals
+
     def test_can_use_session_totals(self, mocker):
         report = Report()
         report.add_session(

--- a/tests/unit/reports/test_readonly.py
+++ b/tests/unit/reports/test_readonly.py
@@ -229,6 +229,26 @@ class TestReadOnly(object):
             diff=0,
         )
 
+    def test_get_file_totals(self, sample_report, mocker):
+        r = ReadOnlyReport.create_from_report(sample_report)
+        print(sample_report._files)
+        print(r)
+        assert r.get_file_totals("location/file_1.py") == ReportTotals(
+            files=0,
+            lines=2,
+            hits=0,
+            misses=0,
+            partials=2,
+            coverage="0",
+            branches=2,
+            methods=0,
+            messages=0,
+            sessions=0,
+            complexity=0,
+            complexity_total=0,
+            diff=0,
+        )
+
     def test_from_chunks_with_totals(self, mocker):
         mocked_process_totals = mocker.patch.object(ReadOnlyReport, "_process_totals")
         mocker.patch.object(

--- a/tests/unit/test_report.py
+++ b/tests/unit/test_report.py
@@ -18,6 +18,145 @@ from tests.helper import v2_to_v3
 END_OF_CHUNK = "\n<<<<< end_of_chunk >>>>>\n"
 
 
+def report_with_file_summaries():
+    return Report(
+        files={
+            "calc/CalcCore.cpp": ReportFileSummary(
+                file_index=0,
+                file_totals=ReportTotals(
+                    files=0,
+                    lines=10,
+                    hits=7,
+                    misses=2,
+                    partials=1,
+                    coverage="70.00000",
+                    branches=6,
+                    methods=4,
+                    messages=0,
+                    sessions=0,
+                    complexity=0,
+                    complexity_total=0,
+                    diff=0,
+                ),
+                session_totals=SessionTotalsArray(
+                    session_count=1,
+                    non_null_items={
+                        0: ReportTotals(
+                            files=0,
+                            lines=10,
+                            hits=7,
+                            misses=2,
+                            partials=1,
+                            coverage="70.00000",
+                            branches=6,
+                            methods=4,
+                            messages=0,
+                            sessions=0,
+                            complexity=0,
+                            complexity_total=0,
+                            diff=0,
+                        )
+                    },
+                ),
+                diff_totals=None,
+            ),
+            "calc/CalcCore.h": ReportFileSummary(
+                file_index=1,
+                file_totals=ReportTotals(
+                    files=0,
+                    lines=1,
+                    hits=1,
+                    misses=0,
+                    partials=0,
+                    coverage="100",
+                    branches=0,
+                    methods=1,
+                    messages=0,
+                    sessions=0,
+                    complexity=0,
+                    complexity_total=0,
+                    diff=0,
+                ),
+                session_totals=SessionTotalsArray(
+                    session_count=1,
+                    non_null_items={
+                        0: ReportTotals(
+                            files=0,
+                            lines=1,
+                            hits=1,
+                            misses=0,
+                            partials=0,
+                            coverage="100",
+                            branches=0,
+                            methods=1,
+                            messages=0,
+                            sessions=0,
+                            complexity=0,
+                            complexity_total=0,
+                            diff=0,
+                        )
+                    },
+                ),
+                diff_totals=None,
+            ),
+            "calc/Calculator.cpp": ReportFileSummary(
+                file_index=2,
+                file_totals=ReportTotals(
+                    files=0,
+                    lines=4,
+                    hits=3,
+                    misses=1,
+                    partials=0,
+                    coverage="75.00000",
+                    branches=1,
+                    methods=1,
+                    messages=0,
+                    sessions=0,
+                    complexity=0,
+                    complexity_total=0,
+                    diff=0,
+                ),
+                session_totals=SessionTotalsArray(
+                    session_count=1,
+                    non_null_items={
+                        0: ReportTotals(
+                            files=0,
+                            lines=4,
+                            hits=3,
+                            misses=1,
+                            partials=0,
+                            coverage="75.00000",
+                            branches=1,
+                            methods=1,
+                            messages=0,
+                            sessions=0,
+                            complexity=0,
+                            complexity_total=0,
+                            diff=0,
+                        )
+                    },
+                ),
+                diff_totals=None,
+            ),
+        },
+        totals=ReportTotals(
+            files=3,
+            lines=15,
+            hits=11,
+            misses=3,
+            partials=1,
+            coverage="73.33333",
+            branches=7,
+            methods=6,
+            messages=0,
+            sessions=0,
+            complexity=0,
+            complexity_total=0,
+            diff=0,
+        ),
+    )
+
+
 @pytest.mark.unit
 def test_report_repr(mocker):
     r = Report()
@@ -249,6 +388,29 @@ def test_manifest(files, manifest):
 
 
 @pytest.mark.unit
+def test_get_file_totals(mocker):
+    report = report_with_file_summaries()
+    report._path_filter = None
+
+    expected_totals = ReportTotals(
+        files=0,
+        lines=10,
+        hits=7,
+        misses=2,
+        partials=1,
+        coverage="70.00000",
+        branches=6,
+        methods=4,
+        messages=0,
+        sessions=0,
+        complexity=0,
+        complexity_total=0,
+        diff=0,
+    )
+    assert report.get_file_totals("calc/CalcCore.cpp") == expected_totals
+
+
+@pytest.mark.unit
 def test_get_folder_totals(mocker):
     r = Report(
         files={
@@ -432,142 +594,7 @@ def test_to_database(mocker):
 
 @pytest.mark.unit
 def test_to_database_report_with_session_totals(mocker):
-    report = Report(
-        files={
-            "calc/CalcCore.cpp": ReportFileSummary(
-                file_index=0,
-                file_totals=ReportTotals(
-                    files=0,
-                    lines=10,
-                    hits=7,
-                    misses=2,
-                    partials=1,
-                    coverage="70.00000",
-                    branches=6,
-                    methods=4,
-                    messages=0,
-                    sessions=0,
-                    complexity=0,
-                    complexity_total=0,
-                    diff=0,
-                ),
-                session_totals=SessionTotalsArray(
-                    session_count=1,
-                    non_null_items={
-                        0: ReportTotals(
-                            files=0,
-                            lines=10,
-                            hits=7,
-                            misses=2,
-                            partials=1,
-                            coverage="70.00000",
-                            branches=6,
-                            methods=4,
-                            messages=0,
-                            sessions=0,
-                            complexity=0,
-                            complexity_total=0,
-                            diff=0,
-                        )
-                    },
-                ),
-                diff_totals=None,
-            ),
-            "calc/CalcCore.h": ReportFileSummary(
-                file_index=1,
-                file_totals=ReportTotals(
-                    files=0,
-                    lines=1,
-                    hits=1,
-                    misses=0,
-                    partials=0,
-                    coverage="100",
-                    branches=0,
-                    methods=1,
-                    messages=0,
-                    sessions=0,
-                    complexity=0,
-                    complexity_total=0,
-                    diff=0,
-                ),
-                session_totals=SessionTotalsArray(
-                    session_count=1,
-                    non_null_items={
-                        0: ReportTotals(
-                            files=0,
-                            lines=1,
-                            hits=1,
-                            misses=0,
-                            partials=0,
-                            coverage="100",
-                            branches=0,
-                            methods=1,
-                            messages=0,
-                            sessions=0,
-                            complexity=0,
-                            complexity_total=0,
-                            diff=0,
-                        )
-                    },
-                ),
-                diff_totals=None,
-            ),
-            "calc/Calculator.cpp": ReportFileSummary(
-                file_index=2,
-                file_totals=ReportTotals(
-                    files=0,
-                    lines=4,
-                    hits=3,
-                    misses=1,
-                    partials=0,
-                    coverage="75.00000",
-                    branches=1,
-                    methods=1,
-                    messages=0,
-                    sessions=0,
-                    complexity=0,
-                    complexity_total=0,
-                    diff=0,
-                ),
-                session_totals=SessionTotalsArray(
-                    session_count=1,
-                    non_null_items={
-                        0: ReportTotals(
-                            files=0,
-                            lines=4,
-                            hits=3,
-                            misses=1,
-                            partials=0,
-                            coverage="75.00000",
-                            branches=1,
-                            methods=1,
-                            messages=0,
-                            sessions=0,
-                            complexity=0,
-                            complexity_total=0,
-                            diff=0,
-                        )
-                    },
-                ),
-                diff_totals=None,
-            ),
-        },
-        totals=ReportTotals(
-            files=3,
-            lines=15,
-            hits=11,
-            misses=3,
-            partials=1,
-            coverage="73.33333",
-            branches=7,
-            methods=6,
-            messages=0,
-            sessions=0,
-            complexity=0,
-            complexity_total=0,
-            diff=0,
-        ),
-    )
+    report = report_with_file_summaries()
     expected_result = (
         {
             "f": 3,


### PR DESCRIPTION
https://github.com/codecov/internal-issues/issues/155

sentry traces show `ReportPaths.single_directory()` in `codecov-api` takes a while. [definition](https://github.com/codecov/codecov-api/blob/8f1d7d5f723d24d06286b3cb656fc99d2b5204da/services/path.py#L214). it basically returns a flat list of directory/file objects with the name/totals, calling `report.get(path).totals` to get the totals which is more processing than necessary

this PR creates a more minimal way to get the totals in case that fixes things
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.