### PR TITLE
GitHub PR labels, SQLAlchemy version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
         "pyjwt",
         "pytz",
         "django>=4.2.3",
-        "sqlalchemy>=2.0",
+        "sqlalchemy==1.*",
         "ijson==3.*",
     ],
 )

--- a/shared/bundle_analysis/models.py
+++ b/shared/bundle_analysis/models.py
@@ -2,9 +2,9 @@ from enum import Enum
 from typing import List
 
 from sqlalchemy import Column, ForeignKey, Table, create_engine, types
-from sqlalchemy.orm import Mapped
+from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import Session as DbSession
-from sqlalchemy.orm import backref, declarative_base, relationship, sessionmaker
+from sqlalchemy.orm import backref, relationship, sessionmaker
 
 SCHEMA = """
 create table sessions (
@@ -131,10 +131,8 @@ class Asset(Base):
     normalized_name = Column(types.Text, nullable=False)
     size = Column(types.Integer, nullable=False)
 
-    session = relationship(Session, backref=backref("assets"))
-    chunks: Mapped[List["Chunk"]] = relationship(
-        secondary=assets_chunks, back_populates="assets"
-    )
+    session = relationship("Session", backref=backref("assets"))
+    chunks = relationship("Chunk", secondary=assets_chunks, back_populates="assets")
 
 
 class Chunk(Base):
@@ -150,12 +148,8 @@ class Chunk(Base):
     entry = Column(types.Boolean, nullable=False)
     initial = Column(types.Boolean, nullable=False)
 
-    assets: Mapped[List["Asset"]] = relationship(
-        secondary=assets_chunks, back_populates="chunks"
-    )
-    modules: Mapped[List["Module"]] = relationship(
-        secondary=chunks_modules, back_populates="chunks"
-    )
+    assets = relationship("Asset", secondary=assets_chunks, back_populates="chunks")
+    modules = relationship("Module", secondary=chunks_modules, back_populates="chunks")
 
 
 class Module(Base):
@@ -169,9 +163,7 @@ class Module(Base):
     name = Column(types.Text, nullable=False)
     size = Column(types.Integer, nullable=False)
 
-    chunks: Mapped[List["Chunk"]] = relationship(
-        secondary=chunks_modules, back_populates="modules"
-    )
+    chunks = relationship("Chunk", secondary=chunks_modules, back_populates="modules")
 
 
 class MetadataKey(Enum):

--- a/shared/torngit/github.py
+++ b/shared/torngit/github.py
@@ -1141,7 +1141,7 @@ class Github(TorngitBaseAdapter):
             title=pull["title"],
             id=str(pull["number"]),
             number=str(pull["number"]),
-            labels=[label["name"] for label in pull.get("labels", [])]
+            labels=[label["name"] for label in pull.get("labels", [])],
         )
 
     async def get_pull_request(self, pullid, token=None):

--- a/shared/torngit/github.py
+++ b/shared/torngit/github.py
@@ -1141,6 +1141,7 @@ class Github(TorngitBaseAdapter):
             title=pull["title"],
             id=str(pull["number"]),
             number=str(pull["number"]),
+            labels=[label["name"] for label in pull.get("labels", [])]
         )
 
     async def get_pull_request(self, pullid, token=None):

--- a/shared/validation/user_schema.py
+++ b/shared/validation/user_schema.py
@@ -490,7 +490,11 @@ schema = {
     },
     "beta_groups": {"type": "list", "schema": {"type": "string"}},
     "ai_pr_review": {
-        "type": ["dict", "boolean"],
-        "schema": {"enabled": {"type": "boolean"}},
+        "type": ["dict"],
+        "schema": {
+            "enabled": {"type": "boolean"},
+            "method": {"type": "string"},
+            "label_name": {"type": "string"},
+        },
     },
 }

--- a/tests/integration/test_github.py
+++ b/tests/integration/test_github.py
@@ -270,6 +270,7 @@ class TestGithubTestCase(object):
                 "state": "merged",
                 "title": "Creating new code for reasons no one knows",
                 "author": {"id": "44376991", "username": "ThiagoCodecov"},
+                "labels": [],
             },
         )
     ]
@@ -293,6 +294,7 @@ class TestGithubTestCase(object):
             "state": "open",
             "title": "PR with more than 250 results",
             "author": {"id": "44376991", "username": "ThiagoCodecov"},
+            "labels": [],
         }
         res = await valid_handler.get_pull_request(pull_id)
         assert res == expected_result
@@ -1182,6 +1184,7 @@ class TestGithubTestCase(object):
             "state": "closed",
             "title": "Thiago/test 1",
             "author": {"id": "44376991", "username": "ThiagoCodecov"},
+            "labels": [],
         }
         res = await valid_handler.get_pull_request(pull_id)
         assert res == expected_result
@@ -1210,6 +1213,7 @@ class TestGithubTestCase(object):
             "state": "merged",
             "title": "CE-1314 GitHub Status Event Handler",
             "author": {"id": "5767537", "username": "pierce-m"},
+            "labels": [],
         }
         res = await handler.get_pull_request(pull_id)
         assert res == expected_result


### PR DESCRIPTION
This PR includes a few changes:

* return PR labels from the GitHub pull request response (for use with https://github.com/codecov/engineering-team/issues/896)
  - only needed for GitHub right now so I didn't implement similar functionality for other providers
* updates the `ai_pr_review` yaml schema (also to support https://github.com/codecov/engineering-team/issues/896)
* switch to SQLAlchemy 1.x so that we're compatible with `worker`