### PR TITLE
chore: add verification task name

### DIFF
--- a/shared/celery_config.py
+++ b/shared/celery_config.py
@@ -28,6 +28,9 @@ pre_process_upload_task_name = (
 upload_task_name = f"app.tasks.{TaskConfigGroup.upload.value}.Upload"
 upload_processor_task_name = f"app.tasks.{TaskConfigGroup.upload.value}.UploadProcessor"
 upload_finisher_task_name = f"app.tasks.{TaskConfigGroup.upload.value}.UploadFinisher"
+parallel_verification_task_name = (
+    f"app.tasks.{TaskConfigGroup.upload.value}.ParallelVerification"
+)
 test_results_processor_task_name = (
     f"app.tasks.{TaskConfigGroup.test_results.value}.TestResultsProcessor"
 )

--- a/shared/storage/minio.py
+++ b/shared/storage/minio.py
@@ -95,7 +95,11 @@ class MinioStorageService(BaseStorageService):
                 ),
             )
         return Minio(
-            host, access_key=access_key, secret_key=secret_key, secure=verify_ssl, region=region
+            host,
+            access_key=access_key,
+            secret_key=secret_key,
+            secure=verify_ssl,
+            region=region,
         )
 
     # writes the initial storage bucket to storage via minio.

--- a/shared/torngit/github.py
+++ b/shared/torngit/github.py
@@ -1272,7 +1272,9 @@ class Github(TorngitBaseAdapter):
                     (
                         "\ndeleted file mode 100644"
                         if f["status"] == "removed"
-                        else "\nnew file mode 100644" if f["status"] == "added" else ""
+                        else "\nnew file mode 100644"
+                        if f["status"] == "added"
+                        else ""
                     ),
                     "--- "
                     + (

--- a/tests/unit/storage/test_minio.py
+++ b/tests/unit/storage/test_minio.py
@@ -242,10 +242,13 @@ class TestMinioStorageService(BaseTestCase):
             "port": "9000",
             "iam_auth": True,
             "iam_endpoint": None,
-            "region": "example"
+            "region": "example",
         }
         storage = MinioStorageService(minio_no_ports_config)
         assert storage.minio_config == minio_no_ports_config
         mocked_minio_client.assert_called_with(
-            "cute_url_no_ports:9000", credentials=mocker.ANY, secure=False, region="example"
+            "cute_url_no_ports:9000",
+            credentials=mocker.ANY,
+            secure=False,
+            region="example",
         )


### PR DESCRIPTION
add verification task name used for https://github.com/codecov/worker/pull/347

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.