### PR TITLE
fix: handle if head->repo is None

### DIFF
--- a/shared/torngit/github.py
+++ b/shared/torngit/github.py
@@ -1143,7 +1143,11 @@ class Github(TorngitBaseAdapter):
             head=dict(
                 branch=pull["head"]["ref"],
                 commitid=pull["head"]["sha"],
-                slug=pull["head"]["repo"]["full_name"],
+                # Through empiric test data it seems that the "repo" key in "head" is set to None
+                # If the PR is from the same repo (e.g. not from a fork)
+                slug=pull["head"]["repo"]["full_name"]
+                if pull["head"]["repo"]
+                else pull["base"]["repo"]["full_name"],
             ),
             state="merged" if pull["merged"] else pull["state"],
             title=pull["title"],


### PR DESCRIPTION
I learned from https://github.com/codecov/codecov-cli/pull/342/commits/f4b31f18ed231b37a74e9bec71d710bc412a5492 that the head->repo value might be null.

Indeed in [the docs](https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#get-a-pull-request), the schema (terribly hard to look in that little window) does state that it can be null.

```
"head": {
  "type": "object",
  "properties": {
 [...]
  "repo": {
    "type": [
      "object",
      "null"
    ],
```

These changes mimic the ones in the linked commit, making it so that
we don't raise an exception if the repo info is null.

<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.