### PR TITLE
feat: handle bundle reports with empty assets/chunks/modules

### DIFF
--- a/shared/bundle_analysis/parser.py
+++ b/shared/bundle_analysis/parser.py
@@ -199,7 +199,8 @@ class Parser:
             inserts.extend(
                 [dict(asset_id=asset.id, chunk_id=chunk_id) for asset in assets]
             )
-        self.db_session.execute(assets_chunks.insert(), inserts)
+        if inserts:
+            self.db_session.execute(assets_chunks.insert(), inserts)
 
         # associate modules to chunks
         # FIXME: this isn't quite right - need to sort out how non-JS assets reference chunks
@@ -215,4 +216,5 @@ class Parser:
             inserts.extend(
                 [dict(chunk_id=chunk.id, module_id=module_id) for chunk in chunks]
             )
-        self.db_session.execute(chunks_modules.insert(), inserts)
+        if inserts:
+            self.db_session.execute(chunks_modules.insert(), inserts)

--- a/shared/bundle_analysis/parser.py
+++ b/shared/bundle_analysis/parser.py
@@ -1,3 +1,4 @@
+import json
 from typing import Optional, Tuple
 
 import ijson
@@ -80,6 +81,9 @@ class Parser:
                 self.db_session.delete(old_session)
                 self.db_session.flush()
 
+            # save top level bundle stats info
+            self.session.info = json.dumps(self.info)
+
             # this happens last so that we could potentially handle any ordering
             # of top-level keys inside the JSON (i.e. we couldn't associate a chunk
             # to an asset above if we parse the chunk before the asset)
@@ -121,6 +125,8 @@ class Parser:
             self.info["plugin_name"] = value
         elif prefix == "plugin.version":
             self.info["plugin_version"] = value
+        elif prefix == "duration":
+            self.info["duration"] = value
 
     def _parse_assets_event(self, prefix: str, event: str, value: str):
         if (prefix, event) == ("assets.item", "start_map"):

--- a/shared/bundle_analysis/report.py
+++ b/shared/bundle_analysis/report.py
@@ -1,3 +1,4 @@
+import json
 import os
 import sqlite3
 import tempfile
@@ -73,6 +74,9 @@ class BundleReport:
             .filter(models.Session.bundle_id == self.bundle.id)
             .scalar()
         ) or 0
+
+    def info(self) -> dict:
+        return json.loads(self.bundle.info)
 
 
 class BundleAnalysisReport:

--- a/shared/bundle_analysis/report.py
+++ b/shared/bundle_analysis/report.py
@@ -76,7 +76,12 @@ class BundleReport:
         ) or 0
 
     def info(self) -> dict:
-        return json.loads(self.bundle.info)
+        session = (
+            self.db_session.query(models.Session)
+            .filter(models.Session.bundle_id == self.bundle.id)
+            .first()
+        )
+        return json.loads(session.info)
 
 
 class BundleAnalysisReport:

--- a/tests/samples/sample_bundle_stats_no_assets.json
+++ b/tests/samples/sample_bundle_stats_no_assets.json
@@ -1,0 +1,44 @@
+{
+    "version": "1",
+    "plugin": {
+      "name": "codecov-vite-bundle-analysis-plugin",
+      "version": "1.0.0"
+    },
+    "builtAt": 1701451048604,
+    "duration": 331,
+    "bundler": { "name": "rollup", "version": "3.29.4" },
+    "bundleName": "b5",
+    "assets": [
+
+    ],
+    "chunks": [
+      {
+        "id": "index",
+        "uniqueId": "b5-1-index",
+        "entry": false,
+        "initial": true,
+        "files": [],
+        "names": ["index"]
+      },
+      {
+        "id": "index",
+        "uniqueId": "b5-2-index",
+        "entry": true,
+        "initial": false,
+        "files": [],
+        "names": ["index"]
+      }
+    ],
+    "modules": [
+      {
+        "name": "./src/IndexedLazyComponent/IndexedLazyComponent.tsx",
+        "size": 1890,
+        "chunkUniqueIds": ["b5-1-index", "b5-2-index"]
+      },
+      {
+        "name": "./src/IndexedLazyComponent/index.ts",
+        "size": 0,
+        "chunkUniqueIds": ["b5-1-index", "b5-2-index"]
+      }
+    ]
+  }

--- a/tests/samples/sample_bundle_stats_no_chunks.json
+++ b/tests/samples/sample_bundle_stats_no_chunks.json
@@ -1,0 +1,38 @@
+{
+    "version": "1",
+    "plugin": {
+      "name": "codecov-vite-bundle-analysis-plugin",
+      "version": "1.0.0"
+    },
+    "builtAt": 1701451048604,
+    "duration": 331,
+    "bundler": { "name": "rollup", "version": "3.29.4" },
+    "bundleName": "sample",
+    "assets": [
+      {
+        "name": "assets/index-c8676264.js",
+        "size": 154,
+        "normalized": "assets/index-*.js"
+      },
+      {
+        "name": "assets/index-666d2e09.js",
+        "size": 144577,
+        "normalized": "assets/index-*.js"
+      }
+    ],
+    "chunks": [
+
+    ],
+    "modules": [
+      {
+        "name": "./src/LazyComponent/LazyComponent.tsx",
+        "size": 497,
+        "chunkUniqueIds": []
+      },
+      {
+        "name": "./src/IndexedLazyComponent/IndexedLazyComponent.tsx",
+        "size": 189,
+        "chunkUniqueIds": []
+      }
+    ]
+  }

--- a/tests/samples/sample_bundle_stats_no_modules.json
+++ b/tests/samples/sample_bundle_stats_no_modules.json
@@ -1,0 +1,44 @@
+{
+    "version": "1",
+    "plugin": {
+      "name": "codecov-vite-bundle-analysis-plugin",
+      "version": "1.0.0"
+    },
+    "builtAt": 1701451048604,
+    "duration": 331,
+    "bundler": { "name": "rollup", "version": "3.29.4" },
+    "bundleName": "sample",
+    "assets": [
+      {
+        "name": "assets/index-c8676264.js",
+        "size": 154,
+        "normalized": "assets/index-*.js"
+      },
+      {
+        "name": "assets/index-666d2e09.js",
+        "size": 144577,
+        "normalized": "assets/index-*.js"
+      }
+    ],
+    "chunks": [
+      {
+        "id": "index",
+        "uniqueId": "1-index",
+        "entry": false,
+        "initial": true,
+        "files": ["assets/index-c8676264.js"],
+        "names": ["index"]
+      },
+      {
+        "id": "index",
+        "uniqueId": "2-index",
+        "entry": true,
+        "initial": false,
+        "files": ["assets/index-666d2e09.js"],
+        "names": ["index"]
+      }
+    ],
+    "modules": [
+
+    ]
+  }

--- a/tests/unit/bundle_analysis/test_bundle_analysis.py
+++ b/tests/unit/bundle_analysis/test_bundle_analysis.py
@@ -140,7 +140,7 @@ def test_bundle_report_no_chunks():
     asset_reports = list(bundle_report.asset_reports())
 
     assert len(asset_reports) == 2
-    assert bundle_report.total_size() == 686
+    assert bundle_report.total_size() == 144731
 
 
 def test_bundle_report_no_modules():
@@ -155,4 +155,4 @@ def test_bundle_report_no_modules():
     asset_reports = list(bundle_report.asset_reports())
 
     assert len(asset_reports) == 2
-    assert bundle_report.total_size() == 686
+    assert bundle_report.total_size() == 144731

--- a/tests/unit/bundle_analysis/test_bundle_analysis.py
+++ b/tests/unit/bundle_analysis/test_bundle_analysis.py
@@ -124,7 +124,7 @@ def test_bundle_report_no_assets():
     bundle_report = report.bundle_report("b5")
     asset_reports = list(bundle_report.asset_reports())
 
-    assert asset_reports is None
+    assert asset_reports == []
     assert bundle_report.total_size == 0
 
 
@@ -136,7 +136,7 @@ def test_bundle_report_no_chunks():
     )
     report = BundleAnalysisReport()
     report.ingest(report_path)
-    bundle_report = report.bundle_report("b5")
+    bundle_report = report.bundle_report("sample")
     asset_reports = list(bundle_report.asset_reports())
 
     assert len(asset_reports) == 2
@@ -151,7 +151,7 @@ def test_bundle_report_no_modules():
     )
     report = BundleAnalysisReport()
     report.ingest(report_path)
-    bundle_report = report.bundle_report("b5")
+    bundle_report = report.bundle_report("sample")
     asset_reports = list(bundle_report.asset_reports())
 
     assert len(asset_reports) == 2

--- a/tests/unit/bundle_analysis/test_bundle_analysis.py
+++ b/tests/unit/bundle_analysis/test_bundle_analysis.py
@@ -124,7 +124,7 @@ def test_bundle_report_no_assets():
     bundle_report = report.bundle_report("b5")
     asset_reports = list(bundle_report.asset_reports())
 
-    assert len(asset_reports) == 0
+    assert asset_reports is None
     assert bundle_report.total_size == 0
 
 

--- a/tests/unit/bundle_analysis/test_bundle_analysis.py
+++ b/tests/unit/bundle_analysis/test_bundle_analysis.py
@@ -111,3 +111,48 @@ def test_reupload_bundle_report():
         assert report.session_count() == 1
     finally:
         report.cleanup()
+
+
+def test_bundle_report_no_assets():
+    report_path = (
+        Path(__file__).parent.parent.parent
+        / "samples"
+        / "sample_bundle_stats_no_assets.json"
+    )
+    report = BundleAnalysisReport()
+    report.ingest(report_path)
+    bundle_report = report.bundle_report("b5")
+    asset_reports = list(bundle_report.asset_reports())
+
+    assert len(asset_reports) == 0
+    assert bundle_report.total_size == 0
+
+
+def test_bundle_report_no_chunks():
+    report_path = (
+        Path(__file__).parent.parent.parent
+        / "samples"
+        / "sample_bundle_stats_no_chunks.json"
+    )
+    report = BundleAnalysisReport()
+    report.ingest(report_path)
+    bundle_report = report.bundle_report("b5")
+    asset_reports = list(bundle_report.asset_reports())
+
+    assert len(asset_reports) == 2
+    assert bundle_report.total_size == 686
+
+
+def test_bundle_report_no_modules():
+    report_path = (
+        Path(__file__).parent.parent.parent
+        / "samples"
+        / "sample_bundle_stats_no_modules.json"
+    )
+    report = BundleAnalysisReport()
+    report.ingest(report_path)
+    bundle_report = report.bundle_report("b5")
+    asset_reports = list(bundle_report.asset_reports())
+
+    assert len(asset_reports) == 2
+    assert bundle_report.total_size == 686

--- a/tests/unit/bundle_analysis/test_bundle_analysis.py
+++ b/tests/unit/bundle_analysis/test_bundle_analysis.py
@@ -125,7 +125,7 @@ def test_bundle_report_no_assets():
     asset_reports = list(bundle_report.asset_reports())
 
     assert asset_reports == []
-    assert bundle_report.total_size == 0
+    assert bundle_report.total_size() == 0
 
 
 def test_bundle_report_no_chunks():
@@ -140,7 +140,7 @@ def test_bundle_report_no_chunks():
     asset_reports = list(bundle_report.asset_reports())
 
     assert len(asset_reports) == 2
-    assert bundle_report.total_size == 686
+    assert bundle_report.total_size() == 686
 
 
 def test_bundle_report_no_modules():
@@ -155,4 +155,4 @@ def test_bundle_report_no_modules():
     asset_reports = list(bundle_report.asset_reports())
 
     assert len(asset_reports) == 2
-    assert bundle_report.total_size == 686
+    assert bundle_report.total_size() == 686

--- a/tests/unit/bundle_analysis/test_bundle_analysis.py
+++ b/tests/unit/bundle_analysis/test_bundle_analysis.py
@@ -156,3 +156,18 @@ def test_bundle_report_no_modules():
 
     assert len(asset_reports) == 2
     assert bundle_report.total_size() == 144731
+
+
+def test_bundle_report_info():
+    report = BundleAnalysisReport()
+    report.ingest(sample_bundle_stats_path)
+    bundle_report = report.bundle_report("sample")
+    bundle_report_info = bundle_report.info()
+
+    assert bundle_report_info["version"] == "1"
+    assert bundle_report_info["bundler_name"] == "rollup"
+    assert bundle_report_info["bundler_version"] == "3.29.4"
+    assert bundle_report_info["built_at"] == 1701451048604
+    assert bundle_report_info["plugin_name"] == "codecov-vite-bundle-analysis-plugin"
+    assert bundle_report_info["plugin_version"] == "1.0.0"
+    assert bundle_report_info["duration"] == 331


### PR DESCRIPTION
When assets is empty -> no asset reports and 0 total size for the bundle
When chunks is empty -> no associations with assets nor modules
When modules is empty -> no associations with chunks

Also saves bundle stats file info into the report.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.