### PR TITLE
perf: don't fetch from db in constructor

### DIFF
--- a/shared/rollouts/__init__.py
+++ b/shared/rollouts/__init__.py
@@ -93,9 +93,7 @@ class Feature:
             args["salt"] = salt
 
         # so it is hashable
-        args = tuple(sorted(args.items()))
-
-        self._fetch_and_set_from_db(args)
+        self.args = tuple(sorted(args.items()))
 
     def check_value(self, identifier, default=False):
         """
@@ -104,7 +102,12 @@ class Feature:
         feature variants via Django Admin.
         """
         # Will only run and refresh values from the database every ~5 minutes due to TTL cache
-        self._fetch_and_set_from_db()
+        self._fetch_and_set_from_db(self.args)
+
+        if (
+            self.args
+        ):  # to create a default when `check_value()` is run for the first time
+            self.args = None
 
         return self._check_value(identifier, default)
 

--- a/tests/unit/test_rollouts.py
+++ b/tests/unit/test_rollouts.py
@@ -24,9 +24,12 @@ class TestFeature(TestCase):
             "complex",
             0.5,
         )
+
         # # To make the math simpler, let's pretend our hash function can only
         # # return 200 different values.
         with patch.object(Feature, "HASHSPACE", 200):
+
+            complex_feature.check_value("garbage")  # to force fetch values from db
 
             # Because the top-level feature proportion is 0.5, we are only using the
             # first 50% of our 200 hash values as our test population: [0..100]


### PR DESCRIPTION
<!-- Describe your PR here. -->

Don't let `Feature` make requests to database unless `check_value()` is called. This will help our tests in worker because they don't have access to django db unless we explicitly give it.

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.