### PR TITLE
fix: fix glob pattern translation

### DIFF
--- a/shared/bundle_analysis/models.py
+++ b/shared/bundle_analysis/models.py
@@ -86,7 +86,6 @@ SCHEMA_VERSION = 1
 Base = declarative_base()
 
 
-
 """
 Create a custom context manager for SQLAlchemy session because worker is currently
 stuck on SQLAlchemy version <1.4, and built in context manager for session is introduced
@@ -98,6 +97,8 @@ version to support modern functionalities and delete this legacy code.
 For now if the SQLAlchemy version is <1.4 it will go through the custom LegacySessionManager
 context manager object to handle opening and closing its sessions.
 """
+
+
 class LegacySessionManager:
     def __init__(self, session: DbSession):
         self.session = session

--- a/shared/validation/helpers.py
+++ b/shared/validation/helpers.py
@@ -212,7 +212,7 @@ class PathPatternSchemaField(object):
             filepath to see if it matches
         - glob - The user inputs a glob (as the glob that we use in unix, using `*` and `**`)
 
-    This class tries to determinw which type of pattern the user inputted. We say "try", because
+    This class tries to determine which type of pattern the user inputted. We say "try", because
         some paths can be more than one type, and we try our best to see what the user meant.
 
     For example, `a.*` could match `a/folder1/path/file.py` as a regex, but not as a glob.
@@ -233,9 +233,6 @@ class PathPatternSchemaField(object):
         return determine_path_pattern_type(value)
 
     def validate_glob(self, value):
-        if not value.endswith("$") and not value.endswith("*"):
-            # Adding support for a prefix-based list of paths
-            value = value + "**"
         return translate_glob_to_regex(value)
 
     def validate_path_prefix(self, value):

--- a/shared/validation/helpers.py
+++ b/shared/validation/helpers.py
@@ -233,6 +233,8 @@ class PathPatternSchemaField(object):
         return determine_path_pattern_type(value)
 
     def validate_glob(self, value):
+        if not value.endswith("$") and not value.endswith("*"):
+            log.warning("Old glob behavior would have interpreted this glob as prefix")
         return translate_glob_to_regex(value)
 
     def validate_path_prefix(self, value):

--- a/tests/unit/validation/test_helpers.py
+++ b/tests/unit/validation/test_helpers.py
@@ -51,8 +51,8 @@ class TestPathPatternSchemaField(BaseTestCase):
         res = ps.validate("a/*/b")
         compiled = re.compile(res)
         assert compiled.match("a/path/b") is not None
-        assert compiled.match("a/path/b/file_2.py") is not None
-        assert compiled.match("a/path/b/more_path/some_file.py") is not None
+        assert compiled.match("a/path/b/file_2.py") is None
+        assert compiled.match("a/path/b/more_path/some_file.py") is None
         assert compiled.match("a/b") is None
         assert compiled.match("a/path/path2/b") is None
 
@@ -73,11 +73,11 @@ class TestPathPatternSchemaField(BaseTestCase):
         res = ps.validate("a/**/b")
         compiled = re.compile(res)
         assert compiled.match("a/path/b") is not None
-        assert compiled.match("a/path/b/some_file.py") is not None
-        assert compiled.match("a/path/b/more_path/some_file.py") is not None
+        assert compiled.match("a/path/b/some_file.py") is None
+        assert compiled.match("a/path/b/more_path/some_file.py") is None
         assert compiled.match("a/path/path2/b") is not None
-        assert compiled.match("a/path/path2/b/some_file.py") is not None
-        assert compiled.match("a/path/path2/b/more_path/some_file.py") is not None
+        assert compiled.match("a/path/path2/b/some_file.py") is None
+        assert compiled.match("a/path/path2/b/more_path/some_file.py") is None
         assert compiled.match("a/c") is None
 
     def test_path_with_leading_period_slash(self):
@@ -101,6 +101,26 @@ class TestPathPatternSchemaField(BaseTestCase):
         res = ps.validate(user_input)
         compiled = re.compile(res)
         assert compiled.match("Snapshots/Snapshots/ViewController.swift") is not None
+
+    def test_double_star_prefix(self):
+        user_input = "**/*bundle"
+        ps = PathPatternSchemaField()
+        res = ps.validate(user_input)
+        compiled = re.compile(res)
+        paths_to_match = [
+            "app/Bundle/ignoreme.bundle",
+            "tests/test_bundle/sample_bundle",
+        ]
+        paths_not_to_match = [
+            "app/Bundle/BundleCart.py",
+            "app/Bundle/__init__.py",
+            "app/Bundle/mybundle.py",
+            "tests/test_bundle/test_bundle_cart.py",
+        ]
+        for path in paths_to_match:
+            assert compiled.match(path) is not None
+        for path in paths_not_to_match:
+            assert compiled.match(path) is None
 
 
 class TestLayoutStructure(BaseTestCase):

--- a/tests/unit/validation/test_install_validation.py
+++ b/tests/unit/validation/test_install_validation.py
@@ -69,7 +69,7 @@ def test_validate_install_configuration_with_user_yaml(mocker):
             "ignore": [
                 "^agent/uiserver/bindata_assetfs.go.*",
                 "(?s:vendor/.*/[^\\/]*)\\Z",
-                "(?s:.*/[^\\/]*\\.pb\\.go.*)\\Z",
+                "(?s:.*/[^\\/]*\\.pb\\.go)\\Z",
             ],
         },
     }

--- a/tests/unit/validation/test_validation.py
+++ b/tests/unit/validation/test_validation.py
@@ -100,7 +100,7 @@ class TestUserYamlValidation(BaseTestCase):
                     "ignore": [
                         "^agent/uiserver/bindata_assetfs.go.*",
                         "(?s:vendor/.*/[^\\/]*)\\Z",
-                        "(?s:.*/[^\\/]*\\.pb\\.go.*)\\Z",
+                        "(?s:.*/[^\\/]*\\.pb\\.go)\\Z",
                     ],
                 },
             ),
@@ -1128,7 +1128,7 @@ def test_profiling_schema():
                 "^/path/to/file.extension.*",
                 "^/path/to/dir.*",
                 "^/path/{src|bin}/regex.{txt|php|cpp}.*",
-                "(?s:/path/using/globs/.*/file\\.extension.*)\\Z",
+                "(?s:/path/using/globs/.*/file\\.extension)\\Z",
             ],
         }
     }

--- a/tests/unit/yaml/test_user_yaml_validation.py
+++ b/tests/unit/yaml/test_user_yaml_validation.py
@@ -15,7 +15,7 @@ def test_show_secret_case():
             "status": {"project": {"default": {"base": "auto"}}},
             "notify": {"irc": {"user_given_title": {"password": encoded_value}}},
         },
-        "ignore": ["Pods/.*"],
+        "ignore": ["Pods/.*", "**/*bundle"],
     }
     expected_result = {
         "coverage": {
@@ -31,7 +31,7 @@ def test_show_secret_case():
                 }
             },
         },
-        "ignore": ["Pods/.*"],
+        "ignore": ["Pods/.*", "(?s:.*/[^\\/]*bundle)\\Z"],
     }
     result = validate_yaml(
         user_input, show_secrets_for=("github", "11934774", "154468867")


### PR DESCRIPTION
Glob patterns were always considered as "prefixes",
and would match any depth after their ending.

Recently this became an issue noticed by a customer that was
trying to ignore all files ending with `bundle`, but ended up having
more files than intended ignored.

These changes remove this "glob is always a prefix" idea and solve this
use case. Users can still use "path as a prefix" but only proper paths,
not globs. They can also use regexes.

<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.