### PR TITLE
fix: Timeout Github API student check (#277)

### DIFF
--- a/shared/torngit/base.py
+++ b/shared/torngit/base.py
@@ -50,8 +50,11 @@ class TorngitBaseAdapter(object):
         "xtend",
     )
 
-    def get_client(self):
-        timeout = httpx.Timeout(self._timeouts[1], connect=self._timeouts[0])
+    def get_client(self, timeouts: List[int] = []) -> httpx.AsyncClient:
+        if timeouts:
+            timeout = httpx.Timeout(timeouts[1], connect=timeouts[0])
+        else:
+            timeout = httpx.Timeout(self._timeouts[1], connect=self._timeouts[0])
         return httpx.AsyncClient(
             verify=self.verify_ssl
             if not isinstance(self.verify_ssl, bool)

--- a/shared/torngit/github.py
+++ b/shared/torngit/github.py
@@ -1463,12 +1463,15 @@ class Github(TorngitBaseAdapter):
             return [r["name"] for r in res]
 
     async def is_student(self):
-        async with self.get_client() as client:
+        async with self.get_client([3, 3]) as client:
             try:
                 res = await self.api(
                     client, "get", "https://education.github.com/api/user"
                 )
                 return res["student"]
+            except TorngitServerUnreachableError:
+                log.warn("Timeout on Github Education API for is_student")
+                return False
             except (TorngitUnauthorizedError, TorngitServer5xxCodeError):
                 return False
 

--- a/tests/unit/torngit/test_github.py
+++ b/tests/unit/torngit/test_github.py
@@ -1311,6 +1311,30 @@ class TestUnitGithub(object):
         assert valid_handler._oauth == dict(key="client_id", secret="client_secret")
 
     @pytest.mark.asyncio
+    async def test_github_is_student_timeout(self, ghapp_handler):
+        def side_effect(*args, **kwargs):
+            raise httpx.TimeoutException("timeout")
+        with respx.mock:
+            mocked_route = respx.get(
+                "https://education.github.com/api/user"
+            ).mock(side_effect=side_effect)
+            res = await ghapp_handler.is_student()
+            assert mocked_route.call_count == 1
+            assert res == False
+
+    @pytest.mark.asyncio
+    async def test_github_is_student_network_error(self, ghapp_handler):
+        def side_effect(*args, **kwargs):
+            raise httpx.NetworkError("timeout")
+        with respx.mock:
+            mocked_route = respx.get(
+                "https://education.github.com/api/user"
+            ).mock(side_effect=side_effect)
+            res = await ghapp_handler.is_student()
+            assert mocked_route.call_count == 1
+            assert res == False
+
+    @pytest.mark.asyncio
     async def test_github_refresh_after_failed_request(self, mocker, valid_handler):
         def side_effect(request, *args, **kwargs):
             print(f"Received request with headers {request.headers['Authorization']}")


### PR DESCRIPTION
Add a short timeout to the GitHub education API we use to check if a user is student. This GH call is known to be flaky, causing timeouts when this is called during the login step. This change gives it 3s to respond before default to "not a student" like how it is being handled currently when there's other errors coming from this GH call.

Note that after this is released and API is using this package, we need to turn off the `student_disabled` config in API.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.