### PR TITLE
fix: force kwargs for feature

### DIFF
--- a/shared/rollouts/__init__.py
+++ b/shared/rollouts/__init__.py
@@ -109,7 +109,7 @@ class Feature:
                 "skip_feature_cache for Feature should only be turned on in development environments, and should not be used in production"
             )
 
-    def check_value(self, owner_id=None, repo_id=None, default=False):
+    def check_value(self, *, owner_id=None, repo_id=None, default=False):
         """
         Returns the value of the applicable feature variant for an identifier. This is commonly a boolean for feature variants
         that represent an ON variant and an OFF variant, but could be other values aswell. You can modify the values in
@@ -131,7 +131,7 @@ class Feature:
         )
 
     @sync_to_async
-    def check_value_async(self, owner_id=None, repo_id=None, default=False):
+    def check_value_async(self, *, owner_id=None, repo_id=None, default=False):
         return self.check_value(owner_id=owner_id, repo_id=repo_id, default=default)
 
     @cached_property

--- a/tests/unit/test_rollouts.py
+++ b/tests/unit/test_rollouts.py
@@ -92,6 +92,23 @@ class TestFeature(TestCase):
         assert feature.check_value(owner_id=123, default=2) == 1
         assert not hasattr(feature.__dict__, "_buckets")
 
+    def test_override_no_proportion(self):
+        overrides = FeatureFlag.objects.create(
+            name="overrides_no_proportion", proportion=0, salt="random_salt"
+        )
+        FeatureFlagVariant.objects.create(
+            name="single_variant",
+            feature_flag=overrides,
+            proportion=0,
+            value=2,
+            override_owner_ids=[321, 123],
+        )
+
+        feature = Feature("overrides_no_proportion")
+
+        assert feature.check_value(owner_id=321, default=1) == 2
+        assert feature.check_value(owner_id=123, default=1) == 2
+
     def test_not_in_test_gets_default(self):
         not_in_test = FeatureFlag.objects.create(
             name="not_in_test", proportion=0.1, salt="random_salt"


### PR DESCRIPTION
Force `.check_value()` interface for feature to accept kwargs so we don't forget to explicitly state which identifier type we're using (repoid vs ownerid)

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.