### PR TITLE
chore: update async interface

### DIFF
--- a/shared/rollouts/__init__.py
+++ b/shared/rollouts/__init__.py
@@ -187,7 +187,7 @@ class Feature:
             )
         )
 
-    @ttl_cache(maxsize=64, ttl=1)  # 5 minute time-to-live cache
+    @ttl_cache(maxsize=64, ttl=300)  # 5 minute time-to-live cache
     def _fetch_and_set_from_db(self):
         """
         Updates the instance with the newest values from database, and clears other caches so

--- a/shared/rollouts/__init__.py
+++ b/shared/rollouts/__init__.py
@@ -118,8 +118,8 @@ class Feature:
         )
 
     @sync_to_async
-    def check_value_async(self, identifier, default=False):
-        return self.check_value(identifier, default)
+    def check_value_async(self, owner_id=None, repo_id=None, default=False):
+        return self.check_value(owner_id=owner_id, repo_id=repo_id, default=default)
 
     @cached_property
     def _buckets(self):
@@ -187,7 +187,7 @@ class Feature:
             )
         )
 
-    @ttl_cache(maxsize=64, ttl=300)  # 5 minute time-to-live cache
+    @ttl_cache(maxsize=64, ttl=1)  # 5 minute time-to-live cache
     def _fetch_and_set_from_db(self):
         """
         Updates the instance with the newest values from database, and clears other caches so

--- a/tests/unit/test_rollouts.py
+++ b/tests/unit/test_rollouts.py
@@ -1,5 +1,6 @@
 from unittest.mock import patch
 
+from django.core.exceptions import SynchronousOnlyOperation
 from django.test import TestCase
 
 from shared.django_apps.rollouts.models import (
@@ -141,6 +142,19 @@ class TestFeature(TestCase):
 
         assert feature_flag is not None
         assert feature_flag.proportion == 0
+
+    def test_sync_feature_call(self):
+        testing_feature = Feature("testing_dummy_feature")
+        assert testing_feature.check_value(owner_id="hi", default=False) == False
+
+    async def test_async_feature_call_fail(self):
+        testing_feature = Feature("testing_dummy_feature")
+        with self.assertRaises(SynchronousOnlyOperation):
+            testing_feature.check_value(owner_id="hi", default=False) == False
+
+    async def test_async_feature_call_success(self):
+        testing_feature = Feature("testing_dummy_feature")
+        await testing_feature.check_value_async(owner_id="hi", default=False) == False
 
 
 class TestFeatureExposures(TestCase):


### PR DESCRIPTION
<!-- Describe your PR here. -->

Updates the async version of `check_value()` so that it matches the non-async version.