### PR TITLE
feat: support minio region passing to client

### DIFF
--- a/shared/storage/minio.py
+++ b/shared/storage/minio.py
@@ -37,6 +37,7 @@ class MinioStorageService(BaseStorageService):
             self.minio_config["verify_ssl"],
             self.minio_config.get("iam_auth", False),
             self.minio_config["iam_endpoint"],
+            self.minio_config["region"],
         )
         log.debug("Done setting up minio client")
 
@@ -52,6 +53,7 @@ class MinioStorageService(BaseStorageService):
         verify_ssl: bool = False,
         iam_auth: bool = False,
         iam_endpoint: str = None,
+        region: str = None,
     ):
         """
             Initialize the minio client
@@ -74,6 +76,7 @@ class MinioStorageService(BaseStorageService):
             verify_ssl (bool, optional): Whether minio should verify ssl
             iam_auth (bool, optional): Whether to use iam_auth
             iam_endpoint (str, optional): The endpoint to try to fetch EC2 metadata
+            region (str, optional): The region of the host where minio lives
         """
         if port is not None:
             host = "{}:{}".format(host, port)
@@ -82,6 +85,7 @@ class MinioStorageService(BaseStorageService):
             return Minio(
                 host,
                 secure=verify_ssl,
+                region=region,
                 credentials=ChainedProvider(
                     providers=[
                         IamAwsProvider(custom_endpoint=iam_endpoint),
@@ -91,7 +95,7 @@ class MinioStorageService(BaseStorageService):
                 ),
             )
         return Minio(
-            host, access_key=access_key, secret_key=secret_key, secure=verify_ssl
+            host, access_key=access_key, secret_key=secret_key, secure=verify_ssl, region=region
         )
 
     # writes the initial storage bucket to storage via minio.

--- a/shared/storage/minio.py
+++ b/shared/storage/minio.py
@@ -37,7 +37,7 @@ class MinioStorageService(BaseStorageService):
             self.minio_config["verify_ssl"],
             self.minio_config.get("iam_auth", False),
             self.minio_config["iam_endpoint"],
-            self.minio_config["region"],
+            self.minio_config.get("region"),
         )
         log.debug("Done setting up minio client")
 

--- a/tests/unit/storage/test_minio.py
+++ b/tests/unit/storage/test_minio.py
@@ -212,7 +212,7 @@ class TestMinioStorageService(BaseTestCase):
         storage = MinioStorageService(minio_no_ports_config)
         assert storage.minio_config == minio_no_ports_config
         mocked_minio_client.assert_called_with(
-            "cute_url_no_ports", credentials=mocker.ANY, secure=False
+            "cute_url_no_ports", credentials=mocker.ANY, secure=False, region=None
         )
 
     def test_minio_with_ports(self, mocker):

--- a/tests/unit/storage/test_minio.py
+++ b/tests/unit/storage/test_minio.py
@@ -229,5 +229,23 @@ class TestMinioStorageService(BaseTestCase):
         storage = MinioStorageService(minio_no_ports_config)
         assert storage.minio_config == minio_no_ports_config
         mocked_minio_client.assert_called_with(
-            "cute_url_no_ports:9000", credentials=mocker.ANY, secure=False
+            "cute_url_no_ports:9000", credentials=mocker.ANY, secure=False, region=None
+        )
+
+    def test_minio_with_region(self, mocker):
+        mocked_minio_client = mocker.patch("shared.storage.minio.Minio")
+        minio_no_ports_config = {
+            "access_key_id": "hodor",
+            "secret_access_key": "haha",
+            "verify_ssl": False,
+            "host": "cute_url_no_ports",
+            "port": "9000",
+            "iam_auth": True,
+            "iam_endpoint": None,
+            "region": "example"
+        }
+        storage = MinioStorageService(minio_no_ports_config)
+        assert storage.minio_config == minio_no_ports_config
+        mocked_minio_client.assert_called_with(
+            "cute_url_no_ports:9000", credentials=mocker.ANY, secure=False, region="example"
         )


### PR DESCRIPTION
this allows us to specify the region correctly so various scopes and other aspects don't default to us-east-1 internally

<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.