### PR TITLE
feat: add task name to save commit measurements

### DIFF
--- a/shared/celery_config.py
+++ b/shared/celery_config.py
@@ -14,6 +14,9 @@ sync_repos_task_name = f"app.tasks.{TaskConfigGroup.sync_repos.value}.SyncRepos"
 sync_repo_languages_task_name = (
     f"app.tasks.{TaskConfigGroup.sync_repo_languages.value}.SyncLanguages"
 )
+save_commit_measurements_task_name = (
+    f"app.tasks.{TaskConfigGroup.save_commit_measurements.value}.SaveCommitMeasurements"
+)
 delete_owner_task_name = f"app.tasks.{TaskConfigGroup.delete_owner.value}.DeleteOwner"
 notify_task_name = f"app.tasks.{TaskConfigGroup.notify.value}.Notify"
 pulls_task_name = f"app.tasks.{TaskConfigGroup.pulls.value}.Sync"
@@ -236,6 +239,15 @@ class BaseCeleryConfig(object):
                 "setup",
                 "tasks",
                 TaskConfigGroup.sync_repo_languages.value,
+                "queue",
+                default=task_default_queue,
+            )
+        },
+        save_commit_measurements_task_name: {
+            "queue": get_config(
+                "setup",
+                "tasks",
+                TaskConfigGroup.save_commit_measurements.value,
                 "queue",
                 default=task_default_queue,
             )

--- a/shared/utils/enums.py
+++ b/shared/utils/enums.py
@@ -34,6 +34,7 @@ class TaskConfigGroup(Enum):
     profiling = "profiling"
     pulls = "pulls"
     remove_webhook = "remove_webhook"
+    save_commit_measurements = "save_commit_measurements"
     send_email = "send_email"
     static_analysis = "static_analysis"
     status = "status"

--- a/tests/unit/test_celery_config.py
+++ b/tests/unit/test_celery_config.py
@@ -39,6 +39,7 @@ def test_celery_config():
         "app.tasks.profiling.*",
         "app.tasks.pulls.Sync",
         "app.tasks.remove_webhook.RemoveOldHook",
+        "app.tasks.save_commit_measurements.SaveCommitMeasurements",
         "app.tasks.static_analysis.*",
         "app.tasks.status.*",
         "app.tasks.sync_plans.SyncPlans",
@@ -97,6 +98,10 @@ def test_celery_config():
         (
             "app.tasks.sync_repo_languages.SyncLanguages",
             TaskConfigGroup.sync_repo_languages.value,
+        ),
+        (
+            "app.tasks.save_commit_measurements.SaveCommitMeasurements",
+            TaskConfigGroup.save_commit_measurements.value,
         ),
         ("app.tasks.sync_teams.SyncTeams", TaskConfigGroup.sync_teams.value),
         ("app.tasks.synchronize.Synchronize", TaskConfigGroup.synchronize.value),


### PR DESCRIPTION
We're adding a task to save_commit_measurements as right now is embedded to the upload_finisher task and we want it to work in isolation. 

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.