### PR TITLE
chore: also log isSameToken

### DIFF
--- a/shared/torngit/github.py
+++ b/shared/torngit/github.py
@@ -198,7 +198,11 @@ class Github(TorngitBaseAdapter):
 
         log.info(
             "Making Github API call",
-            extra=dict(has_token=bool(token), has_self_token=bool(self.token)),
+            extra=dict(
+                has_token=bool(token),
+                has_self_token=bool(self.token),
+                is_same_token=(token == self.token),
+            ),
         )
 
         if not token_to_use:


### PR DESCRIPTION
Small update to the logs to also log if the token is the same as the self.token



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.