### PR TITLE
add django executor for async issues

### DIFF
--- a/shared/django_apps/executor.py
+++ b/shared/django_apps/executor.py
@@ -6,15 +6,12 @@ _executor = None
 def get_executor():
     global _executor
     if _executor == None:
-        print("mattmatt initializing threadpool executor")
         _executor = ThreadPoolExecutor(max_workers=1)
-    print("mattmatt returning executor")
     return _executor
 
 
 def run_in_executor(fn):
     def wrapper(*args, **kwargs):
-        print("mattmatt calling wrapper")
         return get_executor().submit(fn, *args, **kwargs).result()
 
     return wrapper

--- a/shared/django_apps/executor.py
+++ b/shared/django_apps/executor.py
@@ -1,0 +1,20 @@
+from concurrent.futures import ThreadPoolExecutor
+
+_executor = None
+
+
+def get_executor():
+    global _executor
+    if _executor == None:
+        print("mattmatt initializing threadpool executor")
+        _executor = ThreadPoolExecutor(max_workers=1)
+    print("mattmatt returning executor")
+    return _executor
+
+
+def run_in_executor(fn):
+    def wrapper(*args, **kwargs):
+        print("mattmatt calling wrapper")
+        return get_executor().submit(fn, *args, **kwargs).result()
+
+    return wrapper

--- a/tests/unit/django_apps/test_executor.py
+++ b/tests/unit/django_apps/test_executor.py
@@ -1,0 +1,27 @@
+from unittest.mock import Mock, call
+
+import shared.django_apps.executor
+from shared.django_apps.executor import get_executor, run_in_executor
+
+
+def test_get_executor():
+    shared.django_apps.executor._executor = None
+    new_executor = get_executor()
+    assert new_executor != None
+    assert new_executor == shared.django_apps.executor._executor
+
+
+def test_run_in_executor(mocker):
+    mock_executor = Mock()
+    mocker.patch("shared.django_apps.executor.get_executor", return_value=mock_executor)
+
+    def original_foo(arg1, arg2):
+        return arg1 + arg2
+
+    foo = run_in_executor(original_foo)
+
+    foo("hello", "world")
+
+    assert mock_executor.submit.call_args_list == [
+        call(original_foo, "hello", "world"),
+    ]


### PR DESCRIPTION
if you use the django ORM from an asyncio event loop (meaning, anywhere inside a task, since they're all called via `run_async()`) it'll yell at you and say you're only allowed to use it from a sync context

the recommended solution is to use `sync_to_async()` to wrap django usages, but that requires that the calling context be an async function already. for a lot of our code, the top-level task is async but everything else is sync. so taking this approach requires spreading the async "contagion" everywhere which is super painful

an alternative solution is to run django ORM operations on a single thread outside of an async context. this PR adds a decorator which can do that

i am not sure if this is a good direction in the end or if we want to take the async contagion direction. but this should at least let us use the django ORM without needing to commit to the async contagion for now.

NOTE: worker turns autocommit off for django, and each thread has a separate connection which builds its own transaction. so there are a couple things we should run through this decorator:
- [`log_simple_metric()` in `helpers/telemetry.py`](https://github.com/codecov/worker/blob/a4762c411229999fe27b0a621109b90cc4444159/helpers/telemetry.py#L111)
- [`_commit_django()` and `_rollback_django()` in `tasks/base.py`](https://github.com/codecov/worker/blob/a4762c411229999fe27b0a621109b90cc4444159/tasks/base.py#L164-L202)

because this executor is applied to the `Feature` class, we probably actually want a yaml config that lets us control how many workers + whether to use it at all. since API won't need it

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.