### PR TITLE
chore: update llvm to llvm16 in rust tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ test_env.rust_tests:
 	sudo apt-get install gcc lsb-release wget software-properties-common
 	wget https://apt.llvm.org/llvm.sh
 	chmod +x llvm.sh
-	sudo ./llvm.sh 15
+	sudo ./llvm.sh 16
 	RUSTFLAGS="-C instrument-coverage" LLVM_PROFILE_FILE="ribs-%m.profraw" cargo +nightly test --no-default-features
-	llvm-profdata-15 merge -sparse ribs-*.profraw -o ribs.profdata
-	llvm-cov-15 show --ignore-filename-regex='/.cargo/registry' --instr-profile=ribs.profdata --object `ls target/debug/deps/ribs-* | grep -v "\.d" | grep -v "\.o"` > app.coverage.txt
+	llvm-profdata-16 merge -sparse ribs-*.profraw -o ribs.profdata
+	llvm-cov-16 show --ignore-filename-regex='/.cargo/registry' --instr-profile=ribs.profdata --object `ls target/debug/deps/ribs-* | grep -v "\.d" | grep -v "\.o"` > app.coverage.txt


### PR DESCRIPTION
see if this fixes CI failures like https://github.com/codecov/shared/actions/runs/7907945558/job/21632771580

i am redoing how we do rust code coverage as part of moving rust code out of `shared`, but that work stalled out. i'll jump back to it if this doesn't work, else i'll finish it when it comes into play for my rust coverage work

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.