### PR TITLE
[chore] switch from `sleep 86400` to a tty service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,15 +9,13 @@ services:
     build:
       context: .
       dockerfile: docker/Dockerfile
+    tty: true
     depends_on:
       - postgres
       - timescale
     volumes:
       - ./shared/:/app/shared
       - ./tests/:/app/tests
-    command:
-      - sleep
-      - "86400" # so the container doesn't exit
 
   postgres:
     image: postgres:14.7-alpine


### PR DESCRIPTION
instead of starting a container and running `sleep 86400` to keep it from shutting down, we can set `tty: true`

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.