### PR TITLE
Updating get github integration to use host override tech

### DIFF
--- a/shared/github/__init__.py
+++ b/shared/github/__init__.py
@@ -46,11 +46,18 @@ def get_github_integration_token(service, integration_id=None) -> Optional[str]:
             if service == "github"
             else torngit.GithubEnterprise.get_api_url()
         )
+        host_override = (
+            torngit.Github.get_api_host_header()
+            if service == "github"
+            else torngit.GithubEnterprise.get_api_host_header()
+        )
         headers = {
             "Accept": "application/vnd.github.machine-man-preview+json",
             "User-Agent": "Codecov",
             "Authorization": "Bearer %s" % token,
         }
+        if host_override is not None:
+            headers["Host"] = host_override
         url = "%s/app/installations/%s/access_tokens" % (api_endpoint, integration_id)
         res = requests.post(url, headers=headers)
         if res.status_code in (404, 403):

--- a/tests/unit/torngit/test_github.py
+++ b/tests/unit/torngit/test_github.py
@@ -1383,10 +1383,11 @@ class TestUnitGithub(object):
     async def test_github_is_student_timeout(self, ghapp_handler):
         def side_effect(*args, **kwargs):
             raise httpx.TimeoutException("timeout")
+
         with respx.mock:
-            mocked_route = respx.get(
-                "https://education.github.com/api/user"
-            ).mock(side_effect=side_effect)
+            mocked_route = respx.get("https://education.github.com/api/user").mock(
+                side_effect=side_effect
+            )
             res = await ghapp_handler.is_student()
             assert mocked_route.call_count == 1
             assert res == False
@@ -1395,10 +1396,11 @@ class TestUnitGithub(object):
     async def test_github_is_student_network_error(self, ghapp_handler):
         def side_effect(*args, **kwargs):
             raise httpx.NetworkError("timeout")
+
         with respx.mock:
-            mocked_route = respx.get(
-                "https://education.github.com/api/user"
-            ).mock(side_effect=side_effect)
+            mocked_route = respx.get("https://education.github.com/api/user").mock(
+                side_effect=side_effect
+            )
             res = await ghapp_handler.is_student()
             assert mocked_route.call_count == 1
             assert res == False


### PR DESCRIPTION
<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.