### PR TITLE
Use jwt instead of self.token

### DIFF
--- a/shared/torngit/github.py
+++ b/shared/torngit/github.py
@@ -885,7 +885,7 @@ class Github(TorngitBaseAdapter):
         url = f"/app/installations/{installation_id}"
         headers = {
             "Accept": "application/vnd.github+json",
-            "Authorization": f"Bearer {self.token['key']}",
+            "Authorization": f"Bearer {jwt_token}",
             "X-GitHub-Api-Version": "2022-11-28",
         }
 


### PR DESCRIPTION
<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.