### PR TITLE
fix: fix feature bucketing logic

### DIFF
--- a/shared/rollouts/__init__.py
+++ b/shared/rollouts/__init__.py
@@ -156,25 +156,15 @@ class Feature:
         quantile = 0
 
         for variant in self.ff_variants:
-            test_population = int(variant.proportion * Feature.HASHSPACE)
+            variant_test_population = int(variant.proportion * Feature.HASHSPACE)
 
             start = int(quantile * Feature.HASHSPACE)
-            end = int(start + (test_population * self.feature_flag.proportion))
+            end = int(start + (variant_test_population * self.feature_flag.proportion))
 
             quantile += variant.proportion
             buckets.append((start, end, variant))
 
         return buckets
-
-        # test_population = int(self.feature_flag.proportion * Feature.HASHSPACE)
-
-        # buckets = []
-        # quantile = 0
-        # for variant in self.ff_variants:
-        #     quantile += variant.proportion
-        #     buckets.append((int(quantile * test_population), variant))
-
-        # return buckets
 
     def _get_override_variant(self, identifier, identifier_type: IdentifierType):
         """
@@ -251,6 +241,7 @@ class Feature:
 
         if clear_cache:
             self._check_value.cache_clear()
+            print("this ran right?")
 
             if hasattr(self, "_buckets"):
                 del self._buckets  # clears @cached_property

--- a/shared/rollouts/__init__.py
+++ b/shared/rollouts/__init__.py
@@ -241,7 +241,6 @@ class Feature:
 
         if clear_cache:
             self._check_value.cache_clear()
-            print("this ran right?")
 
             if hasattr(self, "_buckets"):
                 del self._buckets  # clears @cached_property

--- a/shared/rollouts/__init__.py
+++ b/shared/rollouts/__init__.py
@@ -150,6 +150,9 @@ class Feature:
         `proportion` of the feature flag and its `variants`. The hash for this repo
         will fall into one of those buckets and the corresponding variant (or default
         value) will be returned.
+
+        Each bucket in the buckets array represents a range: (0, 1000, `enabled_variant`). In
+        this case, hashes that land in [0, 1000) will be assigned `enabled_variant`
         """
 
         buckets = []

--- a/tests/unit/test_rollouts.py
+++ b/tests/unit/test_rollouts.py
@@ -39,7 +39,11 @@ class TestFeature(TestCase):
             # should be [0..33], [34..66], and [67..100]. Anything from [101..200]
             # is not part of the rollout yet.
             buckets = complex_feature._buckets
-            assert list(map(lambda x: x[0], buckets)) == [33, 66, 99]
+            assert list(map(lambda x: (x[0], x[1]), buckets)) == [
+                (0, 33),
+                (66, 99),
+                (133, 166),
+            ]
 
     def test_fully_rolled_out(self):
         rolled_out = FeatureFlag.objects.create(

--- a/tests/unit/test_rollouts.py
+++ b/tests/unit/test_rollouts.py
@@ -27,8 +27,8 @@ class TestFeature(TestCase):
         )
         complex_feature = Feature("complex")
 
-        # # To make the math simpler, let's pretend our hash function can only
-        # # return 200 different values.
+        # To make the math simpler, let's pretend our hash function can only
+        # return 200 different values.
         with patch.object(Feature, "HASHSPACE", 200):
 
             complex_feature.check_value(owner_id=1234)  # to force fetch values from db
@@ -159,6 +159,56 @@ class TestFeature(TestCase):
     async def test_async_feature_call_success(self):
         testing_feature = Feature("testing_dummy_feature")
         await testing_feature.check_value_async(owner_id="hi", default=False) == False
+
+    def test_rollout_proportion_changes_dont_affect_variant_assignments(self):
+        my_feature_flag = FeatureFlag.objects.create(
+            name="my_feature1", proportion=0.5, salt="random_salt"
+        )
+        FeatureFlagVariant.objects.create(
+            name="var1", feature_flag=my_feature_flag, proportion=1 / 3, value=1
+        )
+        FeatureFlagVariant.objects.create(
+            name="var2", feature_flag=my_feature_flag, proportion=1 / 3, value=2
+        )
+        FeatureFlagVariant.objects.create(
+            name="var3", feature_flag=my_feature_flag, proportion=1 / 3, value=3
+        )
+        my_feature = Feature("my_feature1")
+
+        # The purpose of this test is to ensure that even when the feature_flag proportion
+        # changes, users assignments to variants never change. ie, if user `a` was ever assigned
+        # to variant 1, then for any feature_flag proportion, user `a` will either be
+        # assigned to variant 1, or is not participating in the rollout (default value).
+        # https://github.com/codecov/engineering-team/issues/1515
+
+        # To make the math simpler, let's pretend our hash function can only
+        # return 200 different values.
+        with patch.object(Feature, "HASHSPACE", 200):
+            with patch("mmh3.hash128", side_effect=[30, 90, 150, 40, 30, 90, 150, 40]):
+                a = my_feature.check_value(owner_id=123, default="c")
+                b = my_feature.check_value(owner_id=124, default="c")
+                c = my_feature.check_value(owner_id=125, default="c")
+                d = my_feature.check_value(owner_id=126, default="d")
+
+                assert a == 1
+                assert b == 2
+                assert c == 3
+                assert d == "d"
+
+                my_feature_flag.proportion = (
+                    1.0  # buckets are now: [(0,66), (66, 132), (133, 199)]
+                )
+                my_feature_flag.save()
+
+                my_feature._fetch_and_set_from_db.cache_clear()  # clear the TTL
+                my_feature._fetch_and_set_from_db()  # refresh feature flag proportion and clear caches
+
+                assert a == my_feature.check_value(owner_id=123, default="c")
+                assert b == my_feature.check_value(owner_id=124, default="c")
+                assert c == my_feature.check_value(owner_id=125, default="c")
+                assert 1 == my_feature.check_value(
+                    owner_id=126, default="d"
+                )  # now in variant 1 since 40 \in (0,66)
 
 
 class TestFeatureExposures(TestCase):

--- a/tests/unit/test_rollouts.py
+++ b/tests/unit/test_rollouts.py
@@ -33,11 +33,11 @@ class TestFeature(TestCase):
 
             complex_feature.check_value(owner_id=1234)  # to force fetch values from db
 
-            # Because the top-level feature proportion is 0.5, we are only using the
-            # first 50% of our 200 hash values as our test population: [0..100]
-            # Each feature variant has a proportion of 1/3, so our three buckets
-            # should be [0..33], [34..66], and [67..100]. Anything from [101..200]
-            # is not part of the rollout yet.
+            # Because each feature variant has a proportion of 1/3, our three
+            # buckets should be [0, 66], [66, 133], [133, 200]. However, our top-level
+            # feature proportion is only 0.5, so each bucket size should be then
+            # halved: [0, 33], [66, 99], [133, 166]
+
             buckets = complex_feature._buckets
             assert list(map(lambda x: (x[0], x[1]), buckets)) == [
                 (0, 33),

--- a/tests/unit/test_rollouts.py
+++ b/tests/unit/test_rollouts.py
@@ -196,7 +196,7 @@ class TestFeature(TestCase):
                 assert d == "d"
 
                 my_feature_flag.proportion = (
-                    1.0  # buckets are now: [(0,66), (66, 132), (133, 199)]
+                    1.0  # buckets are now: [(0,66), (66, 133), (133, 200)]
                 )
                 my_feature_flag.save()
 


### PR DESCRIPTION
<!-- Describe your PR here. -->

Should close https://github.com/codecov/engineering-team/issues/1515. Refactors the bucketing logic so that users' assignments to variants never change even when the total rollout proportions change.

Added a test for this case specifically

![Screenshot 2024-04-05 at 3 04 15 PM](https://github.com/codecov/shared/assets/159859649/34c12d3d-2340-4666-bd6a-44235353ca51)

![Screenshot 2024-04-05 at 3 04 29 PM](https://github.com/codecov/shared/assets/159859649/c1118e97-79bd-430d-8667-698040f4df26)


<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.