### PR TITLE
upper limit on django version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
         "urllib3>=1.25.4,<1.27",
         "pyjwt",
         "pytz",
-        "django>=4.2.10",
+        "django>=4.2.10,<5.0",  # api uses python 3.9, non-compatible with >5.0
         "sqlalchemy==1.*",
         "ijson==3.*",
         "codecov-ribs",


### PR DESCRIPTION
<!-- Describe your PR here. -->
Without an upper limit here on django versioning, it goes to latest release, `5.x`, which is incompatible with python `3.9`, the version `api` uses. Out of an abundance of caution, let's keep these two projects on the same major version, which has the security patch for the [target vuln](https://github.com/advisories/GHSA-xxj9-f6rv-m3x4) 
