### PR TITLE
add github api call counter

### DIFF
--- a/shared/torngit/base.py
+++ b/shared/torngit/base.py
@@ -50,33 +50,6 @@ class TorngitBaseAdapter(object):
         "xtend",
     )
 
-    def get_client(self, timeouts: List[int] = []) -> httpx.AsyncClient:
-        if timeouts:
-            timeout = httpx.Timeout(timeouts[1], connect=timeouts[0])
-        else:
-            timeout = httpx.Timeout(self._timeouts[1], connect=self._timeouts[0])
-        return httpx.AsyncClient(
-            verify=self.verify_ssl
-            if not isinstance(self.verify_ssl, bool)
-            else self.verify_ssl,
-            timeout=timeout,
-        )
-
-    def get_token_by_type(self, token_type: TokenType):
-        if self._token_type_mapping.get(token_type) is not None:
-            return self._token_type_mapping.get(token_type)
-        return self.token
-
-    def get_token_by_type_if_none(self, token: Optional[str], token_type: TokenType):
-        if token is not None:
-            return token
-        return self.get_token_by_type(token_type)
-
-    def _oauth_consumer_token(self):
-        if not self._oauth:
-            raise Exception("Oauth consumer token not present")
-        return self._oauth
-
     def __init__(
         self,
         oauth_consumer_token: OauthConsumerToken = None,
@@ -106,6 +79,33 @@ class TorngitBaseAdapter(object):
             self.data["owner"].get("ownerid"),
             self.data["repo"].get("repoid"),
         )
+
+    def get_client(self, timeouts: List[int] = []) -> httpx.AsyncClient:
+        if timeouts:
+            timeout = httpx.Timeout(timeouts[1], connect=timeouts[0])
+        else:
+            timeout = httpx.Timeout(self._timeouts[1], connect=self._timeouts[0])
+        return httpx.AsyncClient(
+            verify=self.verify_ssl
+            if not isinstance(self.verify_ssl, bool)
+            else self.verify_ssl,
+            timeout=timeout,
+        )
+
+    def get_token_by_type(self, token_type: TokenType):
+        if self._token_type_mapping.get(token_type) is not None:
+            return self._token_type_mapping.get(token_type)
+        return self.token
+
+    def get_token_by_type_if_none(self, token: Optional[str], token_type: TokenType):
+        if token is not None:
+            return token
+        return self.get_token_by_type(token_type)
+
+    def _oauth_consumer_token(self):
+        if not self._oauth:
+            raise Exception("Oauth consumer token not present")
+        return self._oauth
 
     def _validate_language(self, language):
         if language:

--- a/shared/torngit/github.py
+++ b/shared/torngit/github.py
@@ -43,6 +43,15 @@ GITHUB_API_CALL_COUNTER = Counter(
     ["endpoint"],
 )
 
+GITHUB_API_ENDPOINTS = {
+    "test_2": GITHUB_API_CALL_COUNTER.labels(endpoint="test_2"),
+    "test_4": GITHUB_API_CALL_COUNTER.labels(endpoint="test_4"),
+}
+
+GITHUB_API_CALL_COUNTER.labels(endpoint="test_3")
+GITHUB_API_CALL_COUNTER.labels(endpoint="test_3").inc()
+GITHUB_API_ENDPOINTS["test_4"].inc()
+
 
 class GitHubGraphQLQueries(object):
     _queries = dict(
@@ -146,6 +155,7 @@ class Github(TorngitBaseAdapter):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         # call each counter/label combination to initialize it
+        GITHUB_API_CALL_COUNTER.labels(endpoint="test_1")
         self.github_request_webhook_redelivery_call_counter = (
             GITHUB_API_CALL_COUNTER.labels(endpoint="request_webhook_redelivery")
         )

--- a/shared/torngit/github.py
+++ b/shared/torngit/github.py
@@ -12,7 +12,7 @@ from httpx import Response
 
 from shared.config import get_config
 from shared.github import get_github_jwt_token
-from shared.metrics import metrics
+from shared.metrics import Counter, metrics
 from shared.torngit.base import TokenType, TorngitBaseAdapter
 from shared.torngit.cache import torngit_cache
 from shared.torngit.enums import Endpoints
@@ -35,6 +35,13 @@ from shared.utils.urls import url_concat
 log = logging.getLogger(__name__)
 
 METRICS_PREFIX = "services.torngit.github"
+
+
+GITHUB_API_CALL_COUNTER = Counter(
+    "git_provider_api_calls_github",
+    "Number of times github called this endpoint",
+    ["endpoint"],
+)
 
 
 class GitHubGraphQLQueries(object):
@@ -135,22 +142,166 @@ query Repos($owner: String!, $cursor: String, $first: Int!) {
 class Github(TorngitBaseAdapter):
     service = "github"
     graphql = GitHubGraphQLQueries()
-    urls = dict(
-        repo="{username}/{name}",
-        owner="{username}",
-        user="{username}",
-        issues="{username}/{name}/issues/%(issueid)s",
-        commit="{username}/{name}/commit/{commitid}",
-        commits="{username}/{name}/commits",
-        compare="{username}/{name}/compare/%(base)s...%(head)s",
-        comment="{username}/{name}/issues/%(pullid)s#issuecomment-%(commentid)s",
-        create_file="{username}/{name}/new/%(branch)s?filename=%(path)s&value=%(content)s",
-        pull="{username}/{name}/pull/%(pullid)s",
-        branch="{username}/{name}/tree/%(branch)s",
-        tree="{username}/{name}/tree/%(commitid)s",
-        src="{username}/{name}/blob/%(commitid)s/%(path)s",
-        author="{username}/{name}/commits?author=%(author)s",
-    )
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        # call each counter/label combination to initialize it
+        self.github_request_webhook_redelivery_call_counter = (
+            GITHUB_API_CALL_COUNTER.labels(endpoint="request_webhook_redelivery")
+        )
+        self.github_refresh_token_call_counter = GITHUB_API_CALL_COUNTER.labels(
+            endpoint="refresh_token"
+        )
+        self.github_make_http_call_retry_call_counter = GITHUB_API_CALL_COUNTER.labels(
+            endpoint="make_http_call_retry"
+        )
+        self.github_list_webhook_deliveries_call_counter = (
+            GITHUB_API_CALL_COUNTER.labels(endpoint="list_webhook_deliveries")
+        )
+        self.github_is_student_call_counter = GITHUB_API_CALL_COUNTER.labels(
+            endpoint="is_student"
+        )
+        self.github_get_best_effort_branches_call_counter = (
+            GITHUB_API_CALL_COUNTER.labels(endpoint="get_best_effort_branches")
+        )
+        self.github_get_workflow_run_call_counter = GITHUB_API_CALL_COUNTER.labels(
+            endpoint="get_workflow_run"
+        )
+        self.github_update_check_run_call_counter = GITHUB_API_CALL_COUNTER.labels(
+            endpoint="update_check_run"
+        )
+        self.github_get_repos_with_languages_graphql_call_counter = (
+            GITHUB_API_CALL_COUNTER.labels(endpoint="get_repos_with_languages_graphql")
+        )
+        self.github_get_repo_languages_call_counter = GITHUB_API_CALL_COUNTER.labels(
+            endpoint="get_repo_languages"
+        )
+        self.github_get_check_suites_call_counter = GITHUB_API_CALL_COUNTER.labels(
+            endpoint="get_check_suites"
+        )
+        self.github_get_check_runs_call_counter = GITHUB_API_CALL_COUNTER.labels(
+            endpoint="get_check_runs"
+        )
+        self.github_create_check_run_call_counter = GITHUB_API_CALL_COUNTER.labels(
+            endpoint="create_check_run"
+        )
+        self.github_get_ancestors_tree_call_counter = GITHUB_API_CALL_COUNTER.labels(
+            endpoint="get_ancestors_tree"
+        )
+        self.github_list_files_call_counter = GITHUB_API_CALL_COUNTER.labels(
+            endpoint="list_files"
+        )
+        self.github_get_pull_request_files_call_counter = (
+            GITHUB_API_CALL_COUNTER.labels(endpoint="get_pull_request_files")
+        )
+        self.github_find_pull_request_call_counter = GITHUB_API_CALL_COUNTER.labels(
+            endpoint="find_pull_request"
+        )
+        self.github_get_pull_requests_call_counter = GITHUB_API_CALL_COUNTER.labels(
+            endpoint="get_pull_requests"
+        )
+        self.github_get_pull_request_call_counter = GITHUB_API_CALL_COUNTER.labels(
+            endpoint="get_pull_request"
+        )
+        self.github_get_distance_in_commits_call_counter = (
+            GITHUB_API_CALL_COUNTER.labels(endpoint="get_distance_in_commits")
+        )
+        self.github_get_compare_call_counter = GITHUB_API_CALL_COUNTER.labels(
+            endpoint="get_compare"
+        )
+        self.github_get_commit_diff_call_counter = GITHUB_API_CALL_COUNTER.labels(
+            endpoint="get_commit_diff"
+        )
+        self.github_get_source_call_counter = GITHUB_API_CALL_COUNTER.labels(
+            endpoint="get_source"
+        )
+        self.github_get_source_content_call_counter = GITHUB_API_CALL_COUNTER.labels(
+            endpoint="get_source_content"
+        )
+        self.github_get_commit_statuses_call_counter = GITHUB_API_CALL_COUNTER.labels(
+            endpoint="get_commit_statuses"
+        )
+        self.github_set_commit_status_call_counter = GITHUB_API_CALL_COUNTER.labels(
+            endpoint="set_commit_status"
+        )
+        self.github_set_commit_status_merge_commit_call_counter = (
+            GITHUB_API_CALL_COUNTER.labels(endpoint="set_commit_status_merge_commit")
+        )
+        self.github_delete_comment_call_counter = GITHUB_API_CALL_COUNTER.labels(
+            endpoint="delete_comment"
+        )
+        self.github_edit_comment_call_counter = GITHUB_API_CALL_COUNTER.labels(
+            endpoint="edit_comment"
+        )
+        self.github_post_comment_call_counter = GITHUB_API_CALL_COUNTER.labels(
+            endpoint="post_comment"
+        )
+        self.github_delete_webhook_call_counter = GITHUB_API_CALL_COUNTER.labels(
+            endpoint="delete_webhook"
+        )
+        self.github_edit_webhook_call_counter = GITHUB_API_CALL_COUNTER.labels(
+            endpoint="edit_webhook"
+        )
+        self.github_post_webhook_call_counter = GITHUB_API_CALL_COUNTER.labels(
+            endpoint="post_webhook"
+        )
+        self.github_get_raw_pull_request_commits_call_counter = (
+            GITHUB_API_CALL_COUNTER.labels(endpoint="get_raw_pull_request_commits")
+        )
+        self.github_list_teams_call_counter = GITHUB_API_CALL_COUNTER.labels(
+            endpoint="list_teams"
+        )
+        self.github_list_teams_org_name_call_counter = GITHUB_API_CALL_COUNTER.labels(
+            endpoint="list_teams_org_name"
+        )
+        self.github_get_gh_app_installation_call_counter = (
+            GITHUB_API_CALL_COUNTER.labels(endpoint="get_gh_app_installation")
+        )
+        self.github_get_repos_from_nodeids_generator_graphql_call_counter = (
+            GITHUB_API_CALL_COUNTER.labels(
+                endpoint="get_repos_from_nodeids_generator_graphql"
+            )
+        )
+        self.github_get_owner_from_nodeid_graphql_call_counter = (
+            GITHUB_API_CALL_COUNTER.labels(endpoint="get_owner_from_nodeid_graphql")
+        )
+        self.github_fetch_number_of_repos_graphql_call_counter = (
+            GITHUB_API_CALL_COUNTER.labels(endpoint="fetch_number_of_repos_graphql")
+        )
+        self.github_fetch_page_of_repos_call_counter = GITHUB_API_CALL_COUNTER.labels(
+            endpoint="fetch_page_of_repos"
+        )
+        self.github_fetch_page_of_repos_using_installation_call_counter = (
+            GITHUB_API_CALL_COUNTER.labels(
+                endpoint="fetch_page_of_repos_using_installation"
+            )
+        )
+        self.github_get_repository_call_counter = GITHUB_API_CALL_COUNTER.labels(
+            endpoint="get_repository"
+        )
+        self.github_get_authenticated_call_counter = GITHUB_API_CALL_COUNTER.labels(
+            endpoint="get_authenticated"
+        )
+        self.github_get_is_admin_call_counter = GITHUB_API_CALL_COUNTER.labels(
+            endpoint="get_is_admin"
+        )
+        self.github_get_authenticated_user_call_counter = (
+            GITHUB_API_CALL_COUNTER.labels(endpoint="get_authenticated_user")
+        )
+        self.github_get_authenticated_user_get_user_call_counter = (
+            GITHUB_API_CALL_COUNTER.labels(endpoint="get_authenticated_user_get_user")
+        )
+        self.github_get_authenticated_user_get_user_email_call_counter = (
+            GITHUB_API_CALL_COUNTER.labels(
+                endpoint="get_authenticated_user_get_user_email"
+            )
+        )
+        self.github_get_branch_call_counter = GITHUB_API_CALL_COUNTER.labels(
+            endpoint="get_branch"
+        )
+        self.github_get_branches_call_counter = GITHUB_API_CALL_COUNTER.labels(
+            endpoint="get_branches"
+        )
 
     @classmethod
     def get_service_url(cls):
@@ -166,29 +317,29 @@ class Github(TorngitBaseAdapter):
             "/"
         )
 
+    @property
+    def api_url(self):
+        return self.get_api_url()
+
     @classmethod
     def get_api_host_header(cls):
         return get_config(cls.service, "api_host_override")
+
+    @property
+    def api_host_header(self):
+        return self.get_api_host_header()
 
     @classmethod
     def get_host_header(cls):
         return get_config(cls.service, "host_override")
 
     @property
-    def api_url(self):
-        return self.get_api_url()
+    def host_header(self):
+        return self.get_host_header()
 
     @property
     def token(self):
         return self._token
-
-    @property
-    def api_host_header(self):
-        return self.get_api_host_header()
-
-    @property
-    def host_header(self):
-        return self.get_host_header()
 
     async def api(self, *args, token=None, **kwargs):
         """
@@ -223,6 +374,7 @@ class Github(TorngitBaseAdapter):
         url = initial_url
         while url:
             args = [client, method, url]
+            self.github_list_webhook_deliveries_call_counter.inc()
             response = await self.make_http_call(
                 *args, token_to_use=token_to_use, **kwargs
             )
@@ -299,6 +451,8 @@ class Github(TorngitBaseAdapter):
             try:
                 with metrics.timer(f"{METRICS_PREFIX}.api.run") as timer:
                     res = await client.request(method, url, **kwargs)
+                    if current_retry > 1:
+                        self.github_make_http_call_retry_call_counter.inc()
                 logged_body = None
                 if res.status_code >= 300 and res.text is not None:
                     logged_body = res.text
@@ -434,6 +588,7 @@ class Github(TorngitBaseAdapter):
                 **creds_to_send,
             )
         )
+        self.github_refresh_token_call_counter.inc()
         res = await client.request(
             "POST",
             self.service_url + "/login/oauth/access_token",
@@ -481,6 +636,7 @@ class Github(TorngitBaseAdapter):
             branches = []
             while True:
                 page += 1
+                self.github_get_branches_call_counter.inc()
                 res = await self.api(
                     client,
                     "get",
@@ -498,8 +654,8 @@ class Github(TorngitBaseAdapter):
 
     async def get_branch(self, branch_name: str, token=None):
         async with self.get_client() as client:
-            token = self.get_token_by_type_if_none(token, TokenType.read)
             # https://docs.github.com/en/rest/branches/branches?apiVersion=2022-11-28#get-a-branch
+            self.github_get_branch_call_counter.inc()
             res = await self.api(
                 client,
                 "get",
@@ -509,6 +665,7 @@ class Github(TorngitBaseAdapter):
 
     async def get_authenticated_user(self, code):
         creds = self._oauth_consumer_token()
+        self.github_get_authenticated_user_call_counter.inc()
         async with self.get_client() as client:
             response = await self.make_http_call(
                 client,
@@ -531,10 +688,12 @@ class Github(TorngitBaseAdapter):
                     )
                 )
 
+                self.github_get_authenticated_user_get_user_call_counter.inc()
                 user = await self.api(client, "get", "/user")
                 user.update(session or {})
                 email = user.get("email")
                 if not email:
+                    self.github_get_authenticated_user_get_user_email_call_counter.inc()
                     emails = await self.api(client, "get", "/user/emails")
                     emails = [e["email"] for e in emails if e["primary"]]
                     user["email"] = emails[0] if emails else None
@@ -556,6 +715,7 @@ class Github(TorngitBaseAdapter):
     async def get_is_admin(self, user, token=None):
         async with self.get_client() as client:
             # https://developer.github.com/v3/orgs/members/#get-organization-membership
+            self.github_get_is_admin_call_counter.inc()
             res = await self.api(
                 client,
                 "get",
@@ -569,6 +729,7 @@ class Github(TorngitBaseAdapter):
         """Returns (can_view, can_edit)"""
         # https://developer.github.com/v3/repos/#get
         async with self.get_client() as client:
+            self.github_get_authenticated_call_counter.inc()
             r = await self.api(client, "get", "/repos/%s" % self.slug, token=token)
             ok = r["permissions"]["admin"] or r["permissions"]["push"]
             return (True, ok)
@@ -578,10 +739,12 @@ class Github(TorngitBaseAdapter):
         async with self.get_client() as client:
             if self.data["repo"].get("service_id") is None:
                 # https://developer.github.com/v3/repos/#get
+                self.github_get_repository_call_counter.inc()  # else block uses same counter
                 res = await self.api(
                     client, "get", "/repos/%s" % self.slug, token=token
                 )
             else:
+                self.github_get_repository_call_counter.inc()  # if block uses same counter
                 res = await self.api(
                     client,
                     "get",
@@ -643,6 +806,7 @@ class Github(TorngitBaseAdapter):
         self, client, page_size=100, page=0
     ):
         # https://docs.github.com/en/rest/apps/installations?apiVersion=2022-11-28
+        self.github_fetch_page_of_repos_using_installation_call_counter.inc()
         res = await self.api(
             client,
             "get",
@@ -668,6 +832,7 @@ class Github(TorngitBaseAdapter):
     ):
         # https://developer.github.com/v3/repos/#list-your-repositories
         if username is None:
+            self.github_fetch_page_of_repos_call_counter.inc()  # else block uses same counter
             repos = await self.api(
                 client,
                 "get",
@@ -675,6 +840,7 @@ class Github(TorngitBaseAdapter):
                 token=token,
             )
         else:
+            self.github_fetch_page_of_repos_call_counter.inc()  # if block uses same counter
             repos = await self.api(
                 client,
                 "get",
@@ -695,6 +861,7 @@ class Github(TorngitBaseAdapter):
         return self._process_repository_page(repos)
 
     async def _fetch_number_of_repos(self, client, token):
+        self.github_fetch_number_of_repos_graphql_call_counter.inc()
         res = await self.api(
             client,
             "post",
@@ -708,6 +875,7 @@ class Github(TorngitBaseAdapter):
         query = self.graphql.prepare(
             "OWNER_FROM_NODEID", variables={"node_id": owner_node_id}
         )
+        self.github_get_owner_from_nodeid_graphql_call_counter.inc()
         res = await self.api(
             client,
             "post",
@@ -740,6 +908,7 @@ class Github(TorngitBaseAdapter):
                 query = self.graphql.prepare(
                     "REPOS_FROM_NODEIDS", variables={"node_ids": chunk}
                 )
+                self.github_get_repos_from_nodeids_generator_graphql_call_counter.inc()
                 res = await self.api(
                     client,
                     "post",
@@ -891,6 +1060,7 @@ class Github(TorngitBaseAdapter):
 
         async with self.get_client() as client:
             try:
+                self.github_get_gh_app_installation_call_counter.inc()
                 return await self.api(
                     client,
                     "get",
@@ -913,6 +1083,7 @@ class Github(TorngitBaseAdapter):
         async with self.get_client() as client:
             while True:
                 page += 1
+                self.github_list_teams_call_counter.inc()
                 orgs = await self.api(
                     client,
                     "get",
@@ -926,6 +1097,7 @@ class Github(TorngitBaseAdapter):
                 for org in orgs:
                     try:
                         organization = org["organization"]
+                        self.github_list_teams_org_name_call_counter.inc()
                         org = await self.api(
                             client,
                             "get",
@@ -966,6 +1138,7 @@ class Github(TorngitBaseAdapter):
         MAX_RESULTS_PER_PAGE = 100
         async with self.get_client() as client:
             for page_number in [1, 2, 3]:
+                self.github_get_raw_pull_request_commits_call_counter.inc()
                 page_results = await self.api(
                     client,
                     "get",
@@ -985,6 +1158,7 @@ class Github(TorngitBaseAdapter):
         token = self.get_token_by_type_if_none(token, TokenType.admin)
         # https://developer.github.com/v3/repos/hooks/#create-a-hook
         async with self.get_client() as client:
+            self.github_post_webhook_call_counter.inc()
             res = await self.api(
                 client,
                 "post",
@@ -1004,6 +1178,7 @@ class Github(TorngitBaseAdapter):
         # https://developer.github.com/v3/repos/hooks/#edit-a-hook
         try:
             async with self.get_client() as client:
+                self.github_edit_webhook_call_counter.inc()
                 return await self.api(
                     client,
                     "patch",
@@ -1029,6 +1204,7 @@ class Github(TorngitBaseAdapter):
         # https://developer.github.com/v3/repos/hooks/#delete-a-hook
         try:
             async with self.get_client() as client:
+                self.github_delete_webhook_call_counter.inc()
                 await self.api(
                     client,
                     "delete",
@@ -1050,6 +1226,7 @@ class Github(TorngitBaseAdapter):
         token = self.get_token_by_type_if_none(token, TokenType.comment)
         # https://developer.github.com/v3/issues/comments/#create-a-comment
         async with self.get_client() as client:
+            self.github_post_comment_call_counter.inc()
             res = await self.api(
                 client,
                 "post",
@@ -1064,13 +1241,15 @@ class Github(TorngitBaseAdapter):
         # https://developer.github.com/v3/issues/comments/#edit-a-comment
         try:
             async with self.get_client() as client:
-                return await self.api(
+                self.github_edit_comment_call_counter.inc()
+                res = await self.api(
                     client,
                     "patch",
                     "/repos/%s/issues/comments/%s" % (self.slug, commentid),
                     body=dict(body=body),
                     token=token,
                 )
+                return res
         except TorngitClientError as ce:
             if ce.code == 404:
                 raise TorngitObjectNotFoundError(
@@ -1084,6 +1263,7 @@ class Github(TorngitBaseAdapter):
         # https://developer.github.com/v3/issues/comments/#delete-a-comment
         try:
             async with self.get_client() as client:
+                self.github_delete_comment_call_counter.inc()
                 await self.api(
                     client,
                     "delete",
@@ -1117,6 +1297,7 @@ class Github(TorngitBaseAdapter):
         assert status in ("pending", "success", "error", "failure"), "status not valid"
         async with self.get_client() as client:
             try:
+                self.github_set_commit_status_call_counter.inc()
                 res = await self.api(
                     client,
                     "post",
@@ -1132,6 +1313,7 @@ class Github(TorngitBaseAdapter):
             except TorngitClientError as ce:
                 raise
             if merge_commit:
+                self.github_set_commit_status_merge_commit_call_counter.inc()
                 await self.api(
                     client,
                     "post",
@@ -1159,6 +1341,7 @@ class Github(TorngitBaseAdapter):
             while True:
                 page += 1
                 # https://developer.github.com/v3/repos/statuses/#list-statuses-for-a-specific-ref
+                self.github_get_commit_statuses_call_counter.inc()
                 res = await self.api(
                     client,
                     "get",
@@ -1191,6 +1374,7 @@ class Github(TorngitBaseAdapter):
         # https://developer.github.com/v3/repos/contents/#get-contents
         try:
             async with self.get_client() as client:
+                self.github_get_source_call_counter.inc()
                 content = await self.api(
                     client,
                     "get",
@@ -1208,6 +1392,7 @@ class Github(TorngitBaseAdapter):
                     and content.get("download_url")
                     and content.get("encoding") == "none"
                 ):
+                    self.github_get_source_content_call_counter.inc()
                     content["content"] = await self.api(
                         client=client, method="get", url=content["download_url"]
                     )
@@ -1229,6 +1414,7 @@ class Github(TorngitBaseAdapter):
         # https://developer.github.com/v3/repos/commits/#get-a-single-commit
         try:
             async with self.get_client() as client:
+                self.github_get_commit_diff_call_counter.inc()
                 res = await self.api(
                     client,
                     "get",
@@ -1256,6 +1442,7 @@ class Github(TorngitBaseAdapter):
         token = self.get_token_by_type_if_none(token, TokenType.read)
         # https://developer.github.com/v3/repos/commits/#compare-two-commits
         async with self.get_client() as client:
+            self.github_get_compare_call_counter.inc()
             res = await self.api(
                 client,
                 "get",
@@ -1318,6 +1505,7 @@ class Github(TorngitBaseAdapter):
         token = self.get_token_by_type_if_none(token, TokenType.read)
         # https://developer.github.com/v3/repos/commits/#compare-two-commits
         async with self.get_client() as client:
+            self.github_get_distance_in_commits_call_counter.inc()
             res = await self.api(
                 client,
                 "get",
@@ -1409,6 +1597,7 @@ class Github(TorngitBaseAdapter):
         # https://developer.github.com/v3/pulls/#get-a-single-pull-request
         async with self.get_client() as client:
             try:
+                self.github_get_pull_request_call_counter.inc()
                 res = await self.api(
                     client,
                     "get",
@@ -1463,6 +1652,7 @@ class Github(TorngitBaseAdapter):
         async with self.get_client() as client:
             while True:
                 page += 1
+                self.github_get_pull_requests_call_counter.inc()
                 res = await self.api(
                     client,
                     "get",
@@ -1491,6 +1681,7 @@ class Github(TorngitBaseAdapter):
         async with self.get_client() as client:
             # https://docs.github.com/en/rest/commits/commits#list-pull-requests-associated-with-a-commit
             try:
+                self.github_find_pull_request_call_counter.inc()
                 res = await self.api(
                     client,
                     "get",
@@ -1524,6 +1715,7 @@ class Github(TorngitBaseAdapter):
         async with self.get_client() as client:
             # https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#list-pull-requests-files
             try:
+                self.github_get_pull_request_files_call_counter.inc()
                 res = await self.api(
                     client,
                     "get",
@@ -1551,6 +1743,7 @@ class Github(TorngitBaseAdapter):
         else:
             url = f"/repos/{self.slug}/contents"
         async with self.get_client() as client:
+            self.github_list_files_call_counter.inc()
             content = await self.api(client, "get", url, ref=ref, token=token)
         return [
             {
@@ -1571,6 +1764,7 @@ class Github(TorngitBaseAdapter):
     async def get_ancestors_tree(self, commitid, token=None):
         token = self.get_token_by_type_if_none(token, TokenType.read)
         async with self.get_client() as client:
+            self.github_get_ancestors_tree_call_counter.inc()
             res = await self.api(
                 client,
                 "get",
@@ -1584,7 +1778,7 @@ class Github(TorngitBaseAdapter):
 
     def get_external_endpoint(self, endpoint: Endpoints, **kwargs):
         if endpoint == Endpoints.commit_detail:
-            return self.urls["commit"].format(
+            return "{username}/{name}/commit/{commitid}".format(
                 username=self.data["owner"]["username"],
                 name=self.data["repo"]["name"],
                 commitid=kwargs["commitid"],
@@ -1597,6 +1791,7 @@ class Github(TorngitBaseAdapter):
         self, check_name, head_sha, status="in_progress", token=None
     ):
         async with self.get_client() as client:
+            self.github_create_check_run_call_counter.inc()
             res = await self.api(
                 client,
                 "post",
@@ -1633,11 +1828,13 @@ class Github(TorngitBaseAdapter):
         if name is not None:
             url += "?check_name={}".format(name)
         async with self.get_client() as client:
+            self.github_get_check_runs_call_counter.inc()
             res = await self.api(client, "get", url, token=token)
             return res
 
     async def get_check_suites(self, git_sha, token=None):
         async with self.get_client() as client:
+            self.github_get_check_suites_call_counter.inc()
             res = await self.api(
                 client,
                 "get",
@@ -1655,6 +1852,7 @@ class Github(TorngitBaseAdapter):
         Returns:
             List[str]: A list of language names
         """
+        self.github_get_repo_languages_call_counter.inc()
         async with self.get_client() as client:
             res = await self.api(
                 client, "get", "/repos/{}/languages".format(self.slug), token=token
@@ -1687,6 +1885,7 @@ class Github(TorngitBaseAdapter):
                         "first": first,
                     },
                 )
+                self.github_get_repos_with_languages_graphql_call_counter.inc()
                 res = await self.api(
                     client,
                     "post",
@@ -1725,6 +1924,7 @@ class Github(TorngitBaseAdapter):
         if url:
             body["details_url"] = url
         async with self.get_client() as client:
+            self.github_update_check_run_call_counter.inc()
             res = await self.api(
                 client,
                 "patch",
@@ -1761,6 +1961,7 @@ class Github(TorngitBaseAdapter):
         Run = one instance when the workflow was triggered
         """
         async with self.get_client() as client:
+            self.github_get_workflow_run_call_counter.inc()
             res = await self.api(
                 client,
                 "get",
@@ -1817,6 +2018,7 @@ class Github(TorngitBaseAdapter):
         token = self.get_token_by_type_if_none(token, TokenType.read)
         url = f"/repos/{self.slug}/commits/{commit_sha}/branches-where-head"
         async with self.get_client() as client:
+            self.github_get_best_effort_branches_call_counter.inc()
             res = await self.api(
                 client,
                 "get",
@@ -1829,12 +2031,13 @@ class Github(TorngitBaseAdapter):
     async def is_student(self):
         async with self.get_client([3, 3]) as client:
             try:
+                self.github_is_student_call_counter.inc()
                 res = await self.api(
                     client, "get", "https://education.github.com/api/user"
                 )
                 return res["student"]
             except TorngitServerUnreachableError:
-                log.warn("Timeout on Github Education API for is_student")
+                log.warning("Timeout on Github Education API for is_student")
                 return False
             except (TorngitUnauthorizedError, TorngitServer5xxCodeError):
                 return False
@@ -1876,6 +2079,7 @@ class Github(TorngitBaseAdapter):
         }
         async with self.get_client() as client:
             try:
+                self.github_request_webhook_redelivery_call_counter.inc()
                 await self.api(client, "post", url, headers=headers)
                 return True
             except (TorngitClientError, TorngitServer5xxCodeError):

--- a/tests/unit/torngit/test_github.py
+++ b/tests/unit/torngit/test_github.py
@@ -7,10 +7,10 @@ import httpx
 import pytest
 import respx
 from mock import MagicMock
+from prometheus_client import REGISTRY
 
 from shared.torngit.base import TokenType
 from shared.torngit.exceptions import (
-    TorngitCantRefreshTokenError,
     TorngitClientError,
     TorngitClientGeneralError,
     TorngitMisconfiguredCredentials,
@@ -63,7 +63,7 @@ def ghapp_handler():
 # to the tests that we want to see if Github refreshes the tokens
 # other tests won't retry to refresh (cause the handlers dont have callbacks by default)
 async def token_refresh_fake_callback(new_token: Dict) -> None:
-    print("Saving new token after refresh")
+    pass
 
 
 class TestUnitGithub(object):
@@ -193,11 +193,9 @@ class TestUnitGithub(object):
         assert res == "kowabunga"
         assert client.request.call_count == 1
         args, kwargs = client.request.call_args
-        print(args)
         assert len(args) == 2
         built_url = args[1]
         parsed_url = urlparse(built_url)
-        print(parsed_url)
         assert parsed_url.scheme == "https"
         assert parsed_url.netloc == "api.github.com"
         assert parsed_url.path == url
@@ -228,14 +226,11 @@ class TestUnitGithub(object):
         assert res == "kowabunga"
         assert client.request.call_count == 1
         args, kwargs = client.request.call_args
-        print(args)
-        print(kwargs)
         assert kwargs.get("headers") is not None
         assert kwargs.get("headers").get("Host") == "api.github.com"
         assert len(args) == 2
         built_url = args[1]
         parsed_url = urlparse(built_url)
-        print(parsed_url)
         assert parsed_url.scheme == "https"
         assert parsed_url.netloc == mock_host
         assert parsed_url.path == url
@@ -262,14 +257,11 @@ class TestUnitGithub(object):
         await valid_handler.make_http_call(client, method, url, **query_params)
         assert client.request.call_count == 1
         args, kwargs = client.request.call_args
-        print(args)
-        print(kwargs)
         assert kwargs.get("headers") is not None
         assert kwargs.get("headers").get("Host") == "github.com"
         assert len(args) == 2
         built_url = args[1]
         parsed_url = urlparse(built_url)
-        print(parsed_url)
         assert parsed_url.scheme == "https"
         assert parsed_url.netloc == mock_host
         assert parsed_url.path == "/random_url"
@@ -412,6 +404,10 @@ class TestUnitGithub(object):
 
     @pytest.mark.asyncio
     async def test_find_pull_request_success(self, mocker):
+        before = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total",
+            labels={"endpoint": "find_pull_request"},
+        )
         handler = Github(
             repo=dict(name="repo_name"),
             owner=dict(username="username"),
@@ -481,9 +477,18 @@ class TestUnitGithub(object):
                     state="open",
                 ),
             )
+            after = REGISTRY.get_sample_value(
+                "git_provider_api_calls_github_total",
+                labels={"endpoint": "find_pull_request"},
+            )
+            assert after - before == 1
 
     @pytest.mark.asyncio
     async def test_find_pr_by_pulls_failfast_if_no_commit(self, mocker):
+        before = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total",
+            labels={"endpoint": "find_pull_request"},
+        )
         handler = Github(
             repo=dict(name="repo_name"),
             owner=dict(username="username"),
@@ -491,9 +496,18 @@ class TestUnitGithub(object):
         )
         res = await handler.find_pull_request(commit=None)
         assert res is None
+        after = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total",
+            labels={"endpoint": "find_pull_request"},
+        )
+        assert after - before == 0
 
     @pytest.mark.asyncio
     async def test_find_pr_by_pulls_failfast_if_no_slug(self, mocker):
+        before = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total",
+            labels={"endpoint": "find_pull_request"},
+        )
         handler = Github(
             owner=dict(username="username"),
             token=dict(key="aaaaa"),
@@ -502,9 +516,18 @@ class TestUnitGithub(object):
         assert handler.slug is None
         res = await handler.find_pull_request(None, commit_sha, None)
         assert res is None
+        after = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total",
+            labels={"endpoint": "find_pull_request"},
+        )
+        assert after - before == 0
 
     @pytest.mark.asyncio
     async def test_find_pr_by_pulls_raise_exp_if_not_422(self, mocker):
+        before = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total",
+            labels={"endpoint": "find_pull_request"},
+        )
         handler = Github(
             repo=dict(name="repo_name"),
             owner=dict(username="username"),
@@ -522,13 +545,22 @@ class TestUnitGithub(object):
                     headers={"Content-Type": "application/json; charset=utf-8"},
                 )
             )
-            client = handler.get_client()
             token = handler.get_token_by_type(TokenType.read)
             with pytest.raises(TorngitClientGeneralError):
                 await handler.find_pull_request(commit=commit_sha, token=token)
+            after = REGISTRY.get_sample_value(
+                "git_provider_api_calls_github_total",
+                labels={"endpoint": "find_pull_request"},
+            )
+            assert after - before == 1
 
     @pytest.mark.asyncio
     async def test_distance_in_commits(self, mocker):
+
+        before = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total",
+            labels={"endpoint": "get_distance_in_commits"},
+        )
         handler = Github(
             repo=dict(name="repo_name"),
             owner=dict(username="username"),
@@ -566,9 +598,18 @@ class TestUnitGithub(object):
                 repos_default_branch, base_commit_sha
             )
             assert res == expected_result
+            after = REGISTRY.get_sample_value(
+                "git_provider_api_calls_github_total",
+                labels={"endpoint": "get_distance_in_commits"},
+            )
+            assert after - before == 1
 
     @pytest.mark.asyncio
     async def test_null_distance_in_commits(self, mocker):
+        before = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total",
+            labels={"endpoint": "get_distance_in_commits"},
+        )
         handler = Github(
             repo=dict(name="repo_name"),
             owner=dict(username="username"),
@@ -603,9 +644,17 @@ class TestUnitGithub(object):
                 repos_default_branch, base_commit_sha
             )
             assert res == expected_result
+            after = REGISTRY.get_sample_value(
+                "git_provider_api_calls_github_total",
+                labels={"endpoint": "get_distance_in_commits"},
+            )
+            assert after - before == 1
 
     @pytest.mark.asyncio
     async def test_post_comment(self, respx_vcr, valid_handler):
+        before = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total", labels={"endpoint": "post_comment"}
+        )
         mocked_response = respx_vcr.post(
             url="https://api.github.com/repos/ThiagoCodecov/example-python/issues/1/comments",
             json={"body": "Hello world"},
@@ -682,9 +731,20 @@ class TestUnitGithub(object):
         res = await valid_handler.post_comment("1", "Hello world")
         assert res == expected_result
         assert mocked_response.called is True
+        after = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total", labels={"endpoint": "post_comment"}
+        )
+        assert after - before == 1
 
     @pytest.mark.asyncio
     async def test_list_teams(self, valid_handler, respx_vcr):
+        before_first_call = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total", labels={"endpoint": "list_teams"}
+        )
+        before_second_call = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total",
+            labels={"endpoint": "list_teams_org_name"},
+        )
         mocked_response = respx_vcr.get(
             url="https://api.github.com/user/memberships/orgs?state=active&page=1"
         ).respond(
@@ -867,9 +927,25 @@ class TestUnitGithub(object):
         res = await valid_handler.list_teams()
         assert res == expected_result
         assert mocked_response.called is True
+        after_first_call = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total", labels={"endpoint": "list_teams"}
+        )
+        assert after_first_call - before_first_call == 1
+        after_second_call = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total",
+            labels={"endpoint": "list_teams_org_name"},
+        )
+        assert after_second_call - before_second_call == 2  # len(mocked_response[json]
 
     @pytest.mark.asyncio
     async def test_list_team_with_org_response_404(self, valid_handler, respx_vcr):
+        before_first_call = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total", labels={"endpoint": "list_teams"}
+        )
+        before_second_call = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total",
+            labels={"endpoint": "list_teams_org_name"},
+        )
         mocked_response = respx_vcr.get(
             url="https://api.github.com/user/memberships/orgs?state=active&page=1"
         ).respond(
@@ -927,9 +1003,22 @@ class TestUnitGithub(object):
         res = await valid_handler.list_teams()
         assert res == []
         assert mocked_response.called is True
+        after_first_call = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total", labels={"endpoint": "list_teams"}
+        )
+        assert after_first_call - before_first_call == 1
+        after_second_call = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total",
+            labels={"endpoint": "list_teams_org_name"},
+        )
+        assert after_second_call - before_second_call == 1  # len(mocked_response[json]
 
     @pytest.mark.asyncio
     async def test_update_check_run_no_url(self, valid_handler):
+        before = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total",
+            labels={"endpoint": "update_check_run"},
+        )
         with respx.mock:
             mocked_response = respx.patch(
                 url="https://api.github.com/repos/ThiagoCodecov/example-python/check-runs/1256232357",
@@ -946,9 +1035,18 @@ class TestUnitGithub(object):
             res = await valid_handler.update_check_run(1256232357, "success")
 
         assert mocked_response.call_count == 1
+        after = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total",
+            labels={"endpoint": "update_check_run"},
+        )
+        assert after - before == 1
 
     @pytest.mark.asyncio
     async def test_update_check_run_url(self, valid_handler):
+        before = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total",
+            labels={"endpoint": "update_check_run"},
+        )
         url = "https://app.codecov.io/gh/codecov/example-python/compare/1?src=pr"
         with respx.mock:
             mocked_response = respx.patch(
@@ -969,9 +1067,18 @@ class TestUnitGithub(object):
             )
             res = await valid_handler.update_check_run(1256232357, "success", url=url)
         assert mocked_response.call_count == 1
+        after = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total",
+            labels={"endpoint": "update_check_run"},
+        )
+        assert after - before == 1
 
     @pytest.mark.asyncio
     async def test_get_general_exception_pickle(self, valid_handler, mocker):
+        before = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total",
+            labels={"endpoint": "get_pull_requests"},
+        )
         mock_refresh = mocker.patch.object(Github, "refresh_token")
         valid_handler._on_token_refresh = token_refresh_fake_callback
         with respx.mock:
@@ -995,6 +1102,11 @@ class TestUnitGithub(object):
 
         assert mocked_response.call_count == 2
         assert mock_refresh.call_count == 1
+        after = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total",
+            labels={"endpoint": "get_pull_requests"},
+        )
+        assert after - before == 1
 
     @pytest.mark.asyncio
     async def test_api_no_token(self):
@@ -1013,6 +1125,11 @@ class TestUnitGithub(object):
 
     @pytest.mark.asyncio
     async def test_list_webhook_deliveries(self, ghapp_handler):
+        before = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total",
+            labels={"endpoint": "list_webhook_deliveries"},
+        )
+
         def side_effect(request):
             assert request.headers.get("Accept") == "application/vnd.github+json"
             assert (
@@ -1090,9 +1207,18 @@ class TestUnitGithub(object):
             async for res in ghapp_handler.list_webhook_deliveries():
                 assert len(res) == 4
         assert mocked_response.call_count == 1
+        after = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total",
+            labels={"endpoint": "list_webhook_deliveries"},
+        )
+        assert after - before == 1
 
     @pytest.mark.asyncio
     async def test_list_webhook_deliveries_multiple_pages(self, ghapp_handler):
+        before = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total",
+            labels={"endpoint": "list_webhook_deliveries"},
+        )
         with respx.mock:
             mocked_response_1 = respx.get(
                 url="https://api.github.com/app/hook/deliveries?per_page=50"
@@ -1178,10 +1304,19 @@ class TestUnitGithub(object):
         assert len(aggregate_res) == 4
         assert mocked_response_1.call_count == 1
         assert mocked_response_2.call_count == 1
+        after = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total",
+            labels={"endpoint": "list_webhook_deliveries"},
+        )
+        assert after - before == 2
 
     @pytest.mark.asyncio
     async def test_webhook_redelivery_success(self, ghapp_handler):
         delivery_id = 17323228732
+        before = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total",
+            labels={"endpoint": "request_webhook_redelivery"},
+        )
 
         def side_effect(request):
             assert request.headers.get("Accept") == "application/vnd.github+json"
@@ -1201,10 +1336,19 @@ class TestUnitGithub(object):
             ans = await ghapp_handler.request_webhook_redelivery(delivery_id)
             assert ans is True
         assert mocked_response.call_count == 1
+        after = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total",
+            labels={"endpoint": "request_webhook_redelivery"},
+        )
+        assert after - before == 1
 
     @pytest.mark.asyncio
     async def test_webhook_redelivery_fail(self, ghapp_handler):
         delivery_id = 17323228732
+        before = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total",
+            labels={"endpoint": "request_webhook_redelivery"},
+        )
         with respx.mock:
             mocked_response = respx.post(
                 url=f"https://api.github.com/app/hook/deliveries/{delivery_id}/attempts"
@@ -1216,9 +1360,18 @@ class TestUnitGithub(object):
             ans = await ghapp_handler.request_webhook_redelivery(delivery_id)
             assert ans is False
         assert mocked_response.call_count == 1
+        after = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total",
+            labels={"endpoint": "request_webhook_redelivery"},
+        )
+        assert after - before == 1
 
     @pytest.mark.asyncio
     async def test_get_pull_request_files_404(self, mocker):
+        before = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total",
+            labels={"endpoint": "get_pull_request_files"},
+        )
         mock_refresh = mocker.patch.object(Github, "refresh_token")
         with respx.mock:
             my_route = respx.get(
@@ -1243,9 +1396,18 @@ class TestUnitGithub(object):
             assert excinfo.value.code == 404
             assert excinfo.value.message == "PR with id 4 does not exist"
         assert mock_refresh.call_count == 1
+        after = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total",
+            labels={"endpoint": "get_pull_request_files"},
+        )
+        assert after - before == 1
 
     @pytest.mark.asyncio
     async def test_get_pull_request_files_403(self):
+        before = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total",
+            labels={"endpoint": "get_pull_request_files"},
+        )
         with respx.mock:
             my_route = respx.get(
                 "https://api.github.com/repos/codecove2e/example-python/pulls/4/files"
@@ -1267,9 +1429,18 @@ class TestUnitGithub(object):
                 res = await handler.get_pull_request_files(4)
             assert excinfo.value.code == 403
             assert excinfo.value.message == "Github API rate limit error: Forbidden"
+            after = REGISTRY.get_sample_value(
+                "git_provider_api_calls_github_total",
+                labels={"endpoint": "get_pull_request_files"},
+            )
+            assert after - before == 1
 
     @pytest.mark.asyncio
     async def test_get_pull_request_files_403_secondary_limit(self):
+        before = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total",
+            labels={"endpoint": "get_pull_request_files"},
+        )
         with respx.mock:
             my_route = respx.get(
                 "https://api.github.com/repos/codecove2e/example-python/pulls/4/files"
@@ -1294,11 +1465,19 @@ class TestUnitGithub(object):
                 == "Github API rate limit error: secondary rate limit"
             )
             assert excinfo.value.retry_after == 60
+            after = REGISTRY.get_sample_value(
+                "git_provider_api_calls_github_total",
+                labels={"endpoint": "get_pull_request_files"},
+            )
+            assert after - before == 1
 
     @pytest.mark.asyncio
     async def test_github_refresh_fail_terminates_unavailable(
         self, mocker, valid_handler
     ):
+        before = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total", labels={"endpoint": "refresh_token"}
+        )
         with pytest.raises(TorngitRefreshTokenFailedError) as exp:
             with respx.mock:
                 mocked_refresh = respx.post(
@@ -1313,11 +1492,18 @@ class TestUnitGithub(object):
                 )
             assert exp.code == 555
         assert mocked_refresh.call_count == 1
+        after = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total", labels={"endpoint": "refresh_token"}
+        )
+        assert after - before == 1
 
     @pytest.mark.asyncio
     async def test_github_refresh_fail_terminates_unauthorized(
         self, mocker, valid_handler
     ):
+        before = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total", labels={"endpoint": "refresh_token"}
+        )
         with pytest.raises(TorngitRefreshTokenFailedError) as exp:
             with respx.mock:
                 mocked_refresh = respx.post(
@@ -1332,6 +1518,10 @@ class TestUnitGithub(object):
                 )
             assert exp.code == 555
         assert mocked_refresh.call_count == 1
+        after = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total", labels={"endpoint": "refresh_token"}
+        )
+        assert after - before == 1
 
     @pytest.mark.asyncio
     async def test_github_refresh_fail_terminates_no_refresh_token(
@@ -1347,6 +1537,10 @@ class TestUnitGithub(object):
 
     @pytest.mark.asyncio
     async def test_gihub_double_refresh(self, mocker, valid_handler):
+        before = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total", labels={"endpoint": "refresh_token"}
+        )
+
         def side_effect(request, *args, **kwargs):
             url_parts = urlparse(str(request.url))
             query = url_parts.query
@@ -1390,9 +1584,17 @@ class TestUnitGithub(object):
 
         # Make sure that changing the token doesn't change the _oauth
         assert valid_handler._oauth == dict(key="client_id", secret="client_secret")
+        after = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total", labels={"endpoint": "refresh_token"}
+        )
+        assert after - before == 2
 
     @pytest.mark.asyncio
     async def test_github_is_student_timeout(self, ghapp_handler):
+        before = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total", labels={"endpoint": "is_student"}
+        )
+
         def side_effect(*args, **kwargs):
             raise httpx.TimeoutException("timeout")
 
@@ -1403,9 +1605,17 @@ class TestUnitGithub(object):
             res = await ghapp_handler.is_student()
             assert mocked_route.call_count == 1
             assert res == False
+        after = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total", labels={"endpoint": "is_student"}
+        )
+        assert after - before == 1
 
     @pytest.mark.asyncio
     async def test_github_is_student_network_error(self, ghapp_handler):
+        before = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total", labels={"endpoint": "is_student"}
+        )
+
         def side_effect(*args, **kwargs):
             raise httpx.NetworkError("timeout")
 
@@ -1416,11 +1626,25 @@ class TestUnitGithub(object):
             res = await ghapp_handler.is_student()
             assert mocked_route.call_count == 1
             assert res == False
+        after = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total", labels={"endpoint": "is_student"}
+        )
+        assert after - before == 1
 
     @pytest.mark.asyncio
     async def test_github_refresh_after_failed_request(self, mocker, valid_handler):
+        before = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total", labels={"endpoint": "get_is_admin"}
+        )
+        before_retries = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total",
+            labels={"endpoint": "make_http_call_retry"},
+        )
+        before_token_refresh = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total", labels={"endpoint": "refresh_token"}
+        )
+
         def side_effect(request, *args, **kwargs):
-            print(f"Received request with headers {request.headers['Authorization']}")
             token = request.headers["Authorization"]
             if token == "token some_key":
                 return httpx.Response(
@@ -1463,9 +1687,26 @@ class TestUnitGithub(object):
                 "refresh_token": "new_refresh_token",
             }
         )
+        after = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total", labels={"endpoint": "get_is_admin"}
+        )
+        assert after - before == 1
+        after_retries = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total",
+            labels={"endpoint": "make_http_call_retry"},
+        )
+        assert after_retries - before_retries == 1
+        after_token_refresh = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total", labels={"endpoint": "refresh_token"}
+        )
+        assert after_token_refresh - before_token_refresh == 1
 
     @pytest.mark.asyncio
     async def test__get_owner_from_nodeid(self, ghapp_handler):
+        before = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total",
+            labels={"endpoint": "get_owner_from_nodeid_graphql"},
+        )
         with respx.mock:
             mocked_route = respx.post("https://api.github.com/graphql").mock(
                 return_value=httpx.Response(
@@ -1490,9 +1731,22 @@ class TestUnitGithub(object):
                 )
             assert res == {"username": "codecov", "service_id": 8226205}
             assert mocked_route.call_count == 1
+            after = REGISTRY.get_sample_value(
+                "git_provider_api_calls_github_total",
+                labels={"endpoint": "get_owner_from_nodeid_graphql"},
+            )
+            assert after - before == 1
 
     @pytest.mark.asyncio
     async def test_get_repos_from_nodeids(self, ghapp_handler):
+        before = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total",
+            labels={"endpoint": "get_repos_from_nodeids_generator_graphql"},
+        )
+        before_get_owner = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total",
+            labels={"endpoint": "get_owner_from_nodeid_graphql"},
+        )
         # Mocking different responses from the graphQL API
         # because it all goes to the same endpoint but this test expects a 2nd call
         # with owner by node_id query
@@ -1644,3 +1898,13 @@ class TestUnitGithub(object):
                 },
             ]
             assert mocked_route.call_count == 2
+        after = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total",
+            labels={"endpoint": "get_repos_from_nodeids_generator_graphql"},
+        )
+        assert after - before == 1
+        after_get_owner = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total",
+            labels={"endpoint": "get_owner_from_nodeid_graphql"},
+        )
+        assert after_get_owner - before_get_owner == 1


### PR DESCRIPTION
<!-- Describe your PR here. -->
Part of https://github.com/codecov/engineering-team/issues/1167, this is for Github calls, the other git providers will be added next.

We want to know who's making all these calls! So I added some `Counters`.

This is a first implementation - the strategy I picked was to increment the `Counter` before the code makes the request to github - it uses a helper function and technically could error out somewhere along the way before it actually makes the call. So you could argue that the `Counters` are counting _intended_ requests, but hopefully errors between intent-to-call-github and actually making the outgoing request are low, and if not, at least they are logged.

I learned a bit from the Prometheus docs - each `label` value on a `Counter` is an individual object that will live and wait around to be incremented (and take up resources). I'm going to try initializing them all in the init method of the `Github` object, I think this is the right way to use Counters ([reference](https://prometheus.github.io/client_python/instrumenting/labels/)). Additionally, the docs say a Counter shouldn't have more than 10 labels ([reference](https://prometheus.io/docs/practices/instrumentation/#use-labels)), and this one is ~50, so we will need to monitor prometheus performance around this deploy.
