### PR TITLE
Handle 429 status code in torngit as Rate limit error

### DIFF
--- a/shared/torngit/github.py
+++ b/shared/torngit/github.py
@@ -326,10 +326,9 @@ class Github(TorngitBaseAdapter):
                 elif res.status_code >= 500:
                     metrics.incr(f"{METRICS_PREFIX}.api.5xx")
                     raise TorngitServer5xxCodeError("Github is having 5xx issues")
-                elif (
-                    res.status_code == 403
-                    and int(res.headers.get("X-RateLimit-Remaining", -1)) == 0
-                ):
+                elif (res.status_code == 403 or res.status_code == 429) and int(
+                    res.headers.get("X-RateLimit-Remaining", -1)
+                ) == 0:
                     message = f"Github API rate limit error: {res.reason_phrase}"
                     metrics.incr(f"{METRICS_PREFIX}.api.ratelimiterror")
                     raise TorngitRateLimitError(
@@ -338,9 +337,8 @@ class Github(TorngitBaseAdapter):
                         reset=res.headers.get("X-RateLimit-Reset"),
                     )
                 elif (
-                    res.status_code == 403
-                    and res.headers.get("Retry-After") is not None
-                ):
+                    res.status_code == 403 or res.status_code == 429
+                ) and res.headers.get("Retry-After") is not None:
                     # https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#secondary-rate-limits
                     message = f"Github API rate limit error: secondary rate limit"
                     retry_after = int(res.headers.get("Retry-After"))

--- a/tests/unit/torngit/test_github.py
+++ b/tests/unit/torngit/test_github.py
@@ -114,7 +114,7 @@ class TestUnitGithub(object):
             with pytest.raises(TorngitRateLimitError) as excinfo:
                 async with handler.get_client() as client:
                     res = await handler.api(client, "get", "/endpoint")
-            assert excinfo.value.code == status_code
+            assert excinfo.value.code == 403
             assert excinfo.value.message == "Github API rate limit error: Forbidden"
             assert excinfo.value.reset == "1350085394"
 
@@ -135,7 +135,7 @@ class TestUnitGithub(object):
             with pytest.raises(TorngitClientError) as excinfo:
                 async with handler.get_client() as client:
                     res = await handler.api(client, "get", "/endpoint")
-            assert excinfo.value.code == status_code
+            assert excinfo.value.code == 403
 
     @pytest.mark.asyncio
     async def test_api_client_error_server_error(self, valid_handler, mocker):

--- a/tests/unit/torngit/test_github.py
+++ b/tests/unit/torngit/test_github.py
@@ -93,9 +93,13 @@ class TestUnitGithub(object):
             await valid_handler.api(client, method, url)
         assert mock_refresh.call_count == 1
 
-    @pytest.mark.parametrize("status_code", [403, 429])
+    @pytest.mark.parametrize(
+        "status_code, error_message", [(403, "Forbidden"), (429, "Too Many Requests")]
+    )
     @pytest.mark.asyncio
-    async def test_api_client_error_ratelimit_reached_429(self, status_code):
+    async def test_api_client_error_ratelimit_reached_429(
+        self, status_code, error_message
+    ):
         with respx.mock:
             my_route = respx.get("https://api.github.com/endpoint").mock(
                 return_value=httpx.Response(
@@ -115,7 +119,9 @@ class TestUnitGithub(object):
                 async with handler.get_client() as client:
                     res = await handler.api(client, "get", "/endpoint")
             assert excinfo.value.code == 403
-            assert excinfo.value.message == "Github API rate limit error: Forbidden"
+            assert (
+                excinfo.value.message == f"Github API rate limit error: {error_message}"
+            )
             assert excinfo.value.reset == "1350085394"
 
     @pytest.mark.parametrize("status_code", [403, 429])
@@ -124,7 +130,11 @@ class TestUnitGithub(object):
         with respx.mock:
             my_route = respx.get("https://api.github.com/endpoint").mock(
                 return_value=httpx.Response(
-                    status_code=status_code, headers={"X-RateLimit-Reset": "1350085394"}
+                    status_code=status_code,
+                    headers={
+                        "X-RateLimit-Remaining": "0",
+                        "X-RateLimit-Reset": "1350085394",
+                    },
                 )
             )
             handler = Github(


### PR DESCRIPTION
Github will possibly return a 429 status code if the rate limit is reached per:
https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28#exceeding-the-rate-limit