### PR TITLE
chore: Get origin repo of PRs

### DIFF
--- a/shared/torngit/github.py
+++ b/shared/torngit/github.py
@@ -1135,8 +1135,16 @@ class Github(TorngitBaseAdapter):
                 id=str(pull["user"]["id"]) if pull["user"] else None,
                 username=pull["user"]["login"] if pull["user"] else None,
             ),
-            base=dict(branch=pull["base"]["ref"], commitid=pull["base"]["sha"]),
-            head=dict(branch=pull["head"]["ref"], commitid=pull["head"]["sha"]),
+            base=dict(
+                branch=pull["base"]["ref"],
+                commitid=pull["base"]["sha"],
+                slug=pull["base"]["repo"]["full_name"],
+            ),
+            head=dict(
+                branch=pull["head"]["ref"],
+                commitid=pull["head"]["sha"],
+                slug=pull["head"]["repo"]["full_name"],
+            ),
             state="merged" if pull["merged"] else pull["state"],
             title=pull["title"],
             id=str(pull["number"]),

--- a/tests/integration/cassetes/test_github/TestGithubTestCase/test_get_pull_request_from_fork.yaml
+++ b/tests/integration/cassetes/test_github/TestGithubTestCase/test_get_pull_request_from_fork.yaml
@@ -1,0 +1,190 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.github.com
+      user-agent:
+      - Default
+    method: GET
+    uri: https://api.github.com/repos/codecov/codecov-api/pulls/285
+  response:
+    content: '{"url":"https://api.github.com/repos/codecov/codecov-api/pulls/285","id":1626444498,"node_id":"PR_kwDOJ8oEEM5g8ZLS","html_url":"https://github.com/codecov/codecov-api/pull/285","diff_url":"https://github.com/codecov/codecov-api/pull/285.diff","patch_url":"https://github.com/codecov/codecov-api/pull/285.patch","issue_url":"https://api.github.com/repos/codecov/codecov-api/issues/285","number":285,"state":"open","locked":false,"title":"chore:
+      Switch to Python 3.12","user":{"login":"FraBle","id":1584268,"node_id":"MDQ6VXNlcjE1ODQyNjg=","avatar_url":"https://avatars.githubusercontent.com/u/1584268?v=4","gravatar_id":"","url":"https://api.github.com/users/FraBle","html_url":"https://github.com/FraBle","followers_url":"https://api.github.com/users/FraBle/followers","following_url":"https://api.github.com/users/FraBle/following{/other_user}","gists_url":"https://api.github.com/users/FraBle/gists{/gist_id}","starred_url":"https://api.github.com/users/FraBle/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/FraBle/subscriptions","organizations_url":"https://api.github.com/users/FraBle/orgs","repos_url":"https://api.github.com/users/FraBle/repos","events_url":"https://api.github.com/users/FraBle/events{/privacy}","received_events_url":"https://api.github.com/users/FraBle/received_events","type":"User","site_admin":false},"body":"###
+      Purpose/Motivation\r\nSwitches the API to Python 3.12.\r\n\r\n### Links to relevant
+      tickets\r\n\r\nhttps://github.com/codecov/engineering-team/issues/875\r\n\r\n###
+      Legal Boilerplate\r\n\r\nLook, I get it. The entity doing business as \"Sentry\"
+      was incorporated in the State of Delaware in 2015 as Functional Software, Inc.
+      In 2022 this entity acquired Codecov and as result Sentry is going to need some
+      rights from me in order to utilize my contributions in this PR. So here''s the
+      deal: I retain all rights, title and interest in and to my contributions, and
+      by keeping this boilerplate intact I confirm that Sentry can use, modify, copy,
+      and redistribute my contributions, under Sentry''s choice of terms.\r\n","created_at":"2023-12-01T23:20:48Z","updated_at":"2023-12-01T23:21:51Z","closed_at":null,"merged_at":null,"merge_commit_sha":"7458689acf385c2cbe5fe09bd73536a50ef545c6","assignee":null,"assignees":[],"requested_reviewers":[],"requested_teams":[],"labels":[],"milestone":null,"draft":false,"commits_url":"https://api.github.com/repos/codecov/codecov-api/pulls/285/commits","review_comments_url":"https://api.github.com/repos/codecov/codecov-api/pulls/285/comments","review_comment_url":"https://api.github.com/repos/codecov/codecov-api/pulls/comments{/number}","comments_url":"https://api.github.com/repos/codecov/codecov-api/issues/285/comments","statuses_url":"https://api.github.com/repos/codecov/codecov-api/statuses/67a44e176ffd419f066c1cc34cff391e2a1304e2","head":{"label":"FraBle:python-3-12","ref":"python-3-12","sha":"67a44e176ffd419f066c1cc34cff391e2a1304e2","user":{"login":"FraBle","id":1584268,"node_id":"MDQ6VXNlcjE1ODQyNjg=","avatar_url":"https://avatars.githubusercontent.com/u/1584268?v=4","gravatar_id":"","url":"https://api.github.com/users/FraBle","html_url":"https://github.com/FraBle","followers_url":"https://api.github.com/users/FraBle/followers","following_url":"https://api.github.com/users/FraBle/following{/other_user}","gists_url":"https://api.github.com/users/FraBle/gists{/gist_id}","starred_url":"https://api.github.com/users/FraBle/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/FraBle/subscriptions","organizations_url":"https://api.github.com/users/FraBle/orgs","repos_url":"https://api.github.com/users/FraBle/repos","events_url":"https://api.github.com/users/FraBle/events{/privacy}","received_events_url":"https://api.github.com/users/FraBle/received_events","type":"User","site_admin":false},"repo":{"id":724832882,"node_id":"R_kgDOKzQScg","name":"codecov-api","full_name":"FraBle/codecov-api","private":false,"owner":{"login":"FraBle","id":1584268,"node_id":"MDQ6VXNlcjE1ODQyNjg=","avatar_url":"https://avatars.githubusercontent.com/u/1584268?v=4","gravatar_id":"","url":"https://api.github.com/users/FraBle","html_url":"https://github.com/FraBle","followers_url":"https://api.github.com/users/FraBle/followers","following_url":"https://api.github.com/users/FraBle/following{/other_user}","gists_url":"https://api.github.com/users/FraBle/gists{/gist_id}","starred_url":"https://api.github.com/users/FraBle/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/FraBle/subscriptions","organizations_url":"https://api.github.com/users/FraBle/orgs","repos_url":"https://api.github.com/users/FraBle/repos","events_url":"https://api.github.com/users/FraBle/events{/privacy}","received_events_url":"https://api.github.com/users/FraBle/received_events","type":"User","site_admin":false},"html_url":"https://github.com/FraBle/codecov-api","description":"Code
+      for the API of Codecov","fork":true,"url":"https://api.github.com/repos/FraBle/codecov-api","forks_url":"https://api.github.com/repos/FraBle/codecov-api/forks","keys_url":"https://api.github.com/repos/FraBle/codecov-api/keys{/key_id}","collaborators_url":"https://api.github.com/repos/FraBle/codecov-api/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/FraBle/codecov-api/teams","hooks_url":"https://api.github.com/repos/FraBle/codecov-api/hooks","issue_events_url":"https://api.github.com/repos/FraBle/codecov-api/issues/events{/number}","events_url":"https://api.github.com/repos/FraBle/codecov-api/events","assignees_url":"https://api.github.com/repos/FraBle/codecov-api/assignees{/user}","branches_url":"https://api.github.com/repos/FraBle/codecov-api/branches{/branch}","tags_url":"https://api.github.com/repos/FraBle/codecov-api/tags","blobs_url":"https://api.github.com/repos/FraBle/codecov-api/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/FraBle/codecov-api/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/FraBle/codecov-api/git/refs{/sha}","trees_url":"https://api.github.com/repos/FraBle/codecov-api/git/trees{/sha}","statuses_url":"https://api.github.com/repos/FraBle/codecov-api/statuses/{sha}","languages_url":"https://api.github.com/repos/FraBle/codecov-api/languages","stargazers_url":"https://api.github.com/repos/FraBle/codecov-api/stargazers","contributors_url":"https://api.github.com/repos/FraBle/codecov-api/contributors","subscribers_url":"https://api.github.com/repos/FraBle/codecov-api/subscribers","subscription_url":"https://api.github.com/repos/FraBle/codecov-api/subscription","commits_url":"https://api.github.com/repos/FraBle/codecov-api/commits{/sha}","git_commits_url":"https://api.github.com/repos/FraBle/codecov-api/git/commits{/sha}","comments_url":"https://api.github.com/repos/FraBle/codecov-api/comments{/number}","issue_comment_url":"https://api.github.com/repos/FraBle/codecov-api/issues/comments{/number}","contents_url":"https://api.github.com/repos/FraBle/codecov-api/contents/{+path}","compare_url":"https://api.github.com/repos/FraBle/codecov-api/compare/{base}...{head}","merges_url":"https://api.github.com/repos/FraBle/codecov-api/merges","archive_url":"https://api.github.com/repos/FraBle/codecov-api/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/FraBle/codecov-api/downloads","issues_url":"https://api.github.com/repos/FraBle/codecov-api/issues{/number}","pulls_url":"https://api.github.com/repos/FraBle/codecov-api/pulls{/number}","milestones_url":"https://api.github.com/repos/FraBle/codecov-api/milestones{/number}","notifications_url":"https://api.github.com/repos/FraBle/codecov-api/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/FraBle/codecov-api/labels{/name}","releases_url":"https://api.github.com/repos/FraBle/codecov-api/releases{/id}","deployments_url":"https://api.github.com/repos/FraBle/codecov-api/deployments","created_at":"2023-11-28T22:10:46Z","updated_at":"2023-11-28T22:10:46Z","pushed_at":"2023-12-01T23:21:49Z","git_url":"git://github.com/FraBle/codecov-api.git","ssh_url":"git@github.com:FraBle/codecov-api.git","clone_url":"https://github.com/FraBle/codecov-api.git","svn_url":"https://github.com/FraBle/codecov-api","homepage":null,"size":27481,"stargazers_count":0,"watchers_count":0,"language":null,"has_issues":false,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"has_discussions":false,"forks_count":0,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":0,"license":{"key":"other","name":"Other","spdx_id":"NOASSERTION","url":null,"node_id":"MDc6TGljZW5zZTA="},"allow_forking":true,"is_template":false,"web_commit_signoff_required":false,"topics":[],"visibility":"public","forks":0,"open_issues":0,"watchers":0,"default_branch":"main"}},"base":{"label":"codecov:main","ref":"main","sha":"109eea9a085f5856a20ae5f1714b8c4786c3327b","user":{"login":"codecov","id":8226205,"node_id":"MDEyOk9yZ2FuaXphdGlvbjgyMjYyMDU=","avatar_url":"https://avatars.githubusercontent.com/u/8226205?v=4","gravatar_id":"","url":"https://api.github.com/users/codecov","html_url":"https://github.com/codecov","followers_url":"https://api.github.com/users/codecov/followers","following_url":"https://api.github.com/users/codecov/following{/other_user}","gists_url":"https://api.github.com/users/codecov/gists{/gist_id}","starred_url":"https://api.github.com/users/codecov/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/codecov/subscriptions","organizations_url":"https://api.github.com/users/codecov/orgs","repos_url":"https://api.github.com/users/codecov/repos","events_url":"https://api.github.com/users/codecov/events{/privacy}","received_events_url":"https://api.github.com/users/codecov/received_events","type":"Organization","site_admin":false},"repo":{"id":667550736,"node_id":"R_kgDOJ8oEEA","name":"codecov-api","full_name":"codecov/codecov-api","private":false,"owner":{"login":"codecov","id":8226205,"node_id":"MDEyOk9yZ2FuaXphdGlvbjgyMjYyMDU=","avatar_url":"https://avatars.githubusercontent.com/u/8226205?v=4","gravatar_id":"","url":"https://api.github.com/users/codecov","html_url":"https://github.com/codecov","followers_url":"https://api.github.com/users/codecov/followers","following_url":"https://api.github.com/users/codecov/following{/other_user}","gists_url":"https://api.github.com/users/codecov/gists{/gist_id}","starred_url":"https://api.github.com/users/codecov/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/codecov/subscriptions","organizations_url":"https://api.github.com/users/codecov/orgs","repos_url":"https://api.github.com/users/codecov/repos","events_url":"https://api.github.com/users/codecov/events{/privacy}","received_events_url":"https://api.github.com/users/codecov/received_events","type":"Organization","site_admin":false},"html_url":"https://github.com/codecov/codecov-api","description":"Code
+      for the API of Codecov","fork":false,"url":"https://api.github.com/repos/codecov/codecov-api","forks_url":"https://api.github.com/repos/codecov/codecov-api/forks","keys_url":"https://api.github.com/repos/codecov/codecov-api/keys{/key_id}","collaborators_url":"https://api.github.com/repos/codecov/codecov-api/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/codecov/codecov-api/teams","hooks_url":"https://api.github.com/repos/codecov/codecov-api/hooks","issue_events_url":"https://api.github.com/repos/codecov/codecov-api/issues/events{/number}","events_url":"https://api.github.com/repos/codecov/codecov-api/events","assignees_url":"https://api.github.com/repos/codecov/codecov-api/assignees{/user}","branches_url":"https://api.github.com/repos/codecov/codecov-api/branches{/branch}","tags_url":"https://api.github.com/repos/codecov/codecov-api/tags","blobs_url":"https://api.github.com/repos/codecov/codecov-api/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/codecov/codecov-api/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/codecov/codecov-api/git/refs{/sha}","trees_url":"https://api.github.com/repos/codecov/codecov-api/git/trees{/sha}","statuses_url":"https://api.github.com/repos/codecov/codecov-api/statuses/{sha}","languages_url":"https://api.github.com/repos/codecov/codecov-api/languages","stargazers_url":"https://api.github.com/repos/codecov/codecov-api/stargazers","contributors_url":"https://api.github.com/repos/codecov/codecov-api/contributors","subscribers_url":"https://api.github.com/repos/codecov/codecov-api/subscribers","subscription_url":"https://api.github.com/repos/codecov/codecov-api/subscription","commits_url":"https://api.github.com/repos/codecov/codecov-api/commits{/sha}","git_commits_url":"https://api.github.com/repos/codecov/codecov-api/git/commits{/sha}","comments_url":"https://api.github.com/repos/codecov/codecov-api/comments{/number}","issue_comment_url":"https://api.github.com/repos/codecov/codecov-api/issues/comments{/number}","contents_url":"https://api.github.com/repos/codecov/codecov-api/contents/{+path}","compare_url":"https://api.github.com/repos/codecov/codecov-api/compare/{base}...{head}","merges_url":"https://api.github.com/repos/codecov/codecov-api/merges","archive_url":"https://api.github.com/repos/codecov/codecov-api/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/codecov/codecov-api/downloads","issues_url":"https://api.github.com/repos/codecov/codecov-api/issues{/number}","pulls_url":"https://api.github.com/repos/codecov/codecov-api/pulls{/number}","milestones_url":"https://api.github.com/repos/codecov/codecov-api/milestones{/number}","notifications_url":"https://api.github.com/repos/codecov/codecov-api/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/codecov/codecov-api/labels{/name}","releases_url":"https://api.github.com/repos/codecov/codecov-api/releases{/id}","deployments_url":"https://api.github.com/repos/codecov/codecov-api/deployments","created_at":"2023-07-17T19:06:58Z","updated_at":"2023-12-08T12:41:15Z","pushed_at":"2023-12-12T15:56:05Z","git_url":"git://github.com/codecov/codecov-api.git","ssh_url":"git@github.com:codecov/codecov-api.git","clone_url":"https://github.com/codecov/codecov-api.git","svn_url":"https://github.com/codecov/codecov-api","homepage":null,"size":27915,"stargazers_count":197,"watchers_count":197,"language":"Python","has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"has_discussions":false,"forks_count":21,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":14,"license":{"key":"other","name":"Other","spdx_id":"NOASSERTION","url":null,"node_id":"MDc6TGljZW5zZTA="},"allow_forking":true,"is_template":false,"web_commit_signoff_required":false,"topics":[],"visibility":"public","forks":21,"open_issues":14,"watchers":197,"default_branch":"main"}},"_links":{"self":{"href":"https://api.github.com/repos/codecov/codecov-api/pulls/285"},"html":{"href":"https://github.com/codecov/codecov-api/pull/285"},"issue":{"href":"https://api.github.com/repos/codecov/codecov-api/issues/285"},"comments":{"href":"https://api.github.com/repos/codecov/codecov-api/issues/285/comments"},"review_comments":{"href":"https://api.github.com/repos/codecov/codecov-api/pulls/285/comments"},"review_comment":{"href":"https://api.github.com/repos/codecov/codecov-api/pulls/comments{/number}"},"commits":{"href":"https://api.github.com/repos/codecov/codecov-api/pulls/285/commits"},"statuses":{"href":"https://api.github.com/repos/codecov/codecov-api/statuses/67a44e176ffd419f066c1cc34cff391e2a1304e2"}},"author_association":"CONTRIBUTOR","auto_merge":null,"active_lock_reason":null,"merged":false,"mergeable":true,"rebaseable":true,"mergeable_state":"behind","merged_by":null,"comments":0,"review_comments":0,"maintainer_can_modify":true,"commits":2,"additions":4,"deletions":6,"changed_files":3}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 12 Dec 2023 17:17:52 GMT
+      ETag:
+      - W/"75031a844ae3475a0255b2014cb4d7f96973216079c0123c4415f75234d5b626"
+      Last-Modified:
+      - Fri, 01 Dec 2023 23:21:51 GMT
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Server:
+      - GitHub.com
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Accepted-OAuth-Scopes:
+      - ''
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-GitHub-Media-Type:
+      - github.v3
+      X-GitHub-Request-Id:
+      - CF27:BC0A:16CF49:18099C:657895BF
+      X-OAuth-Scopes:
+      - repo, user
+      X-RateLimit-Limit:
+      - '5000'
+      X-RateLimit-Remaining:
+      - '4987'
+      X-RateLimit-Reset:
+      - '1702401614'
+      X-RateLimit-Resource:
+      - core
+      X-RateLimit-Used:
+      - '13'
+      X-XSS-Protection:
+      - '0'
+      github-authentication-token-expiration:
+      - 2023-12-19 17:14:49 UTC
+      x-github-api-version-selected:
+      - '2022-11-28'
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.github.com
+      user-agent:
+      - Default
+    method: GET
+    uri: https://api.github.com/repos/codecov/codecov-api/pulls/285/commits?page=1&per_page=100
+  response:
+    content: '[{"sha":"24732c7c43912738228b2509fe73fa0b94255440","node_id":"C_kwDOKzQSctoAKDI0NzMyYzdjNDM5MTI3MzgyMjhiMjUwOWZlNzNmYTBiOTQyNTU0NDA","commit":{"author":{"name":"Frank
+      Blechschmidt","email":"frank.blechschmidt@lattice.com","date":"2023-12-01T23:19:54Z"},"committer":{"name":"Frank
+      Blechschmidt","email":"frank.blechschmidt@lattice.com","date":"2023-12-01T23:19:54Z"},"message":"chore:
+      Switch to Python 3.12","tree":{"sha":"0c5669987c62f010dfbded5d7e691b3a6fbb0e3b","url":"https://api.github.com/repos/codecov/codecov-api/git/trees/0c5669987c62f010dfbded5d7e691b3a6fbb0e3b"},"url":"https://api.github.com/repos/codecov/codecov-api/git/commits/24732c7c43912738228b2509fe73fa0b94255440","comment_count":0,"verification":{"verified":true,"reason":"valid","signature":"-----BEGIN
+      PGP SIGNATURE-----\n\niHUEABYIAB0WIQSVjuhupFplVZZQvEi9MqB215bO9AUCZWpqGgAKCRC9MqB215bO\n9B9dAPsEc1epSl3Txv+A0/768ZmtbW+IoCKNIngtD99zJQuHMAEAykNO+OoEeWWC\nJGSAA3psVhbfTq0mZg1hbwUjI0J2tQE=\n=zVJX\n-----END
+      PGP SIGNATURE-----","payload":"tree 0c5669987c62f010dfbded5d7e691b3a6fbb0e3b\nparent
+      109eea9a085f5856a20ae5f1714b8c4786c3327b\nauthor Frank Blechschmidt <frank.blechschmidt@lattice.com>
+      1701472794 -0800\ncommitter Frank Blechschmidt <frank.blechschmidt@lattice.com>
+      1701472794 -0800\n\nchore: Switch to Python 3.12\n"}},"url":"https://api.github.com/repos/codecov/codecov-api/commits/24732c7c43912738228b2509fe73fa0b94255440","html_url":"https://github.com/codecov/codecov-api/commit/24732c7c43912738228b2509fe73fa0b94255440","comments_url":"https://api.github.com/repos/codecov/codecov-api/commits/24732c7c43912738228b2509fe73fa0b94255440/comments","author":{"login":"FraBle","id":1584268,"node_id":"MDQ6VXNlcjE1ODQyNjg=","avatar_url":"https://avatars.githubusercontent.com/u/1584268?v=4","gravatar_id":"","url":"https://api.github.com/users/FraBle","html_url":"https://github.com/FraBle","followers_url":"https://api.github.com/users/FraBle/followers","following_url":"https://api.github.com/users/FraBle/following{/other_user}","gists_url":"https://api.github.com/users/FraBle/gists{/gist_id}","starred_url":"https://api.github.com/users/FraBle/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/FraBle/subscriptions","organizations_url":"https://api.github.com/users/FraBle/orgs","repos_url":"https://api.github.com/users/FraBle/repos","events_url":"https://api.github.com/users/FraBle/events{/privacy}","received_events_url":"https://api.github.com/users/FraBle/received_events","type":"User","site_admin":false},"committer":{"login":"FraBle","id":1584268,"node_id":"MDQ6VXNlcjE1ODQyNjg=","avatar_url":"https://avatars.githubusercontent.com/u/1584268?v=4","gravatar_id":"","url":"https://api.github.com/users/FraBle","html_url":"https://github.com/FraBle","followers_url":"https://api.github.com/users/FraBle/followers","following_url":"https://api.github.com/users/FraBle/following{/other_user}","gists_url":"https://api.github.com/users/FraBle/gists{/gist_id}","starred_url":"https://api.github.com/users/FraBle/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/FraBle/subscriptions","organizations_url":"https://api.github.com/users/FraBle/orgs","repos_url":"https://api.github.com/users/FraBle/repos","events_url":"https://api.github.com/users/FraBle/events{/privacy}","received_events_url":"https://api.github.com/users/FraBle/received_events","type":"User","site_admin":false},"parents":[{"sha":"109eea9a085f5856a20ae5f1714b8c4786c3327b","url":"https://api.github.com/repos/codecov/codecov-api/commits/109eea9a085f5856a20ae5f1714b8c4786c3327b","html_url":"https://github.com/codecov/codecov-api/commit/109eea9a085f5856a20ae5f1714b8c4786c3327b"}]},{"sha":"67a44e176ffd419f066c1cc34cff391e2a1304e2","node_id":"C_kwDOKzQSctoAKDY3YTQ0ZTE3NmZmZDQxOWYwNjZjMWNjMzRjZmYzOTFlMmExMzA0ZTI","commit":{"author":{"name":"Frank
+      Blechschmidt","email":"frank.blechschmidt@lattice.com","date":"2023-12-01T23:21:47Z"},"committer":{"name":"Frank
+      Blechschmidt","email":"frank.blechschmidt@lattice.com","date":"2023-12-01T23:21:47Z"},"message":"Add
+      note to readme","tree":{"sha":"61276344bbf52c071bbc03f105911755cc1a6263","url":"https://api.github.com/repos/codecov/codecov-api/git/trees/61276344bbf52c071bbc03f105911755cc1a6263"},"url":"https://api.github.com/repos/codecov/codecov-api/git/commits/67a44e176ffd419f066c1cc34cff391e2a1304e2","comment_count":0,"verification":{"verified":true,"reason":"valid","signature":"-----BEGIN
+      PGP SIGNATURE-----\n\niHUEABYIAB0WIQSVjuhupFplVZZQvEi9MqB215bO9AUCZWpqiwAKCRC9MqB215bO\n9IgdAP48j41v/TOEBuJ6Q3Jte8qBnNfyfWKpbK7Ah+O6a5JUsAEA07u4N0TdZoOT\nnNcDRYX7+VgV404rmdn4VsSN630d9Ag=\n=dqsE\n-----END
+      PGP SIGNATURE-----","payload":"tree 61276344bbf52c071bbc03f105911755cc1a6263\nparent
+      24732c7c43912738228b2509fe73fa0b94255440\nauthor Frank Blechschmidt <frank.blechschmidt@lattice.com>
+      1701472907 -0800\ncommitter Frank Blechschmidt <frank.blechschmidt@lattice.com>
+      1701472907 -0800\n\nAdd note to readme\n"}},"url":"https://api.github.com/repos/codecov/codecov-api/commits/67a44e176ffd419f066c1cc34cff391e2a1304e2","html_url":"https://github.com/codecov/codecov-api/commit/67a44e176ffd419f066c1cc34cff391e2a1304e2","comments_url":"https://api.github.com/repos/codecov/codecov-api/commits/67a44e176ffd419f066c1cc34cff391e2a1304e2/comments","author":{"login":"FraBle","id":1584268,"node_id":"MDQ6VXNlcjE1ODQyNjg=","avatar_url":"https://avatars.githubusercontent.com/u/1584268?v=4","gravatar_id":"","url":"https://api.github.com/users/FraBle","html_url":"https://github.com/FraBle","followers_url":"https://api.github.com/users/FraBle/followers","following_url":"https://api.github.com/users/FraBle/following{/other_user}","gists_url":"https://api.github.com/users/FraBle/gists{/gist_id}","starred_url":"https://api.github.com/users/FraBle/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/FraBle/subscriptions","organizations_url":"https://api.github.com/users/FraBle/orgs","repos_url":"https://api.github.com/users/FraBle/repos","events_url":"https://api.github.com/users/FraBle/events{/privacy}","received_events_url":"https://api.github.com/users/FraBle/received_events","type":"User","site_admin":false},"committer":{"login":"FraBle","id":1584268,"node_id":"MDQ6VXNlcjE1ODQyNjg=","avatar_url":"https://avatars.githubusercontent.com/u/1584268?v=4","gravatar_id":"","url":"https://api.github.com/users/FraBle","html_url":"https://github.com/FraBle","followers_url":"https://api.github.com/users/FraBle/followers","following_url":"https://api.github.com/users/FraBle/following{/other_user}","gists_url":"https://api.github.com/users/FraBle/gists{/gist_id}","starred_url":"https://api.github.com/users/FraBle/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/FraBle/subscriptions","organizations_url":"https://api.github.com/users/FraBle/orgs","repos_url":"https://api.github.com/users/FraBle/repos","events_url":"https://api.github.com/users/FraBle/events{/privacy}","received_events_url":"https://api.github.com/users/FraBle/received_events","type":"User","site_admin":false},"parents":[{"sha":"24732c7c43912738228b2509fe73fa0b94255440","url":"https://api.github.com/repos/codecov/codecov-api/commits/24732c7c43912738228b2509fe73fa0b94255440","html_url":"https://github.com/codecov/codecov-api/commit/24732c7c43912738228b2509fe73fa0b94255440"}]}]'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 12 Dec 2023 17:17:52 GMT
+      ETag:
+      - W/"0ed03bab2f3600d91a5c852473bf50d36aacef2f38fbf69665673e2859dbef55"
+      Last-Modified:
+      - Fri, 01 Dec 2023 23:21:51 GMT
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Server:
+      - GitHub.com
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Accepted-OAuth-Scopes:
+      - ''
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-GitHub-Media-Type:
+      - github.v3
+      X-GitHub-Request-Id:
+      - CF28:10533:157338:16AD8C:657895C0
+      X-OAuth-Scopes:
+      - repo, user
+      X-RateLimit-Limit:
+      - '5000'
+      X-RateLimit-Remaining:
+      - '4986'
+      X-RateLimit-Reset:
+      - '1702401614'
+      X-RateLimit-Resource:
+      - core
+      X-RateLimit-Used:
+      - '14'
+      X-XSS-Protection:
+      - '0'
+      github-authentication-token-expiration:
+      - 2023-12-19 17:14:49 UTC
+      x-github-api-version-selected:
+      - '2022-11-28'
+    http_version: HTTP/1.1
+    status_code: 200
+version: 1

--- a/tests/integration/test_github.py
+++ b/tests/integration/test_github.py
@@ -260,10 +260,12 @@ class TestGithubTestCase(object):
                 "base": {
                     "branch": "master",
                     "commitid": "68946ef98daec68c7798459150982fc799c87d85",
+                    "slug": "ThiagoCodecov/example-python",
                 },
                 "head": {
                     "branch": "reason/some-testing",
                     "commitid": "119c1907fb266f374b8440bbd70dccbea54daf8f",
+                    "slug": "ThiagoCodecov/example-python",
                 },
                 "number": "1",
                 "id": "1",
@@ -284,10 +286,12 @@ class TestGithubTestCase(object):
             "base": {
                 "branch": "master",
                 "commitid": "335ec9958daf0242bc8945659bb120c05800eacf",
+                "slug": "ThiagoCodecov/example-python",
             },
             "head": {
                 "branch": "thiago/f/big-pt",
                 "commitid": "d55dc4ef748fd11537e50c9abed4ab1864fa1d94",
+                "slug": "ThiagoCodecov/example-python",
             },
             "number": pull_id,
             "id": pull_id,
@@ -1174,10 +1178,12 @@ class TestGithubTestCase(object):
             "base": {
                 "branch": "master",
                 "commitid": "30cc1ed751a59fa9e7ad8e79fff41a6fe11ef5dd",
+                "slug": "ThiagoCodecov/example-python",
             },
             "head": {
                 "branch": "thiago/test-1",
                 "commitid": "2e2600aa09525e2e1e1d98b09de61454d29c94bb",
+                "slug": "ThiagoCodecov/example-python",
             },
             "number": "15",
             "id": "15",
@@ -1187,6 +1193,35 @@ class TestGithubTestCase(object):
             "labels": [],
         }
         res = await valid_handler.get_pull_request(pull_id)
+        assert res == expected_result
+
+    @pytest.mark.asyncio
+    async def test_get_pull_request_from_fork(self, valid_handler, codecov_vcr):
+        handler = Github(
+            repo=dict(name="codecov-api"),
+            owner=dict(username="codecov"),
+            token=valid_handler.token,
+        )
+        pull_id = "285"
+        expected_result = {
+            "base": {
+                "branch": "main",
+                "commitid": "109eea9a085f5856a20ae5f1714b8c4786c3327b",
+                "slug": "codecov/codecov-api",
+            },
+            "head": {
+                "branch": "python-3-12",
+                "commitid": "67a44e176ffd419f066c1cc34cff391e2a1304e2",
+                "slug": "FraBle/codecov-api",
+            },
+            "number": "285",
+            "id": "285",
+            "state": "open",
+            "title": "chore: Switch to Python 3.12",
+            "author": {"id": "1584268", "username": "FraBle"},
+            "labels": [],
+        }
+        res = await handler.get_pull_request(pull_id)
         assert res == expected_result
 
     @pytest.mark.asyncio
@@ -1203,10 +1238,12 @@ class TestGithubTestCase(object):
             "base": {
                 "branch": "master",
                 "commitid": "77141afbd13a1273f87cf02f7f32265ea19a3b77",
+                "slug": "codecov/codecov-api-archive",
             },
             "head": {
                 "branch": "ce-1314/gh-status-handler",
                 "commitid": "a178a13c65f44d5b81c807f3c0fa2cb4922f020f",
+                "slug": "codecov/codecov-api-archive",
             },
             "number": "110",
             "id": "110",


### PR DESCRIPTION
context: codecov/engineering-team#736

To authenticate that a tokenless upload legitimely comes from a fork
we need to check the git provider. We also need the repo where the
PR originated.

These changes also add the "slug" to the PR info, so that we can
check that the HEAD is from the fork and the BASE is the target repo
of the upload.

Notice that currently the CLI only supports tokenless for Github,
so yeah I'm only adding this to github and not other providers, but
we need to add tokenless to the others anyway.

<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.