### PR TITLE
fix: remove parallel_processed enum

### DIFF
--- a/shared/reports/enums.py
+++ b/shared/reports/enums.py
@@ -11,7 +11,7 @@ class UploadState(CodecovDatabaseEnum):
     # not used right now, but will be when parallel upload procesing is rolled out. The
     # purpose of this is to signify a `UploadProcessor` task has ran for an upload, but
     # has not quite fully merged into the final report in `UploadFinisher` task
-    PARALLEL_PROCESSED = (6,)
+    # PARALLEL_PROCESSED = (6,)
 
     def __init__(self, db_id):
         self.db_id = db_id

--- a/shared/torngit/github.py
+++ b/shared/torngit/github.py
@@ -1245,7 +1245,9 @@ class Github(TorngitBaseAdapter):
                     (
                         "\ndeleted file mode 100644"
                         if f["status"] == "removed"
-                        else "\nnew file mode 100644" if f["status"] == "added" else ""
+                        else "\nnew file mode 100644"
+                        if f["status"] == "added"
+                        else ""
                     ),
                     "--- "
                     + (

--- a/tests/unit/reports/test_enums.py
+++ b/tests/unit/reports/test_enums.py
@@ -8,6 +8,6 @@ def test_enums():
         (3, "ERROR"),
         (4, "FULLY_OVERWRITTEN"),
         (5, "PARTIALLY_OVERWRITTEN"),
-        (6, "PARALLEL_PROCESSED"),
+        # (6, "PARALLEL_PROCESSED"),
     )
     assert UploadType.choices() == ((1, "UPLOADED"), (2, "CARRIEDFORWARD"))


### PR DESCRIPTION
Remove the `PARALLEL_PROCESSED` enum because it currently is not used. It will be used when parallel upload processing is fully rolled out.

There's no need to make the migration for it right now if it's not going to be used. (migration hasn't been made yet)

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.