### PR TITLE
feat: flag names are longer and contain special chars

### DIFF
--- a/shared/validation/user_schema.py
+++ b/shared/validation/user_schema.py
@@ -1,4 +1,9 @@
-flag_name = {"type": "string", "minlength": 1, "maxlength": 45, "regex": r"^[\w\.\-]+$"}
+flag_name = {
+    "type": "string",
+    "minlength": 1,
+    "maxlength": 1024,
+    "regex": r"^[^\'\"]+$",
+}
 
 branches_structure = {
     "type": "list",

--- a/tests/unit/validation/test_validation.py
+++ b/tests/unit/validation/test_validation.py
@@ -465,12 +465,12 @@ class TestUserYamlValidation(BaseTestCase):
         assert result == expected_result
 
     def test_validate_flag_too_long(self):
-        user_input = {"flags": {"abcdefg" * 7: {"paths": ["banana"]}}}
+        user_input = {"flags": {"abcdefg" * 500: {"paths": ["banana"]}}}
         with pytest.raises(InvalidYamlException) as exc:
             validate_yaml(user_input)
         assert exc.value.error_location == [
             "flags",
-            "abcdefgabcdefgabcdefgabcdefgabcdefgabcdefgabcdefg",
+            "abcdefg" * 500,
         ]
 
     def test_validate_parser_only_field(self):


### PR DESCRIPTION
We want to support longer flag names up to 1024 characters. We also want to support special characters other than single and double quotes.