### PR TITLE
fix: bundle total size not calculated correctly (#1021)

### DIFF
--- a/shared/bundle_analysis/report.py
+++ b/shared/bundle_analysis/report.py
@@ -68,6 +68,7 @@ class BundleReport:
     def total_size(self) -> int:
         return (
             self.db_session.query(func.sum(models.Asset.size).label("asset_size"))
+            .join(models.Asset.session)
             .join(models.Session.bundle)
             .filter(models.Session.bundle_id == self.bundle.id)
             .scalar()


### PR DESCRIPTION
Fix bundle total_size function, in the query forgot a join with Asset and Session models, so it was retrieving all Assets in the DB

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.