### PR TITLE
feat: allow environment vars to disable/override Feature values

### DIFF
--- a/shared/rollouts/__init__.py
+++ b/shared/rollouts/__init__.py
@@ -140,11 +140,11 @@ class Feature:
         feature variants via Django Admin.
         """
 
-        if self.env_disable:
-            return default
-
         if hasattr(self, "env_override"):
             return self.env_override
+
+        if self.env_disable:
+            return default
 
         if self.refresh:
             self._fetch_and_set_from_db.cache_clear()

--- a/shared/rollouts/__init__.py
+++ b/shared/rollouts/__init__.py
@@ -36,9 +36,10 @@ class Feature:
     every 5 minutes, meaning it can take up to 5 minutes for changes to show up here.
 
     If you manage your own deployment, you can disable or override feature checks with environment variables:
-    - If `CODECOV__FEATURE__DISABLE` is set, checks will be skipped and default values will be returned every time
     - If `CODECOV__FEATURE__{name.upper()}` is set, its value will be deserialized as JSON and returned for the
       `Feature` with that name
+    - If `CODECOV__FEATURE__DISABLE` is set, checks will be skipped and default values will be returned every time
+      for every feature except those with overrides set via `CODECOV__FEATURE__{name.upper()}` env vars
 
     If you instantiate a `Feature` instance with a new name, the associated database entry
     will be created for you. Otherwise, the existing database entry will be used to populate

--- a/shared/rollouts/__init__.py
+++ b/shared/rollouts/__init__.py
@@ -1,4 +1,6 @@
+import json
 import logging
+import os
 from enum import Enum
 from functools import cached_property
 
@@ -32,6 +34,11 @@ class Feature:
 
     You can modify the parameters of your feature flag via Django Admin. The parameters are fetched and updated roughly
     every 5 minutes, meaning it can take up to 5 minutes for changes to show up here.
+
+    If you manage your own deployment, you can disable or override feature checks with environment variables:
+    - If `CODECOV__FEATURE__DISABLE` is set, checks will be skipped and default values will be returned every time
+    - If `CODECOV__FEATURE__{name.upper()}` is set, its value will be deserialized as JSON and returned for the
+      `Feature` with that name
 
     If you instantiate a `Feature` instance with a new name, the associated database entry
     will be created for you. Otherwise, the existing database entry will be used to populate
@@ -101,6 +108,23 @@ class Feature:
         self.feature_flag = None
         self.ff_variants = None
 
+        # See if this environment has disabled feature flagging entirely.
+        # These environments will always get default values.
+        self.env_disable = os.getenv(f"CODECOV__FEATURE__DISABLE") is not None
+
+        # See if this environment has provided an override for this feature in
+        # its environment variables. Since feature variant values are stored in
+        # the database as JSON, we read these overrides as JSON as well.
+        #
+        # We need to be able to tell the difference between the case where an
+        # override is _undefined_ and the case where the override is defined and
+        # set to `"null"`/`None`. Two cases:
+        # - If the override is defined, `hasattr(self, 'env_override') == True`
+        # - If the override is undefined, `hasattr(self, 'env_override') == False`
+        env_override = os.getenv(f"CODECOV__FEATURE__{name.upper()}")
+        if env_override is not None:
+            self.env_override = json.loads(env_override or '""')
+
         self.refresh = get_config(
             "setup", "skip_feature_cache", default=False
         )  # to be used only during development
@@ -115,6 +139,12 @@ class Feature:
         that represent an ON variant and an OFF variant, but could be other values aswell. You can modify the values in
         feature variants via Django Admin.
         """
+
+        if self.env_disable:
+            return default
+
+        if hasattr(self, "env_override"):
+            return self.env_override
 
         if self.refresh:
             self._fetch_and_set_from_db.cache_clear()

--- a/tests/unit/test_rollouts.py
+++ b/tests/unit/test_rollouts.py
@@ -258,6 +258,21 @@ class TestFeature(TestCase):
             fetch_fn.assert_not_called()
             assert not hasattr(feature.__dict__, "_buckets")
 
+    @patch.dict(os.environ, {"CODECOV__FEATURE__NUM_FEATURE": "30"})
+    @patch.dict(os.environ, {"CODECOV__FEATURE__DISABLE": ""})
+    def test_check_value_with_env_disable_and_env_override(self):
+        feature = Feature("num_feature")
+        with patch.object(feature, "_fetch_and_set_from_db") as fetch_fn:
+            assert feature.check_value(owner_id=1, default=100) == 30
+            fetch_fn.assert_not_called()
+            assert not hasattr(feature.__dict__, "_buckets")
+
+        feature = Feature("other_feature")
+        with patch.object(feature, "_fetch_and_set_from_db") as fetch_fn:
+            assert feature.check_value(owner_id=1, default=100) == 100
+            fetch_fn.assert_not_called()
+            assert not hasattr(feature.__dict__, "_buckets")
+
 
 class TestFeatureExposures(TestCase):
     def test_exposure_created(self):

--- a/tests/unit/test_rollouts.py
+++ b/tests/unit/test_rollouts.py
@@ -1,3 +1,4 @@
+import os
 from unittest.mock import patch
 
 from django.core.exceptions import SynchronousOnlyOperation
@@ -226,6 +227,36 @@ class TestFeature(TestCase):
                 assert 1 == my_feature.check_value(
                     owner_id=126, default="d"
                 )  # now in variant 1 since 40 \in (0,66)
+
+    @patch.dict(os.environ, {"CODECOV__FEATURE__DISABLE": ""})
+    def test_check_value_with_env_disable(self):
+        feature = Feature("my_feature")
+        with patch.object(feature, "_fetch_and_set_from_db") as fetch_fn:
+            assert feature.check_value(owner_id=1, default=100) == 100
+            fetch_fn.assert_not_called()
+            assert not hasattr(feature.__dict__, "_buckets")
+
+    @patch.dict(os.environ, {"CODECOV__FEATURE__NUM_FEATURE": "30"})
+    @patch.dict(os.environ, {"CODECOV__FEATURE__STR_FEATURE": '"foo"'})
+    @patch.dict(os.environ, {"CODECOV__FEATURE__NULL_FEATURE": "null"})
+    def test_check_value_with_env_override(self):
+        feature = Feature("num_feature")
+        with patch.object(feature, "_fetch_and_set_from_db") as fetch_fn:
+            assert feature.check_value(owner_id=1, default=100) == 30
+            fetch_fn.assert_not_called()
+            assert not hasattr(feature.__dict__, "_buckets")
+
+        feature = Feature("str_feature")
+        with patch.object(feature, "_fetch_and_set_from_db") as fetch_fn:
+            assert feature.check_value(owner_id=1, default="bar") == "foo"
+            fetch_fn.assert_not_called()
+            assert not hasattr(feature.__dict__, "_buckets")
+
+        feature = Feature("null_feature")
+        with patch.object(feature, "_fetch_and_set_from_db") as fetch_fn:
+            assert feature.check_value(owner_id=1, default=100) == None
+            fetch_fn.assert_not_called()
+            assert not hasattr(feature.__dict__, "_buckets")
 
 
 class TestFeatureExposures(TestCase):


### PR DESCRIPTION
- if the `CODECOV__FEATURE__DISABLE` env var is set, return default values without bothering to look in the db for feature configuration
- if `CODECOV__FEATURE__{name.upper()}` is set, return the value it is set to for the experiment with that name

self-hosted users or users on dedicated enterprise instances may want to turn some of these knobs but may not want to use (or have access to) the Django Admin UI for configuring feature variants

https://github.com/codecov/worker/pull/373 is the experiment that we want this for initially. at least one environment is interested in raising this value without waiting on us to follow through on a whole experiment + cleanup to get whatever we decide

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.