### PR TITLE
feat: add 'guest_access' option to install config

### DIFF
--- a/shared/validation/install.py
+++ b/shared/validation/install.py
@@ -242,6 +242,7 @@ config_schema = {
                 "type": "list",
                 "schema": {"type": "string"},
             },
+            "guest_access": {"type": "boolean"},
         },
     },
     "services": {

--- a/tests/unit/validation/test_install_validation.py
+++ b/tests/unit/validation/test_install_validation.py
@@ -27,7 +27,7 @@ def test_validate_install_configuration_invalid(mocker):
 
 def test_validate_install_configuration_with_user_yaml(mocker):
     user_input = {
-        "setup": {"codecov_url": "http://codecov.company.com"},
+        "setup": {"codecov_url": "http://codecov.company.com", "guest_access": False},
         "site": {
             "coverage": {
                 "status": {
@@ -51,7 +51,7 @@ def test_validate_install_configuration_with_user_yaml(mocker):
     }
     mock_warning = mocker.patch.object(install_log, "warning")
     assert validate_install_configuration(user_input) == {
-        "setup": {"codecov_url": "http://codecov.company.com"},
+        "setup": {"codecov_url": "http://codecov.company.com", "guest_access": False},
         "site": {
             "coverage": {
                 "status": {


### PR DESCRIPTION
context: codecov/engineering-team#1243

Adds a `guest_access` bool config option for the install yaml.
Apparently this is a documented legacy setting that we want to bring back.

<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.