### PR TITLE
chore: add repo logs when fetching GH repos

### DIFF
--- a/shared/torngit/github.py
+++ b/shared/torngit/github.py
@@ -645,7 +645,9 @@ class Github(TorngitBaseAdapter):
 
         log.info(
             "Fetched page of repos using installation",
-            extra=dict(page_size=page_size, page=page, repos=repos),
+            extra=dict(
+                page_size=page_size, page=page, repo_names=[repo.name for repo in repos]
+            ),
         )
 
         return self._process_repository_page(repos)
@@ -674,7 +676,7 @@ class Github(TorngitBaseAdapter):
             extra=dict(
                 page_size=page_size,
                 page=page,
-                repos=repos,
+                repo_names=[repo.name for repo in repos],
                 username=username,
             ),
         )

--- a/shared/torngit/github.py
+++ b/shared/torngit/github.py
@@ -646,7 +646,9 @@ class Github(TorngitBaseAdapter):
         log.info(
             "Fetched page of repos using installation",
             extra=dict(
-                page_size=page_size, page=page, repo_names=[repo.name for repo in repos]
+                page_size=page_size,
+                page=page,
+                repo_names=[repo["name"] for repo in repos],
             ),
         )
 
@@ -676,7 +678,7 @@ class Github(TorngitBaseAdapter):
             extra=dict(
                 page_size=page_size,
                 page=page,
-                repo_names=[repo.name for repo in repos],
+                repo_names=[repo["name"] for repo in repos],
                 username=username,
             ),
         )

--- a/shared/torngit/github.py
+++ b/shared/torngit/github.py
@@ -196,6 +196,11 @@ class Github(TorngitBaseAdapter):
         """
         token_to_use = token or self.token
 
+        log.info(
+            "Making Github API call",
+            extra=dict(has_token=bool(token), has_self_token=bool(self.token)),
+        )
+
         if not token_to_use:
             raise TorngitMisconfiguredCredentials()
         response = await self.make_http_call(*args, token_to_use=token_to_use, **kwargs)

--- a/shared/torngit/github.py
+++ b/shared/torngit/github.py
@@ -653,7 +653,7 @@ class Github(TorngitBaseAdapter):
             extra=dict(
                 page_size=page_size,
                 page=page,
-                repo_names=[repo["name"] for repo in repos],
+                repo_names=[repo["name"] for repo in repos] if len(repos) > 0 else [],
             ),
         )
 
@@ -683,7 +683,7 @@ class Github(TorngitBaseAdapter):
             extra=dict(
                 page_size=page_size,
                 page=page,
-                repo_names=[repo["name"] for repo in repos],
+                repo_names=[repo["name"] for repo in repos] if len(repos) > 0 else [],
                 username=username,
             ),
         )


### PR DESCRIPTION
Adding some logging for the fetch_page functions in github.py for logging the repo names when returned from the api call


<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.