### PR TITLE
Bundle Analysis: surface plugin name on parser error

### DIFF
--- a/shared/bundle_analysis/__init__.py
+++ b/shared/bundle_analysis/__init__.py
@@ -8,7 +8,7 @@ from shared.bundle_analysis.comparison import (
     MissingBundleError,
     MissingHeadReportError,
 )
-from shared.bundle_analysis.parser import Parser
+from shared.bundle_analysis.parser import Parser, ParserError
 from shared.bundle_analysis.report import (
     AssetReport,
     BundleAnalysisReport,

--- a/shared/bundle_analysis/__init__.py
+++ b/shared/bundle_analysis/__init__.py
@@ -8,7 +8,7 @@ from shared.bundle_analysis.comparison import (
     MissingBundleError,
     MissingHeadReportError,
 )
-from shared.bundle_analysis.parser import Parser, ParserError
+from shared.bundle_analysis.parser import Parser
 from shared.bundle_analysis.report import (
     AssetReport,
     BundleAnalysisReport,

--- a/shared/bundle_analysis/parser.py
+++ b/shared/bundle_analysis/parser.py
@@ -68,7 +68,8 @@ class Parser:
 
             with open(path, "rb") as f:
                 for event in ijson.parse(f):
-                    self._parse_event(event)
+                    print("PARSING EVENT")
+                    self._parse_item(event)
 
                 # Delete old session/asset/chunk/module with the same bundle name if applicable
                 old_session = (
@@ -127,7 +128,7 @@ class Parser:
         elif prefix == "duration":
             self.info["duration"] = value
 
-    def _parse_event(self, event: Tuple[str, str, str]):
+    def _parse_item(self, event: Tuple[str, str, str]):
         prefix, _, value = event
         prefix_path = prefix.split(".")
 

--- a/shared/bundle_analysis/parser.py
+++ b/shared/bundle_analysis/parser.py
@@ -102,7 +102,10 @@ class Parser:
         except Exception as e:
             # Inject the plugin name to the Exception object so we have visibilitity on which plugin
             # is causing the trouble.
-            e.bundle_analysis_plugin_name = self.info.get("plugin_name", "unknown")
+            print("SAVING bundle_analysis_plugin_name", self.info)
+            e.bundle_analysis_plugin_name = self.info.get(
+                "plugin_name", "unknown_plugin_name"
+            )
             raise e
 
     def _parse_info(self, event: Tuple[str, str, str]):

--- a/shared/bundle_analysis/parser.py
+++ b/shared/bundle_analysis/parser.py
@@ -16,6 +16,10 @@ from shared.bundle_analysis.models import (
 )
 
 
+class ParserError(Exception):
+    pass
+
+
 class Parser:
     """
     This does a streaming JSON parse of the stats JSON file referenced by `path`.
@@ -102,8 +106,11 @@ class Parser:
         except Exception as e:
             # Inject the plugin name to the Exception object so we have visibilitity on which plugin
             # is causing the trouble.
-            e.bundle_analysis_plugin_name = self.info.get("plugin_name", "unknown")
-            raise e
+            parser_error = ParserError(e)
+            parser_error.bundle_analysis_plugin_name = self.info.get(
+                "plugin_name", "unknown"
+            )
+            raise parser_error
 
     def _parse_info(self, event: Tuple[str, str, str]):
         prefix, _, value = event

--- a/shared/bundle_analysis/parser.py
+++ b/shared/bundle_analysis/parser.py
@@ -68,8 +68,7 @@ class Parser:
 
             with open(path, "rb") as f:
                 for event in ijson.parse(f):
-                    print("PARSING EVENT")
-                    self._parse_item(event)
+                    self._parse_event(event)
 
                 # Delete old session/asset/chunk/module with the same bundle name if applicable
                 old_session = (
@@ -103,10 +102,7 @@ class Parser:
         except Exception as e:
             # Inject the plugin name to the Exception object so we have visibilitity on which plugin
             # is causing the trouble.
-            print("SAVING bundle_analysis_plugin_name", self.info)
-            e.bundle_analysis_plugin_name = self.info.get(
-                "plugin_name", "unknown_plugin_name"
-            )
+            e.bundle_analysis_plugin_name = self.info.get("plugin_name", "unknown")
             raise e
 
     def _parse_info(self, event: Tuple[str, str, str]):
@@ -128,7 +124,7 @@ class Parser:
         elif prefix == "duration":
             self.info["duration"] = value
 
-    def _parse_item(self, event: Tuple[str, str, str]):
+    def _parse_event(self, event: Tuple[str, str, str]):
         prefix, _, value = event
         prefix_path = prefix.split(".")
 

--- a/shared/bundle_analysis/parser.py
+++ b/shared/bundle_analysis/parser.py
@@ -16,10 +16,6 @@ from shared.bundle_analysis.models import (
 )
 
 
-class ParserError(Exception):
-    pass
-
-
 class Parser:
     """
     This does a streaming JSON parse of the stats JSON file referenced by `path`.
@@ -106,11 +102,8 @@ class Parser:
         except Exception as e:
             # Inject the plugin name to the Exception object so we have visibilitity on which plugin
             # is causing the trouble.
-            parser_error = ParserError(e)
-            parser_error.bundle_analysis_plugin_name = self.info.get(
-                "plugin_name", "unknown"
-            )
-            raise parser_error
+            e.bundle_analysis_plugin_name = self.info.get("plugin_name", "unknown")
+            raise e
 
     def _parse_info(self, event: Tuple[str, str, str]):
         prefix, _, value = event

--- a/shared/bundle_analysis/parser.py
+++ b/shared/bundle_analysis/parser.py
@@ -54,49 +54,73 @@ class Parser:
         self.module_chunk_unique_external_ids = []
 
     def parse(self, path: str) -> int:
-        self.reset()
+        try:
+            self.reset()
 
-        self.session = Session(info={})
-        self.db_session.add(self.session)
+            self.session = Session(info={})
+            self.db_session.add(self.session)
 
-        with open(path, "rb") as f:
-            for event in ijson.parse(f):
-                self._parse_event(event)
+            with open(path, "rb") as f:
+                for event in ijson.parse(f):
+                    self._parse_event(event)
 
-            # Delete old session/asset/chunk/module with the same bundle name if applicable
-            old_session = (
-                self.db_session.query(Session)
-                .filter(
-                    Session.bundle == self.session.bundle, Session.id != self.session.id
-                )
-                .one_or_none()
-            )
-            if old_session:
-                for model in [Asset, Chunk, Module]:
-                    to_be_deleted = self.db_session.query(model).filter(
-                        model.session == old_session
+                # Delete old session/asset/chunk/module with the same bundle name if applicable
+                old_session = (
+                    self.db_session.query(Session)
+                    .filter(
+                        Session.bundle == self.session.bundle,
+                        Session.id != self.session.id,
                     )
-                    for item in to_be_deleted:
-                        self.db_session.delete(item)
-                self.db_session.delete(old_session)
-                self.db_session.flush()
+                    .one_or_none()
+                )
+                if old_session:
+                    for model in [Asset, Chunk, Module]:
+                        to_be_deleted = self.db_session.query(model).filter(
+                            model.session == old_session
+                        )
+                        for item in to_be_deleted:
+                            self.db_session.delete(item)
+                    self.db_session.delete(old_session)
+                    self.db_session.flush()
 
-            # save top level bundle stats info
-            self.session.info = json.dumps(self.info)
+                # save top level bundle stats info
+                self.session.info = json.dumps(self.info)
 
-            # this happens last so that we could potentially handle any ordering
-            # of top-level keys inside the JSON (i.e. we couldn't associate a chunk
-            # to an asset above if we parse the chunk before the asset)
-            self._create_associations()
+                # this happens last so that we could potentially handle any ordering
+                # of top-level keys inside the JSON (i.e. we couldn't associate a chunk
+                # to an asset above if we parse the chunk before the asset)
+                self._create_associations()
 
-        assert self.session.bundle is not None
-        return self.session.id
+                assert self.session.bundle is not None
+                return self.session.id
+        except Exception as e:
+            # Inject the plugin name to the Exception object so we have visibilitity on which plugin
+            # is causing the trouble.
+            e.bundle_analysis_plugin_name = self.info.get("plugin_name", "unknown")
+            raise e
 
     def _parse_event(self, event: Tuple[str, str, str]):
         prefix, _, value = event
-
         prefix_path = prefix.split(".")
-        if prefix_path[0] == "assets":
+
+        # session info
+        if prefix == "version":
+            self.info["version"] = value
+        elif prefix == "bundler.name":
+            self.info["bundler_name"] = value
+        elif prefix == "bundler.version":
+            self.info["bundler_version"] = value
+        elif prefix == "builtAt":
+            self.info["built_at"] = value
+        elif prefix == "plugin.name":
+            self.info["plugin_name"] = value
+        elif prefix == "plugin.version":
+            self.info["plugin_version"] = value
+        elif prefix == "duration":
+            self.info["duration"] = value
+
+        # asset / chunks / modules
+        elif prefix_path[0] == "assets":
             self._parse_assets_event(*event)
         elif prefix_path[0] == "chunks":
             self._parse_chunks_event(*event)
@@ -111,22 +135,6 @@ class Parser:
                 self.db_session.add(bundle)
             self.session.bundle = bundle
             self.db_session.flush()
-
-        # session info
-        elif prefix == "version":
-            self.info["version"] = value
-        elif prefix == "bundler.name":
-            self.info["bundler_name"] = value
-        elif prefix == "bundler.version":
-            self.info["bundler_version"] = value
-        elif prefix == "builtAt":
-            self.info["built_at"] = value
-        elif prefix == "plugin.name":
-            self.info["plugin_name"] = value
-        elif prefix == "plugin.version":
-            self.info["plugin_version"] = value
-        elif prefix == "duration":
-            self.info["duration"] = value
 
     def _parse_assets_event(self, prefix: str, event: str, value: str):
         if (prefix, event) == ("assets.item", "start_map"):

--- a/tests/unit/bundle_analysis/test_bundle_analysis.py
+++ b/tests/unit/bundle_analysis/test_bundle_analysis.py
@@ -1,4 +1,7 @@
 from pathlib import Path
+from unittest.mock import patch
+
+import pytest
 
 from shared.bundle_analysis import BundleAnalysisReport, BundleAnalysisReportLoader
 from shared.bundle_analysis.models import MetadataKey
@@ -189,3 +192,17 @@ def test_bundle_report_size_integer():
     bundle_report = report.bundle_report("sample")
 
     assert bundle_report.total_size() == 150572
+
+
+def test_bundle_parser_error():
+    with patch(
+        "shared.bundle_analysis.parser.Parser._parse_assets_event",
+        side_effect=Exception("MockError"),
+    ):
+        report = BundleAnalysisReport()
+        with pytest.raises(Exception) as excinfo:
+            report.ingest(sample_bundle_stats_path)
+            assert (
+                excinfo.bundle_analysis_plugin_name
+                == "codecov-vite-bundle-analysis-plugin"
+            )


### PR DESCRIPTION
Inject the plugin name (the plugin that was responsible for creating the stats file) if parsing the bundle stats file fails, this will be later used by the worker's BA processor to surface the bad plugin name as Sentry metrics.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.