### PR TITLE
Bundle analysis: auto open and close DB session

### DIFF
--- a/shared/bundle_analysis/report.py
+++ b/shared/bundle_analysis/report.py
@@ -5,8 +5,6 @@ import tempfile
 from typing import Any, Dict, Iterator, Optional
 
 from sqlalchemy.exc import OperationalError
-from sqlalchemy.orm import Session as SQLAlchemySession
-from sqlalchemy.orm import sessionmaker
 from sqlalchemy.sql import func
 
 from shared.bundle_analysis import models

--- a/shared/bundle_analysis/report.py
+++ b/shared/bundle_analysis/report.py
@@ -95,7 +95,7 @@ class BundleAnalysisReport:
     def __init__(self, db_path: Optional[str] = None):
         self.db_path = db_path
         if self.db_path is None:
-            _, self.db_path = tempfile.mkstemp()
+            _, self.db_path = tempfile.mkstemp(prefix="bundle_analysis_")
         self.db_session = models.get_db_session(self.db_path)
         self._setup()
 

--- a/shared/bundle_analysis/storage.py
+++ b/shared/bundle_analysis/storage.py
@@ -40,7 +40,7 @@ class BundleAnalysisReportLoader:
         path = StoragePaths.bundle_report.path(
             repo_key=self.repo_key, report_key=report_key
         )
-        _, db_path = tempfile.mkstemp()
+        _, db_path = tempfile.mkstemp(prefix="bundle_analysis_")
 
         with open(db_path, "w+b") as f:
             try:


### PR DESCRIPTION
Add a context manager for opening and closing DB sessions around queries in `AssetReport` and `BundleReport`. This way when the session in `BundleAnalysisReport` is closed, it won't make its children reports' session closed. This is needed in API when `BundleAnalysisReport` is resolved and cleaned up (ie DB session closed), but subsequent resolves to `AssetReport` and `BundleReport` will fail due to the shared DB session. This makes sure each `*Report` can manage its own DB session.


### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.