### PR TITLE
feat: Support multiple bundles per bundle analysis report

### DIFF
--- a/shared/bundle_analysis/__init__.py
+++ b/shared/bundle_analysis/__init__.py
@@ -1,10 +1,17 @@
 from shared.bundle_analysis import models
 from shared.bundle_analysis.comparison import (
+    AssetChange,
     BundleAnalysisComparison,
     BundleChange,
+    BundleComparison,
     MissingBaseReportError,
+    MissingBundleError,
     MissingHeadReportError,
 )
-from shared.bundle_analysis.parser import parse
-from shared.bundle_analysis.report import Bundle, BundleReport
-from shared.bundle_analysis.storage import BundleReportLoader
+from shared.bundle_analysis.parser import Parser
+from shared.bundle_analysis.report import (
+    AssetReport,
+    BundleAnalysisReport,
+    BundleReport,
+)
+from shared.bundle_analysis.storage import BundleAnalysisReportLoader, StoragePaths

--- a/shared/bundle_analysis/comparison.py
+++ b/shared/bundle_analysis/comparison.py
@@ -2,10 +2,14 @@ from collections import defaultdict
 from dataclasses import dataclass
 from enum import Enum
 from functools import cached_property
-from typing import List, MutableSet, Optional, Tuple
+from typing import Iterator, List, MutableSet, Optional, Tuple
 
-from shared.bundle_analysis.report import Bundle, BundleReport
-from shared.bundle_analysis.storage import BundleReportLoader
+from shared.bundle_analysis.report import (
+    AssetReport,
+    BundleAnalysisReport,
+    BundleReport,
+)
+from shared.bundle_analysis.storage import BundleAnalysisReportLoader
 
 
 class MissingBaseReportError(Exception):
@@ -16,10 +20,14 @@ class MissingHeadReportError(Exception):
     pass
 
 
+class MissingBundleError(Exception):
+    pass
+
+
 @dataclass(frozen=True)
 class BundleChange:
     """
-    Info about how a bundle has changed between two different commits.
+    Info about how a bundle has changed between two different reports.
     """
 
     class ChangeType(Enum):
@@ -32,128 +40,207 @@ class BundleChange:
     size_delta: int
 
 
-BundleMatch = Tuple[Optional[Bundle], Optional[Bundle]]
+@dataclass(frozen=True)
+class AssetChange:
+    """
+    Info about how an asset has changed between two different reports.
+    """
+
+    class ChangeType(Enum):
+        ADDED = "added"
+        REMOVED = "removed"
+        CHANGED = "changed"
+
+    asset_name: str
+    change_type: ChangeType
+    size_delta: int
+
+
+AssetMatch = Tuple[Optional[AssetReport], Optional[AssetReport]]
+
+
+class BundleComparison:
+    def __init__(
+        self, base_bundle_report: BundleReport, head_bundle_report: BundleReport
+    ):
+        self.base_bundle_report = base_bundle_report
+        self.head_bundle_report = head_bundle_report
+
+    def total_size_delta(self) -> int:
+        base_size = self.base_bundle_report.total_size()
+        head_size = self.head_bundle_report.total_size()
+        return head_size - base_size
+
+    def asset_changes(self) -> List[AssetChange]:
+        # this groups assets by name
+        # there can be multiple assets with the same name and we
+        # need to try and match them across base and head reports
+        base_asset_reports = defaultdict(set)
+        for asset_report in self.base_bundle_report.asset_reports():
+            base_asset_reports[asset_report.name].add(asset_report)
+        head_asset_reports = defaultdict(set)
+        for asset_report in self.head_bundle_report.asset_reports():
+            head_asset_reports[asset_report.name].add(asset_report)
+
+        # match bundles across base and head
+        # (A, B) means that bundle A transformed to bundle B
+        # (X, None) means that bundle X was deleted
+        # (None, X) means that bundle X was added
+        matches: List[AssetMatch] = []
+        asset_names = []
+        for asset_name, asset_reports in head_asset_reports.items():
+            asset_names.append(asset_name)
+            matches += self._match_assets(base_asset_reports[asset_name], asset_reports)
+        for asset_name, asset_reports in base_asset_reports.items():
+            if asset_name not in asset_names:
+                matches += self._match_assets(asset_reports, [])
+
+        changes = []
+        for (base_asset_report, head_asset_report) in matches:
+            if base_asset_report is None:
+                change = AssetChange(
+                    asset_name=head_asset_report.name,
+                    change_type=AssetChange.ChangeType.ADDED,
+                    size_delta=head_asset_report.size,
+                )
+            elif head_asset_report is None:
+                change = AssetChange(
+                    asset_name=base_asset_report.name,
+                    change_type=AssetChange.ChangeType.REMOVED,
+                    size_delta=-base_asset_report.size,
+                )
+            else:
+                change = AssetChange(
+                    asset_name=head_asset_report.name,
+                    change_type=AssetChange.ChangeType.CHANGED,
+                    size_delta=head_asset_report.size - base_asset_report.size,
+                )
+            changes.append(change)
+
+        return changes
+
+    def _match_assets(
+        self,
+        base_asset_reports: MutableSet[AssetReport],
+        head_asset_reports: MutableSet[AssetReport],
+    ) -> List[AssetMatch]:
+        """
+        The given base assets and head assets all have the same name.
+        This method attempts to pick the most likely matching of assets between
+        base and head (so as to track their changes through time).
+
+        The current approach is fairly naive and just picks the asset with the
+        closest size.  There are probably better ways of doing this that we can
+        improve upon in the future.
+        """
+        n = max([len(base_asset_reports), len(head_asset_reports)])
+        matches: List[AssetMatch] = []
+
+        while len(matches) < n:
+            if len(head_asset_reports) > 0:
+                # we have an unmatched head asset
+                head_asset_report = head_asset_reports.pop()
+
+                if len(base_asset_reports) == 0:
+                    # no more base assets to match against
+                    matches.append((None, head_asset_report))
+                else:
+                    # try and find the most "similar" base asset
+                    size_deltas = {
+                        abs(head_asset_report.size - base_bundle.size): base_bundle
+                        for base_bundle in base_asset_reports
+                    }
+                    min_delta = min(size_deltas.keys())
+                    base_asset_report = size_deltas[min_delta]
+
+                    matches.append((base_asset_report, head_asset_report))
+                    base_asset_reports.remove(base_asset_report)
+            elif len(base_asset_reports) > 0:
+                # we have unmatched base assets and no more head assets
+                base_asset_report = base_asset_reports.pop()
+                matches.append((base_asset_report, None))
+            else:
+                # shouldn't ever get here
+                raise Exception("incorrect asset matching logic")  # pragma: no cover
+
+        return matches
 
 
 class BundleAnalysisComparison:
     """
-    Compares bundle reports on two different commits.
+    Compares two different bundle analysis reports.
     """
 
     def __init__(
-        self, loader: BundleReportLoader, base_report_key: str, head_report_key: str
+        self,
+        loader: BundleAnalysisReportLoader,
+        base_report_key: str,
+        head_report_key: str,
     ):
         self.loader = loader
         self.base_report_key = base_report_key
         self.head_report_key = head_report_key
 
     @cached_property
-    def base_report(self) -> BundleReport:
+    def base_report(self) -> BundleAnalysisReport:
         base_report = self.loader.load(self.base_report_key)
         if base_report is None:
             raise MissingBaseReportError()
         return base_report
 
     @cached_property
-    def head_report(self) -> BundleReport:
+    def head_report(self) -> BundleAnalysisReport:
         head_report = self.loader.load(self.head_report_key)
         if head_report is None:
             raise MissingHeadReportError()
         return head_report
 
-    def total_size_delta(self) -> int:
-        base_size = self.base_report.total_size()
-        head_size = self.head_report.total_size()
-        return head_size - base_size
+    def bundle_changes(self) -> Iterator[BundleChange]:
+        """
+        Returns a list of changes across the bundles in the base and head reports.
+        """
+        base_bundle_reports = {
+            bundle_report.name: bundle_report
+            for bundle_report in self.base_report.bundle_reports()
+        }
+        head_bundle_reports = {
+            bundle_report.name: bundle_report
+            for bundle_report in self.head_report.bundle_reports()
+        }
 
-    def bundle_changes(self) -> List[BundleChange]:
-        # this groups bundles by name
-        # there can be multiple bundles with the same name and we
-        # need to try and match them across base and head reports
-        base_bundles = defaultdict(set)
-        for bundle in self.base_report.bundles():
-            base_bundles[bundle.name].add(bundle)
-        head_bundles = defaultdict(set)
-        for bundle in self.head_report.bundles():
-            head_bundles[bundle.name].add(bundle)
-
-        # match bundles across base and head
-        # (A, B) means that bundle A transformed to bundle B
-        # (X, None) means that bundle X was deleted
-        # (None, X) means that bundle X was added
-        matches: List[BundleMatch] = []
-        bundle_names = []
-        for bundle_name, bundles in head_bundles.items():
-            bundle_names.append(bundle_name)
-            matches += self._match_bundles(base_bundles[bundle_name], bundles)
-        for bundle_name, bundles in base_bundles.items():
-            if bundle_name not in bundle_names:
-                matches += self._match_bundles(bundles, [])
-
-        changes = []
-        for (base_bundle, head_bundle) in matches:
-            if base_bundle is None:
-                change = BundleChange(
-                    bundle_name=head_bundle.name,
+        for bundle_name, head_bundle_report in head_bundle_reports.items():
+            if bundle_name not in base_bundle_reports:
+                yield BundleChange(
+                    bundle_name=bundle_name,
                     change_type=BundleChange.ChangeType.ADDED,
-                    size_delta=head_bundle.size,
-                )
-            elif head_bundle is None:
-                change = BundleChange(
-                    bundle_name=base_bundle.name,
-                    change_type=BundleChange.ChangeType.REMOVED,
-                    size_delta=-base_bundle.size,
+                    size_delta=head_bundle_report.total_size(),
                 )
             else:
-                change = BundleChange(
-                    bundle_name=head_bundle.name,
+                base_bundle_report = base_bundle_reports[bundle_name]
+                del base_bundle_reports[bundle_name]
+                size_delta = (
+                    head_bundle_report.total_size() - base_bundle_report.total_size()
+                )
+                yield BundleChange(
+                    bundle_name=bundle_name,
                     change_type=BundleChange.ChangeType.CHANGED,
-                    size_delta=head_bundle.size - base_bundle.size,
+                    size_delta=size_delta,
                 )
-            changes.append(change)
 
-        return changes
+        for bundle_name, base_bundle_report in base_bundle_reports.items():
+            yield BundleChange(
+                bundle_name=bundle_name,
+                change_type=BundleChange.ChangeType.REMOVED,
+                size_delta=-base_bundle_report.total_size(),
+            )
 
-    def _match_bundles(
-        self, base_bundles: MutableSet[Bundle], head_bundles: MutableSet[Bundle]
-    ) -> List[BundleMatch]:
+    def bundle_comparison(self, bundle_name: str) -> BundleComparison:
         """
-        The given base bundles and head bundles all have the same name.
-        This method attempts to pick the most likely matching of bundles between
-        base and head (so as to track their changes through time).
-
-        The current approach is fairly naive and just picks the bundle with the
-        closest size.  There are probably better ways of doing this that we can
-        improve upon in the future.
+        More detailed comparison (about asset changes) for a particular bundle that
+        exists both in the base and head reports.
         """
-        n = max([len(base_bundles), len(head_bundles)])
-        matches: List[BundleMatch] = []
-
-        while len(matches) < n:
-            if len(head_bundles) > 0:
-                # we have an unmatched head bundle
-                head_bundle = head_bundles.pop()
-
-                if len(base_bundles) == 0:
-                    # no more base bundles to match against
-                    matches.append((None, head_bundle))
-                else:
-                    # try and find the most "similar" base bundle
-                    size_deltas = {
-                        abs(head_bundle.size - base_bundle.size): base_bundle
-                        for base_bundle in base_bundles
-                    }
-                    min_delta = min(size_deltas.keys())
-                    base_bundle = size_deltas[min_delta]
-
-                    matches.append((base_bundle, head_bundle))
-                    base_bundles.remove(base_bundle)
-            elif len(base_bundles) > 0:
-                # we have unmatched base bundles and no more head bundles
-                base_bundle = base_bundles.pop()
-                matches.append((base_bundle, None))
-            else:
-                # shouldn't ever get here
-                raise Exception("incorrect bundle matching logic")  # pragma: no cover
-
-        return matches
+        base_bundle_report = self.base_report.bundle_report(bundle_name)
+        head_bundle_report = self.head_report.bundle_report(bundle_name)
+        if base_bundle_report is None or head_bundle_report is None:
+            raise MissingBundleError()
+        return BundleComparison(base_bundle_report, head_bundle_report)

--- a/tests/samples/sample_bundle_stats.json
+++ b/tests/samples/sample_bundle_stats.json
@@ -7,6 +7,7 @@
   "builtAt": 1701451048604,
   "duration": 331,
   "bundler": { "name": "rollup", "version": "3.29.4" },
+  "bundleName": "sample",
   "assets": [
     {
       "name": "assets/react-35ef61ed.svg",

--- a/tests/samples/sample_bundle_stats_other.json
+++ b/tests/samples/sample_bundle_stats_other.json
@@ -7,6 +7,7 @@
   "builtAt": 1701451048604,
   "duration": 331,
   "bundler": { "name": "rollup", "version": "3.29.4" },
+  "bundleName": "sample",
   "assets": [
     {
       "name": "assets/other-35ef61ed.svg",

--- a/tests/unit/bundle_analysis/test_bundle_analysis.py
+++ b/tests/unit/bundle_analysis/test_bundle_analysis.py
@@ -1,61 +1,72 @@
 from pathlib import Path
 
-from shared.bundle_analysis import BundleReport, BundleReportLoader
+from shared.bundle_analysis import BundleAnalysisReport, BundleAnalysisReportLoader
 from shared.bundle_analysis.models import MetadataKey
 from shared.storage.memory import MemoryStorageService
 
-here = Path(__file__)
 sample_bundle_stats_path = (
-    here.parent.parent.parent / "samples" / "sample_bundle_stats.json"
+    Path(__file__).parent.parent.parent / "samples" / "sample_bundle_stats.json"
 )
 
 
 def test_create_bundle_report():
-    bundle_report = BundleReport()
-    session_id = bundle_report.ingest(sample_bundle_stats_path)
-    assert session_id == 1
+    try:
+        report = BundleAnalysisReport()
+        session_id = report.ingest(sample_bundle_stats_path)
+        assert session_id == 1
 
-    assert bundle_report.metadata() == {
-        MetadataKey.SCHEMA_VERSION: 1,
-    }
+        assert report.metadata() == {
+            MetadataKey.SCHEMA_VERSION: 1,
+        }
 
-    bundles = list(bundle_report.bundles())
-    assert len(bundles) == 5
+        bundle_reports = list(report.bundle_reports())
+        assert len(bundle_reports) == 1
 
-    assert [(b.name, b.hashed_name, b.size, len(b.modules())) for b in bundles] == [
-        ("assets/react-*.svg", "assets/react-35ef61ed.svg", 4126, 0),
-        ("assets/index-*.css", "assets/index-d526a0c5.css", 1421, 0),
-        ("assets/LazyComponent-*.js", "assets/LazyComponent-fcbb0922.js", 294, 1),
-        ("assets/index-*.js", "assets/index-c8676264.js", 154, 2),
-        # FIXME: this is wrong since it's capturing the SVG and CSS modules as well.
-        # Made a similar note in the parser code where the associations are made
-        ("assets/index-*.js", "assets/index-666d2e09.js", 144577, 28),
-    ]
+        bundle_report = report.bundle_report("invalid")
+        assert bundle_report is None
+        bundle_report = report.bundle_report("sample")
 
-    assert bundle_report.total_size() == 150572
-    assert bundle_report.session_count() == 1
-    bundle_report.cleanup()
+        asset_reports = list(bundle_report.asset_reports())
+
+        assert [
+            (ar.name, ar.hashed_name, ar.size, len(ar.modules()))
+            for ar in asset_reports
+        ] == [
+            ("assets/react-*.svg", "assets/react-35ef61ed.svg", 4126, 0),
+            ("assets/index-*.css", "assets/index-d526a0c5.css", 1421, 0),
+            ("assets/LazyComponent-*.js", "assets/LazyComponent-fcbb0922.js", 294, 1),
+            ("assets/index-*.js", "assets/index-c8676264.js", 154, 2),
+            # FIXME: this is wrong since it's capturing the SVG and CSS modules as well.
+            # Made a similar note in the parser code where the associations are made
+            ("assets/index-*.js", "assets/index-666d2e09.js", 144577, 28),
+        ]
+
+        assert bundle_report.total_size() == 150572
+        assert report.session_count() == 1
+    finally:
+        report.cleanup()
 
 
 def test_save_load_bundle_report():
-    bundle_report = BundleReport()
-    bundle_report.ingest(sample_bundle_stats_path)
+    try:
+        report = BundleAnalysisReport()
+        report.ingest(sample_bundle_stats_path)
 
-    loader = BundleReportLoader(
-        storage_service=MemoryStorageService({}),
-        repo_key="testing",
-    )
-    test_key = "eeaedb769885e9547f517fa2c2eea41849663454"
-    loader.save(bundle_report, test_key)
+        loader = BundleAnalysisReportLoader(
+            storage_service=MemoryStorageService({}),
+            repo_key="testing",
+        )
+        test_key = "8d1099f1-ba73-472f-957f-6908eced3f42"
+        loader.save(report, test_key)
 
-    db_path = bundle_report.db_path
-    bundle_report = loader.load(test_key)
+        db_path = report.db_path
+        report = loader.load(test_key)
 
-    initial_data = open(db_path, "rb").read()
-    loaded_data = open(bundle_report.db_path, "rb").read()
+        initial_data = open(db_path, "rb").read()
+        loaded_data = open(report.db_path, "rb").read()
 
-    assert db_path != bundle_report.db_path
-    assert len(initial_data) > 0
-    assert initial_data == loaded_data
-
-    bundle_report.cleanup()
+        assert db_path != report.db_path
+        assert len(initial_data) > 0
+        assert initial_data == loaded_data
+    finally:
+        report.cleanup()


### PR DESCRIPTION
Support multiple bundles per bundle analysis report.  A bundle is a high level thing that might exist in a monorepo (i.e. something like "dashboard" or "admin" etc.).  A single session/upload contains information pertaining to a single bundle.  See the schema changes in `models.py` for a more detailed understanding of the relationships.