### PR TITLE
Add admins to config schema

### DIFF
--- a/shared/validation/install.py
+++ b/shared/validation/install.py
@@ -122,6 +122,16 @@ config_schema = {
             "api_cors_allowed_origins": {"type": "string"},
             "codecov_dashboard_url": {"type": "string"},
             "enterprise_license": {"type": "string"},
+            "admins": {
+                "type": "list",
+                "schema": {
+                    "type": "dict",
+                    "schema": {
+                        "service": {"type": "string"},
+                        "username": {"type": "string"},
+                    },
+                },
+            },
             "api_allowed_hosts": {"type": "list", "schema": {"type": "string"}},
             "secure_cookie": {"type": "boolean"},
             "segment": {

--- a/tests/unit/validation/test_install_validation.py
+++ b/tests/unit/validation/test_install_validation.py
@@ -404,16 +404,7 @@ def test_pubsub_config(mocker):
 
 
 def test_admins(mocker):
-    assert validate_install_configuration(
-        {
-            "setup": {
-                "admins": {
-                    "service": "github",
-                    "username": "user123",
-                }
-            },
-        }
-    ) == {
+    user_input = {
         "setup": {
             "admins": {
                 "service": "github",
@@ -421,6 +412,18 @@ def test_admins(mocker):
             }
         },
     }
+    expected_result = {
+        "setup": {
+            "admins": {
+                "service": "github",
+                "username": "user123",
+            }
+        },
+    }
+    mock_warning = mocker.patch.object(install_log, "warning")
+    res = validate_install_configuration(user_input)
+    assert mock_warning.call_count == 0
+    assert res == expected_result
 
 
 def test_validate_install_configuration_raise_warning(mocker):

--- a/tests/unit/validation/test_install_validation.py
+++ b/tests/unit/validation/test_install_validation.py
@@ -403,6 +403,26 @@ def test_pubsub_config(mocker):
     }
 
 
+def test_admins(mocker):
+    assert validate_install_configuration(
+        {
+            "setup": {
+                "admins": {
+                    "service": "github",
+                    "username": "user123",
+                }
+            },
+        }
+    ) == {
+        "setup": {
+            "admins": {
+                "service": "github",
+                "username": "user123",
+            }
+        },
+    }
+
+
 def test_validate_install_configuration_raise_warning(mocker):
     mock_warning = mocker.patch.object(install_log, "warning")
     input = {

--- a/tests/unit/validation/test_install_validation.py
+++ b/tests/unit/validation/test_install_validation.py
@@ -406,18 +406,18 @@ def test_pubsub_config(mocker):
 def test_admins(mocker):
     user_input = {
         "setup": {
-            "admins": {
+            "admins":[{
                 "service": "github",
                 "username": "user123",
-            }
+            }],
         },
     }
     expected_result = {
         "setup": {
-            "admins": {
+            "admins": [{
                 "service": "github",
                 "username": "user123",
-            }
+            }],
         },
     }
     mock_warning = mocker.patch.object(install_log, "warning")


### PR DESCRIPTION
[Instance-wide admins](https://docs.codecov.com/docs/configuration#instance-wide-admins) are needed to set up the self-hosted version of Codecov, but the schema validation fails as it currently does not allow `admins`.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.