### PR TITLE
Bundle Analysis: Create DB session manager for legacy SQLAlchemy versions

### DIFF
--- a/shared/bundle_analysis/report.py
+++ b/shared/bundle_analysis/report.py
@@ -115,7 +115,7 @@ class BundleAnalysisReport:
         self.db_path = db_path
         if self.db_path is None:
             _, self.db_path = tempfile.mkstemp(prefix="bundle_analysis_")
-        self.db_session = models.get_db_session(self.db_path)
+        self.db_session = models.get_db_session(self.db_path, auto_close=False)
         self._setup()
 
     def _setup(self):


### PR DESCRIPTION
- Create a custom context manager for SQLAlchemy session because worker is currently stuck on SQLAlchemy version <1.4, and built in context manager for session is introduced in 1.4 (which is also what codecov-api uses).
- It is a lot of work to upgrade worker's SQLAlchemy version because it is too closely tied into its postgres DB support. 
When worker fully migrates to Django for postgres, we can simply upgrade the SQLAlchemy version to support modern functionalities and delete this legacy code.
- For now if the SQLAlchemy version is <1.4 it will go through the custom LegacySessionManager context manager object to handle opening and closing its sessions.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.