### PR TITLE
Add count_and_get_url_template to github handler

### DIFF
--- a/shared/django_apps/reports/migrations/0016_testresultreporttotals_error.py
+++ b/shared/django_apps/reports/migrations/0016_testresultreporttotals_error.py
@@ -6,13 +6,15 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('reports', '0015_testresultreporttotals'),
+        ("reports", "0015_testresultreporttotals"),
     ]
 
     operations = [
         migrations.AddField(
-            model_name='testresultreporttotals',
-            name='error',
-            field=models.CharField(choices=[('no_success', 'No Success')], max_length=100, null=True),
+            model_name="testresultreporttotals",
+            name="error",
+            field=models.CharField(
+                choices=[("no_success", "No Success")], max_length=100, null=True
+            ),
         ),
     ]

--- a/shared/django_apps/reports/migrations/0017_testinstance_flaky_status.py
+++ b/shared/django_apps/reports/migrations/0017_testinstance_flaky_status.py
@@ -6,13 +6,21 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('reports', '0016_testresultreporttotals_error'),
+        ("reports", "0016_testresultreporttotals_error"),
     ]
 
     operations = [
         migrations.AddField(
-            model_name='testinstance',
-            name='flaky_status',
-            field=models.CharField(choices=[('failed_in_default_branch', 'Failed In Default Branch'), ('consecutive_diff_outcomes', 'Consecutive Diff Outcomes'), ('unrelated_matching_failures', 'Unrelated Matching Failures')], max_length=100, null=True),
+            model_name="testinstance",
+            name="flaky_status",
+            field=models.CharField(
+                choices=[
+                    ("failed_in_default_branch", "Failed In Default Branch"),
+                    ("consecutive_diff_outcomes", "Consecutive Diff Outcomes"),
+                    ("unrelated_matching_failures", "Unrelated Matching Failures"),
+                ],
+                max_length=100,
+                null=True,
+            ),
         ),
     ]

--- a/shared/django_apps/reports/models.py
+++ b/shared/django_apps/reports/models.py
@@ -286,8 +286,10 @@ class TestInstance(BaseCodecovModel):
         FAILED_IN_DEFAULT_BRANCH = "failed_in_default_branch"
         CONSECUTIVE_DIFF_OUTCOMES = "consecutive_diff_outcomes"
         UNRELATED_MATCHING_FAILURES = "unrelated_matching_failures"
-        
-    flaky_status = models.CharField(null=True, max_length=100, choices=FlakeSymptomType.choices)
+
+    flaky_status = models.CharField(
+        null=True, max_length=100, choices=FlakeSymptomType.choices
+    )
     duration_seconds = models.FloatField()
     outcome = models.CharField(max_length=100, choices=Outcome.choices)
     upload = models.ForeignKey(
@@ -307,7 +309,7 @@ class TestResultReportTotals(BaseCodecovModel):
     passed = models.IntegerField()
     skipped = models.IntegerField()
     failed = models.IntegerField()
-    
+
     class TestResultsProcessingError(models.TextChoices):
         NO_SUCCESS = "no_success"
 

--- a/shared/torngit/base.py
+++ b/shared/torngit/base.py
@@ -50,33 +50,6 @@ class TorngitBaseAdapter(object):
         "xtend",
     )
 
-    def get_client(self, timeouts: List[int] = []) -> httpx.AsyncClient:
-        if timeouts:
-            timeout = httpx.Timeout(timeouts[1], connect=timeouts[0])
-        else:
-            timeout = httpx.Timeout(self._timeouts[1], connect=self._timeouts[0])
-        return httpx.AsyncClient(
-            verify=self.verify_ssl
-            if not isinstance(self.verify_ssl, bool)
-            else self.verify_ssl,
-            timeout=timeout,
-        )
-
-    def get_token_by_type(self, token_type: TokenType):
-        if self._token_type_mapping.get(token_type) is not None:
-            return self._token_type_mapping.get(token_type)
-        return self.token
-
-    def get_token_by_type_if_none(self, token: Optional[str], token_type: TokenType):
-        if token is not None:
-            return token
-        return self.get_token_by_type(token_type)
-
-    def _oauth_consumer_token(self):
-        if not self._oauth:
-            raise Exception("Oauth consumer token not present")
-        return self._oauth
-
     def __init__(
         self,
         oauth_consumer_token: OauthConsumerToken = None,
@@ -106,6 +79,33 @@ class TorngitBaseAdapter(object):
             self.data["owner"].get("ownerid"),
             self.data["repo"].get("repoid"),
         )
+
+    def get_client(self, timeouts: List[int] = []) -> httpx.AsyncClient:
+        if timeouts:
+            timeout = httpx.Timeout(timeouts[1], connect=timeouts[0])
+        else:
+            timeout = httpx.Timeout(self._timeouts[1], connect=self._timeouts[0])
+        return httpx.AsyncClient(
+            verify=self.verify_ssl
+            if not isinstance(self.verify_ssl, bool)
+            else self.verify_ssl,
+            timeout=timeout,
+        )
+
+    def get_token_by_type(self, token_type: TokenType):
+        if self._token_type_mapping.get(token_type) is not None:
+            return self._token_type_mapping.get(token_type)
+        return self.token
+
+    def get_token_by_type_if_none(self, token: Optional[str], token_type: TokenType):
+        if token is not None:
+            return token
+        return self.get_token_by_type(token_type)
+
+    def _oauth_consumer_token(self):
+        if not self._oauth:
+            raise Exception("Oauth consumer token not present")
+        return self._oauth
 
     def _validate_language(self, language):
         if language:

--- a/shared/torngit/github.py
+++ b/shared/torngit/github.py
@@ -4,6 +4,7 @@ import hashlib
 import logging
 import os
 from base64 import b64decode
+from string import Template
 from typing import Dict, List, Optional
 from urllib.parse import parse_qs, urlencode
 
@@ -43,14 +44,284 @@ GITHUB_API_CALL_COUNTER = Counter(
     ["endpoint"],
 )
 
+
 GITHUB_API_ENDPOINTS = {
-    "test_2": GITHUB_API_CALL_COUNTER.labels(endpoint="test_2"),
-    "test_4": GITHUB_API_CALL_COUNTER.labels(endpoint="test_4"),
+    "request_webhook_redelivery": {
+        "counter": GITHUB_API_CALL_COUNTER.labels(
+            endpoint="request_webhook_redelivery"
+        ),
+        "url_template": Template("/app/hook/deliveries/${delivery_id}/attempts"),
+    },
+    "refresh_token": {
+        "counter": GITHUB_API_CALL_COUNTER.labels(endpoint="refresh_token"),
+        "url_template": Template("/login/oauth/access_token"),
+    },
+    "make_http_call_retry": {
+        "counter": GITHUB_API_CALL_COUNTER.labels(endpoint="make_http_call_retry"),
+        "url_template": "",  # no url template, just counter
+    },
+    "list_webhook_deliveries": {
+        "counter": GITHUB_API_CALL_COUNTER.labels(endpoint="list_webhook_deliveries"),
+        "url_template": Template("/app/hook/deliveries?per_page=50"),
+    },
+    "is_student": {
+        "counter": GITHUB_API_CALL_COUNTER.labels(endpoint="is_student"),
+        "url_template": Template("https://education.github.com/api/user"),
+    },
+    "get_best_effort_branches": {
+        "counter": GITHUB_API_CALL_COUNTER.labels(endpoint="get_best_effort_branches"),
+        "url_template": Template(
+            "/repos/${slug}/commits/${commit_sha}/branches-where-head"
+        ),
+    },
+    "get_workflow_run": {
+        "counter": GITHUB_API_CALL_COUNTER.labels(endpoint="get_workflow_run"),
+        "url_template": Template("/repos/${slug}/actions/runs/${run_id}"),
+    },
+    "update_check_run": {
+        "counter": GITHUB_API_CALL_COUNTER.labels(endpoint="update_check_run"),
+        "url_template": Template("/repos/${slug}/check-runs/${check_run_id}"),
+    },
+    "get_repos_with_languages_graphql": {
+        "counter": GITHUB_API_CALL_COUNTER.labels(
+            endpoint="get_repos_with_languages_graphql"
+        ),
+        "url_template": Template("/graphql"),
+    },
+    "get_repo_languages": {
+        "counter": GITHUB_API_CALL_COUNTER.labels(endpoint="get_repo_languages"),
+        "url_template": Template("/repos/${slug}/languages"),
+    },
+    "get_check_suites": {
+        "counter": GITHUB_API_CALL_COUNTER.labels(endpoint="get_check_suites"),
+        "url_template": Template("/repos/${slug}/commits/${git_sha}/check-suites"),
+    },
+    "create_check_run": {
+        "counter": GITHUB_API_CALL_COUNTER.labels(endpoint="create_check_run"),
+        "url_template": Template("/repos/${slug}/check-runs"),
+    },
+    "get_ancestors_tree": {
+        "counter": GITHUB_API_CALL_COUNTER.labels(endpoint="get_ancestors_tree"),
+        "url_template": Template("/repos/${slug}/commits"),
+    },
+    "list_files": {
+        "counter": GITHUB_API_CALL_COUNTER.labels(endpoint="list_files"),
+        "url_template": Template("/repos/${slug}/contents"),
+    },
+    "get_pull_request_files": {
+        "counter": GITHUB_API_CALL_COUNTER.labels(endpoint="get_pull_request_files"),
+        "url_template": Template("/repos/${slug}/pulls/${pullid}/files"),
+    },
+    "find_pull_request": {
+        "counter": GITHUB_API_CALL_COUNTER.labels(endpoint="find_pull_request"),
+        "url_template": Template("/repos/${slug}/commits/${commit}/pulls"),
+    },
+    "get_pull_requests": {
+        "counter": GITHUB_API_CALL_COUNTER.labels(endpoint="get_pull_requests"),
+        "url_template": Template("/repos/${slug}/pulls"),
+    },
+    "get_pull_request": {
+        "counter": GITHUB_API_CALL_COUNTER.labels(endpoint="get_pull_request"),
+        "url_template": Template("/repos/${slug}/pulls/${pullid}"),
+    },
+    "get_distance_in_commits": {
+        "counter": GITHUB_API_CALL_COUNTER.labels(endpoint="get_distance_in_commits"),
+        "url_template": Template("/repos/${slug}/compare/${base_branch}...${base}"),
+    },
+    "get_compare": {
+        "counter": GITHUB_API_CALL_COUNTER.labels(endpoint="get_compare"),
+        "url_template": Template("/repos/${slug}/compare/${base}...${head}"),
+    },
+    "get_commit_diff": {
+        "counter": GITHUB_API_CALL_COUNTER.labels(endpoint="get_commit_diff"),
+        "url_template": Template("/repos/${slug}/commits/${commit}"),
+    },
+    "get_source": {
+        "counter": GITHUB_API_CALL_COUNTER.labels(endpoint="get_source"),
+        "url_template": Template("/repos/${slug}/contents/${path}"),
+    },
+    "get_source_again": {
+        "counter": GITHUB_API_CALL_COUNTER.labels(endpoint="get_source_again"),
+        "url_template": "",  # no url template, just counter
+    },
+    "get_commit_statuses": {
+        "counter": GITHUB_API_CALL_COUNTER.labels(endpoint="get_commit_statuses"),
+        "url_template": Template("/repos/${slug}/commits/${commit}/status"),
+    },
+    "set_commit_status": {
+        "counter": GITHUB_API_CALL_COUNTER.labels(endpoint="set_commit_status"),
+        "url_template": Template("/repos/${slug}/statuses/${commit}"),
+    },
+    "set_commit_status_merge_commit": {
+        "counter": GITHUB_API_CALL_COUNTER.labels(
+            endpoint="set_commit_status_merge_commit"
+        ),
+        "url_template": Template("/repos/${slug}/statuses/${merge_commit}"),
+    },
+    "delete_comment": {
+        "counter": GITHUB_API_CALL_COUNTER.labels(endpoint="delete_comment"),
+        "url_template": Template("/repos/${slug}/issues/comments/${commentid}"),
+    },
+    "edit_comment": {
+        "counter": GITHUB_API_CALL_COUNTER.labels(endpoint="edit_comment"),
+        "url_template": Template("/repos/${slug}/issues/comments/${commentid}"),
+    },
+    "post_comment": {
+        "counter": GITHUB_API_CALL_COUNTER.labels(endpoint="post_comment"),
+        "url_template": Template("/repos/${slug}/issues/${issueid}/comments"),
+    },
+    "delete_webhook": {
+        "counter": GITHUB_API_CALL_COUNTER.labels(endpoint="delete_webhook"),
+        "url_template": Template("/repos/${slug}/hooks/${hookid}"),
+    },
+    "edit_webhook": {
+        "counter": GITHUB_API_CALL_COUNTER.labels(endpoint="edit_webhook"),
+        "url_template": Template("/repos/${slug}/hooks/${hookid}"),
+    },
+    "post_webhook": {
+        "counter": GITHUB_API_CALL_COUNTER.labels(endpoint="post_webhook"),
+        "url_template": Template("/repos/${slug}/hooks"),
+    },
+    "get_raw_pull_request_commits": {
+        "counter": GITHUB_API_CALL_COUNTER.labels(
+            endpoint="get_raw_pull_request_commits"
+        ),
+        "url_template": Template(
+            "/repos/${slug}/pulls/${pullid}/commits?per_page=${max}&page=${page_n}"
+        ),
+    },
+    "list_teams": {
+        "counter": GITHUB_API_CALL_COUNTER.labels(endpoint="list_teams"),
+        "url_template": Template("/user/memberships/orgs?state=active"),
+    },
+    "list_teams_org_name": {
+        "counter": GITHUB_API_CALL_COUNTER.labels(endpoint="list_teams_org_name"),
+        "url_template": Template("/users/${login}"),
+    },
+    "get_gh_app_installation": {
+        "counter": GITHUB_API_CALL_COUNTER.labels(endpoint="get_gh_app_installation"),
+        "url_template": Template("/app/installations/${installation_id}"),
+    },
+    "get_repos_from_nodeids_generator_graphql": {
+        "counter": GITHUB_API_CALL_COUNTER.labels(
+            endpoint="get_repos_from_nodeids_generator_graphql"
+        ),
+        "url_template": Template("/graphql"),
+    },
+    "get_owner_from_nodeid_graphql": {
+        "counter": GITHUB_API_CALL_COUNTER.labels(
+            endpoint="get_owner_from_nodeid_graphql"
+        ),
+        "url_template": Template("/graphql"),
+    },
+    "fetch_number_of_repos_graphql": {
+        "counter": GITHUB_API_CALL_COUNTER.labels(
+            endpoint="fetch_number_of_repos_graphql"
+        ),
+        "url_template": Template("/graphql"),
+    },
+    "fetch_page_of_repos_without_username": {
+        "counter": GITHUB_API_CALL_COUNTER.labels(
+            endpoint="fetch_page_of_repos_without_username"
+        ),
+        "url_template": Template("/user/repos?per_page=${page_size}&page=${page}"),
+    },
+    "fetch_page_of_repos_with_username": {
+        "counter": GITHUB_API_CALL_COUNTER.labels(
+            endpoint="fetch_page_of_repos_with_username"
+        ),
+        "url_template": Template(
+            "/users/${username}/repos?per_page=${page_size}&page=${page}"
+        ),
+    },
+    "fetch_page_of_repos_using_installation": {
+        "counter": GITHUB_API_CALL_COUNTER.labels(
+            endpoint="fetch_page_of_repos_using_installation"
+        ),
+        "url_template": Template(
+            "/installation/repositories?per_page=${page_size}&page=${page}"
+        ),
+    },
+    "get_authenticated": {
+        "counter": GITHUB_API_CALL_COUNTER.labels(endpoint="get_authenticated"),
+        "url_template": Template("/repos/${slug}"),
+    },
+    "get_is_admin": {
+        "counter": GITHUB_API_CALL_COUNTER.labels(endpoint="get_is_admin"),
+        "url_template": Template(
+            "/orgs/${owner_username}/memberships/${user_username}"
+        ),
+    },
+    "get_user_token": {
+        "counter": GITHUB_API_CALL_COUNTER.labels(endpoint="get_user_token"),
+        "url_template": Template("/login/oauth/access_token"),
+    },
+    "get_authenticated_user": {
+        "counter": GITHUB_API_CALL_COUNTER.labels(endpoint="get_authenticated_user"),
+        "url_template": Template("/user"),
+    },
+    "get_authenticated_user_email": {
+        "counter": GITHUB_API_CALL_COUNTER.labels(
+            endpoint="get_authenticated_user_email"
+        ),
+        "url_template": Template("/user/emails"),
+    },
+    "get_branch": {
+        "counter": GITHUB_API_CALL_COUNTER.labels(endpoint="get_branch"),
+        "url_template": Template("/repos/${slug}/branches/${branch_name}"),
+    },
+    "get_branches": {
+        "counter": GITHUB_API_CALL_COUNTER.labels(endpoint="get_branches"),
+        "url_template": Template("/repos/${slug}/branches"),
+    },
+    "get_repository_with_service_id": {
+        "counter": GITHUB_API_CALL_COUNTER.labels(
+            endpoint="get_repository_with_service_id"
+        ),
+        "url_template": Template("/repositories/${service_id}"),
+    },
+    "get_repository_without_service_id": {
+        "counter": GITHUB_API_CALL_COUNTER.labels(
+            endpoint="get_repository_without_service_id"
+        ),
+        "url_template": Template("/repos/${slug}"),
+    },
+    "get_check_runs_with_head_sha": {
+        "counter": GITHUB_API_CALL_COUNTER.labels(
+            endpoint="get_check_runs_with_head_sha"
+        ),
+        "url_template": Template("/repos/${slug}/commits/${head_sha}/check-runs"),
+    },
+    "get_check_runs_with_check_suite_id": {
+        "counter": GITHUB_API_CALL_COUNTER.labels(
+            endpoint="get_check_runs_with_check_suite_id"
+        ),
+        "url_template": Template(
+            "/repos/${slug}/check-suites/${check_suite_id}/check-runs"
+        ),
+    },
+    "list_files_with_dir_path": {
+        "counter": GITHUB_API_CALL_COUNTER.labels(endpoint="list_files_with_dir_path"),
+        "url_template": Template("/repos/${slug}/contents/${dir_path}"),
+    },
+    "get_github_integration_token": {
+        "counter": GITHUB_API_CALL_COUNTER.labels(
+            endpoint="get_github_integration_token"
+        ),
+        "url_template": Template(
+            "${api_endpoint}/app/installations/${integration_id}/access_tokens"
+        ),
+    },
 }
 
-GITHUB_API_CALL_COUNTER.labels(endpoint="test_3")
-GITHUB_API_CALL_COUNTER.labels(endpoint="test_3").inc()
-GITHUB_API_ENDPOINTS["test_4"].inc()
+
+# uncounted urls
+external_endpoint_template = Template("${username}/${name}/commit/${commitid}")
+
+
+def count_and_get_url_template(url_name):
+    GITHUB_API_ENDPOINTS[url_name]["counter"].inc()
+    return GITHUB_API_ENDPOINTS[url_name]["url_template"]
 
 
 class GitHubGraphQLQueries(object):
@@ -140,167 +411,6 @@ class Github(TorngitBaseAdapter):
     service = "github"
     graphql = GitHubGraphQLQueries()
 
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-        # call each counter/label combination to initialize it
-        GITHUB_API_CALL_COUNTER.labels(endpoint="test_1")
-        self.github_request_webhook_redelivery_call_counter = (
-            GITHUB_API_CALL_COUNTER.labels(endpoint="request_webhook_redelivery")
-        )
-        self.github_refresh_token_call_counter = GITHUB_API_CALL_COUNTER.labels(
-            endpoint="refresh_token"
-        )
-        self.github_make_http_call_retry_call_counter = GITHUB_API_CALL_COUNTER.labels(
-            endpoint="make_http_call_retry"
-        )
-        self.github_list_webhook_deliveries_call_counter = (
-            GITHUB_API_CALL_COUNTER.labels(endpoint="list_webhook_deliveries")
-        )
-        self.github_is_student_call_counter = GITHUB_API_CALL_COUNTER.labels(
-            endpoint="is_student"
-        )
-        self.github_get_best_effort_branches_call_counter = (
-            GITHUB_API_CALL_COUNTER.labels(endpoint="get_best_effort_branches")
-        )
-        self.github_get_workflow_run_call_counter = GITHUB_API_CALL_COUNTER.labels(
-            endpoint="get_workflow_run"
-        )
-        self.github_update_check_run_call_counter = GITHUB_API_CALL_COUNTER.labels(
-            endpoint="update_check_run"
-        )
-        self.github_get_repos_with_languages_graphql_call_counter = (
-            GITHUB_API_CALL_COUNTER.labels(endpoint="get_repos_with_languages_graphql")
-        )
-        self.github_get_repo_languages_call_counter = GITHUB_API_CALL_COUNTER.labels(
-            endpoint="get_repo_languages"
-        )
-        self.github_get_check_suites_call_counter = GITHUB_API_CALL_COUNTER.labels(
-            endpoint="get_check_suites"
-        )
-        self.github_get_check_runs_call_counter = GITHUB_API_CALL_COUNTER.labels(
-            endpoint="get_check_runs"
-        )
-        self.github_create_check_run_call_counter = GITHUB_API_CALL_COUNTER.labels(
-            endpoint="create_check_run"
-        )
-        self.github_get_ancestors_tree_call_counter = GITHUB_API_CALL_COUNTER.labels(
-            endpoint="get_ancestors_tree"
-        )
-        self.github_list_files_call_counter = GITHUB_API_CALL_COUNTER.labels(
-            endpoint="list_files"
-        )
-        self.github_get_pull_request_files_call_counter = (
-            GITHUB_API_CALL_COUNTER.labels(endpoint="get_pull_request_files")
-        )
-        self.github_find_pull_request_call_counter = GITHUB_API_CALL_COUNTER.labels(
-            endpoint="find_pull_request"
-        )
-        self.github_get_pull_requests_call_counter = GITHUB_API_CALL_COUNTER.labels(
-            endpoint="get_pull_requests"
-        )
-        self.github_get_pull_request_call_counter = GITHUB_API_CALL_COUNTER.labels(
-            endpoint="get_pull_request"
-        )
-        self.github_get_distance_in_commits_call_counter = (
-            GITHUB_API_CALL_COUNTER.labels(endpoint="get_distance_in_commits")
-        )
-        self.github_get_compare_call_counter = GITHUB_API_CALL_COUNTER.labels(
-            endpoint="get_compare"
-        )
-        self.github_get_commit_diff_call_counter = GITHUB_API_CALL_COUNTER.labels(
-            endpoint="get_commit_diff"
-        )
-        self.github_get_source_call_counter = GITHUB_API_CALL_COUNTER.labels(
-            endpoint="get_source"
-        )
-        self.github_get_source_content_call_counter = GITHUB_API_CALL_COUNTER.labels(
-            endpoint="get_source_content"
-        )
-        self.github_get_commit_statuses_call_counter = GITHUB_API_CALL_COUNTER.labels(
-            endpoint="get_commit_statuses"
-        )
-        self.github_set_commit_status_call_counter = GITHUB_API_CALL_COUNTER.labels(
-            endpoint="set_commit_status"
-        )
-        self.github_set_commit_status_merge_commit_call_counter = (
-            GITHUB_API_CALL_COUNTER.labels(endpoint="set_commit_status_merge_commit")
-        )
-        self.github_delete_comment_call_counter = GITHUB_API_CALL_COUNTER.labels(
-            endpoint="delete_comment"
-        )
-        self.github_edit_comment_call_counter = GITHUB_API_CALL_COUNTER.labels(
-            endpoint="edit_comment"
-        )
-        self.github_post_comment_call_counter = GITHUB_API_CALL_COUNTER.labels(
-            endpoint="post_comment"
-        )
-        self.github_delete_webhook_call_counter = GITHUB_API_CALL_COUNTER.labels(
-            endpoint="delete_webhook"
-        )
-        self.github_edit_webhook_call_counter = GITHUB_API_CALL_COUNTER.labels(
-            endpoint="edit_webhook"
-        )
-        self.github_post_webhook_call_counter = GITHUB_API_CALL_COUNTER.labels(
-            endpoint="post_webhook"
-        )
-        self.github_get_raw_pull_request_commits_call_counter = (
-            GITHUB_API_CALL_COUNTER.labels(endpoint="get_raw_pull_request_commits")
-        )
-        self.github_list_teams_call_counter = GITHUB_API_CALL_COUNTER.labels(
-            endpoint="list_teams"
-        )
-        self.github_list_teams_org_name_call_counter = GITHUB_API_CALL_COUNTER.labels(
-            endpoint="list_teams_org_name"
-        )
-        self.github_get_gh_app_installation_call_counter = (
-            GITHUB_API_CALL_COUNTER.labels(endpoint="get_gh_app_installation")
-        )
-        self.github_get_repos_from_nodeids_generator_graphql_call_counter = (
-            GITHUB_API_CALL_COUNTER.labels(
-                endpoint="get_repos_from_nodeids_generator_graphql"
-            )
-        )
-        self.github_get_owner_from_nodeid_graphql_call_counter = (
-            GITHUB_API_CALL_COUNTER.labels(endpoint="get_owner_from_nodeid_graphql")
-        )
-        self.github_fetch_number_of_repos_graphql_call_counter = (
-            GITHUB_API_CALL_COUNTER.labels(endpoint="fetch_number_of_repos_graphql")
-        )
-        self.github_fetch_page_of_repos_call_counter = GITHUB_API_CALL_COUNTER.labels(
-            endpoint="fetch_page_of_repos"
-        )
-        self.github_fetch_page_of_repos_using_installation_call_counter = (
-            GITHUB_API_CALL_COUNTER.labels(
-                endpoint="fetch_page_of_repos_using_installation"
-            )
-        )
-        self.github_get_repository_call_counter = GITHUB_API_CALL_COUNTER.labels(
-            endpoint="get_repository"
-        )
-        self.github_get_authenticated_call_counter = GITHUB_API_CALL_COUNTER.labels(
-            endpoint="get_authenticated"
-        )
-        self.github_get_is_admin_call_counter = GITHUB_API_CALL_COUNTER.labels(
-            endpoint="get_is_admin"
-        )
-        self.github_get_authenticated_user_call_counter = (
-            GITHUB_API_CALL_COUNTER.labels(endpoint="get_authenticated_user")
-        )
-        self.github_get_authenticated_user_get_user_call_counter = (
-            GITHUB_API_CALL_COUNTER.labels(endpoint="get_authenticated_user_get_user")
-        )
-        self.github_get_authenticated_user_get_user_email_call_counter = (
-            GITHUB_API_CALL_COUNTER.labels(
-                endpoint="get_authenticated_user_get_user_email"
-            )
-        )
-        self.github_get_branch_call_counter = GITHUB_API_CALL_COUNTER.labels(
-            endpoint="get_branch"
-        )
-        self.github_get_branches_call_counter = GITHUB_API_CALL_COUNTER.labels(
-            endpoint="get_branches"
-        )
-
     @classmethod
     def get_service_url(cls):
         return get_config("github", "url", default="https://github.com").strip("/")
@@ -360,7 +470,7 @@ class Github(TorngitBaseAdapter):
         return self._parse_response(response)
 
     async def paginated_api_generator(
-        self, client, method, initial_url, token=None, **kwargs
+        self, client, method, url_name, token=None, **kwargs
     ):
         """
         Generator that requests pages from GitHub and yields each page as they come.
@@ -369,15 +479,22 @@ class Github(TorngitBaseAdapter):
         token_to_use = token or self.token
         if not token_to_use:
             raise TorngitMisconfiguredCredentials()
-        url = initial_url
+        url = count_and_get_url_template(
+            url_name=url_name
+        ).substitute()  # counts first call
+        page = 1
         while url:
             args = [client, method, url]
-            self.github_list_webhook_deliveries_call_counter.inc()
             response = await self.make_http_call(
                 *args, token_to_use=token_to_use, **kwargs
             )
             yield self._parse_response(response)
             url = response.links.get("next", {}).get("url", "")
+            if page > 1:
+                _ = count_and_get_url_template(
+                    url_name=url_name
+                ).substitute()  # counts subsequent calls
+            page += 1
 
     def _parse_response(self, res: Response):
         if res.status_code == 204:
@@ -463,7 +580,8 @@ class Github(TorngitBaseAdapter):
                 with metrics.timer(f"{METRICS_PREFIX}.api.run") as timer:
                     res = await client.request(method, url, **kwargs)
                     if current_retry > 1:
-                        self.github_make_http_call_retry_call_counter.inc()
+                        # count retries without getting a url
+                        count_and_get_url_template(url_name="make_http_call_retry")
                 logged_body = None
                 if res.status_code >= 300 and res.text is not None:
                     logged_body = res.text
@@ -613,10 +731,13 @@ class Github(TorngitBaseAdapter):
                 **creds_to_send,
             )
         )
-        self.github_refresh_token_call_counter.inc()
+        url = (
+            self.service_url
+            + count_and_get_url_template(url_name="refresh_token").substitute()
+        )
         res = await client.request(
             "POST",
-            self.service_url + "/login/oauth/access_token",
+            url,
             params=params,
         )
         if res.status_code >= 300:
@@ -661,11 +782,13 @@ class Github(TorngitBaseAdapter):
             branches = []
             while True:
                 page += 1
-                self.github_get_branches_call_counter.inc()
+                url = count_and_get_url_template(url_name="get_branches").substitute(
+                    slug=self.slug
+                )
                 res = await self.api(
                     client,
                     "get",
-                    "/repos/%s/branches" % self.slug,
+                    url,
                     per_page=100,
                     page=page,
                     token=token,
@@ -680,22 +803,23 @@ class Github(TorngitBaseAdapter):
     async def get_branch(self, branch_name: str, token=None):
         async with self.get_client() as client:
             # https://docs.github.com/en/rest/branches/branches?apiVersion=2022-11-28#get-a-branch
-            self.github_get_branch_call_counter.inc()
-            res = await self.api(
-                client,
-                "get",
-                f"/repos/{self.slug}/branches/{branch_name}",
+            url = count_and_get_url_template(url_name="get_branch").substitute(
+                slug=self.slug, branch_name=branch_name
             )
+            res = await self.api(client, "get", url)
             return {"name": res["name"], "sha": res["commit"]["sha"]}
 
     async def get_authenticated_user(self, code):
         creds = self._oauth_consumer_token()
-        self.github_get_authenticated_user_call_counter.inc()
         async with self.get_client() as client:
+            url = (
+                self.service_url
+                + count_and_get_url_template(url_name="get_user_token").substitute()
+            )
             response = await self.make_http_call(
                 client,
                 "get",
-                self.service_url + "/login/oauth/access_token",
+                url,
                 code=code,
                 client_id=creds["key"],
                 client_secret=creds["secret"],
@@ -712,14 +836,17 @@ class Github(TorngitBaseAdapter):
                         refresh_token=session.get("refresh_token", None),
                     )
                 )
-
-                self.github_get_authenticated_user_get_user_call_counter.inc()
-                user = await self.api(client, "get", "/user")
+                url = count_and_get_url_template(
+                    url_name="get_authenticated_user"
+                ).substitute()
+                user = await self.api(client, "get", url)
                 user.update(session or {})
                 email = user.get("email")
+                url = count_and_get_url_template(
+                    url_name="get_authenticated_user_email"
+                ).substitute()
                 if not email:
-                    self.github_get_authenticated_user_get_user_email_call_counter.inc()
-                    emails = await self.api(client, "get", "/user/emails")
+                    emails = await self.api(client, "get", url)
                     emails = [e["email"] for e in emails if e["primary"]]
                     user["email"] = emails[0] if emails else None
                 return user
@@ -740,22 +867,21 @@ class Github(TorngitBaseAdapter):
     async def get_is_admin(self, user, token=None):
         async with self.get_client() as client:
             # https://developer.github.com/v3/orgs/members/#get-organization-membership
-            self.github_get_is_admin_call_counter.inc()
-            res = await self.api(
-                client,
-                "get",
-                "/orgs/%s/memberships/%s"
-                % (self.data["owner"]["username"], user["username"]),
-                token=token,
+            url = count_and_get_url_template(url_name="get_is_admin").substitute(
+                owner_username=self.data["owner"]["username"],
+                user_username=user["username"],
             )
+            res = await self.api(client, "get", url, token=token)
             return res["state"] == "active" and res["role"] == "admin"
 
     async def get_authenticated(self, token=None):
         """Returns (can_view, can_edit)"""
         # https://developer.github.com/v3/repos/#get
         async with self.get_client() as client:
-            self.github_get_authenticated_call_counter.inc()
-            r = await self.api(client, "get", "/repos/%s" % self.slug, token=token)
+            url = count_and_get_url_template(url_name="get_authenticated").substitute(
+                slug=self.slug
+            )
+            r = await self.api(client, "get", url, token=token)
             ok = r["permissions"]["admin"] or r["permissions"]["push"]
             return (True, ok)
 
@@ -764,18 +890,15 @@ class Github(TorngitBaseAdapter):
         async with self.get_client() as client:
             if self.data["repo"].get("service_id") is None:
                 # https://developer.github.com/v3/repos/#get
-                self.github_get_repository_call_counter.inc()  # else block uses same counter
-                res = await self.api(
-                    client, "get", "/repos/%s" % self.slug, token=token
-                )
+                url = count_and_get_url_template(
+                    url_name="get_repository_without_service_id"
+                ).substitute(slug=self.slug)
+                res = await self.api(client, "get", url, token=token)
             else:
-                self.github_get_repository_call_counter.inc()  # if block uses same counter
-                res = await self.api(
-                    client,
-                    "get",
-                    "/repositories/%s" % self.data["repo"]["service_id"],
-                    token=token,
-                )
+                url = count_and_get_url_template(
+                    url_name="get_repository_with_service_id"
+                ).substitute(service_id=self.data["repo"]["service_id"])
+                res = await self.api(client, "get", url, token=token)
 
         username, repo = tuple(res["full_name"].split("/", 1))
         parent = res.get("parent")
@@ -831,11 +954,13 @@ class Github(TorngitBaseAdapter):
         self, client, page_size=100, page=1
     ):
         # https://docs.github.com/en/rest/apps/installations?apiVersion=2022-11-28
-        self.github_fetch_page_of_repos_using_installation_call_counter.inc()
+        url = count_and_get_url_template(
+            url_name="fetch_page_of_repos_using_installation"
+        ).substitute(page_size=page_size, page=page)
         res = await self.api(
             client,
             "get",
-            f"/installation/repositories?per_page={page_size}&page={page}",
+            url,
             headers={"Accept": "application/vnd.github.machine-man-preview+json"},
         )
 
@@ -857,21 +982,15 @@ class Github(TorngitBaseAdapter):
     ):
         # https://developer.github.com/v3/repos/#list-your-repositories
         if username is None:
-            self.github_fetch_page_of_repos_call_counter.inc()  # else block uses same counter
-            repos = await self.api(
-                client,
-                "get",
-                f"/user/repos?per_page={page_size}&page={page}",
-                token=token,
-            )
+            url = count_and_get_url_template(
+                url_name="fetch_page_of_repos_without_username"
+            ).substitute(page_size=page_size, page=page)
+            repos = await self.api(client, "get", url, token=token)
         else:
-            self.github_fetch_page_of_repos_call_counter.inc()  # if block uses same counter
-            repos = await self.api(
-                client,
-                "get",
-                f"/users/{username}/repos?per_page={page_size}&page={page}",
-                token=token,
-            )
+            url = count_and_get_url_template(
+                url_name="fetch_page_of_repos_with_username"
+            ).substitute(username=username, page_size=page_size, page=page)
+            repos = await self.api(client, "get", url, token=token)
 
         log.info(
             "Fetched page of repos",
@@ -889,14 +1008,10 @@ class Github(TorngitBaseAdapter):
         query = self.graphql.prepare(
             "OWNER_FROM_NODEID", variables={"node_id": owner_node_id}
         )
-        self.github_get_owner_from_nodeid_graphql_call_counter.inc()
-        res = await self.api(
-            client,
-            "post",
-            "/graphql",
-            body=query,
-            token=token,
-        )
+        url = count_and_get_url_template(
+            url_name="get_owner_from_nodeid_graphql"
+        ).substitute()
+        res = await self.api(client, "post", url, body=query, token=token)
         owner_data = res["data"]["node"]
         return {"username": owner_data["login"], "service_id": owner_data["databaseId"]}
 
@@ -922,14 +1037,10 @@ class Github(TorngitBaseAdapter):
                 query = self.graphql.prepare(
                     "REPOS_FROM_NODEIDS", variables={"node_ids": chunk}
                 )
-                self.github_get_repos_from_nodeids_generator_graphql_call_counter.inc()
-                res = await self.api(
-                    client,
-                    "post",
-                    "/graphql",
-                    body=query,
-                    token=token,
-                )
+                url = count_and_get_url_template(
+                    url_name="get_repos_from_nodeids_generator_graphql"
+                ).substitute()
+                res = await self.api(client, "post", url, body=query, token=token)
                 for raw_repo_data in res["data"]["nodes"]:
                     if (
                         raw_repo_data is None
@@ -1060,7 +1171,9 @@ class Github(TorngitBaseAdapter):
             Dict: a dictionary that adheres to gh's response value in the link above
         """
         jwt_token = get_github_jwt_token(service=self.service)
-        url = f"/app/installations/{installation_id}"
+        url = count_and_get_url_template(url_name="get_gh_app_installation").substitute(
+            installation_id=installation_id
+        )
         headers = {
             "Accept": "application/vnd.github+json",
             "Authorization": f"Bearer {jwt_token}",
@@ -1069,7 +1182,6 @@ class Github(TorngitBaseAdapter):
 
         async with self.get_client() as client:
             try:
-                self.github_get_gh_app_installation_call_counter.inc()
                 return await self.api(
                     client,
                     "get",
@@ -1092,27 +1204,18 @@ class Github(TorngitBaseAdapter):
         async with self.get_client() as client:
             while True:
                 page += 1
-                self.github_list_teams_call_counter.inc()
-                orgs = await self.api(
-                    client,
-                    "get",
-                    "/user/memberships/orgs?state=active",
-                    page=page,
-                    token=token,
-                )
+                url = count_and_get_url_template(url_name="list_teams").substitute()
+                orgs = await self.api(client, "get", url, page=page, token=token)
                 if len(orgs) == 0:
                     break
                 # organization names
                 for org in orgs:
                     try:
                         organization = org["organization"]
-                        self.github_list_teams_org_name_call_counter.inc()
-                        org = await self.api(
-                            client,
-                            "get",
-                            "/users/%s" % organization["login"],
-                            token=token,
-                        )
+                        url = count_and_get_url_template(
+                            url_name="list_teams_org_name"
+                        ).substitute(login=organization["login"])
+                        org = await self.api(client, "get", url, token=token)
                         data.append(
                             dict(
                                 name=organization.get("name", org["login"]),
@@ -1147,14 +1250,15 @@ class Github(TorngitBaseAdapter):
         MAX_RESULTS_PER_PAGE = 100
         async with self.get_client() as client:
             for page_number in [1, 2, 3]:
-                self.github_get_raw_pull_request_commits_call_counter.inc()
-                page_results = await self.api(
-                    client,
-                    "get",
-                    "/repos/%s/pulls/%s/commits?per_page=%s&page=%s"
-                    % (self.slug, pullid, MAX_RESULTS_PER_PAGE, page_number),
-                    token=token,
+                url = count_and_get_url_template(
+                    url_name="get_raw_pull_request_commits"
+                ).substitute(
+                    slug=self.slug,
+                    pullid=pullid,
+                    max=MAX_RESULTS_PER_PAGE,
+                    page_n=page_number,
                 )
+                page_results = await self.api(client, "get", url, token=token)
                 if len(page_results):
                     all_commits.extend(page_results)
                 if len(page_results) < MAX_RESULTS_PER_PAGE:
@@ -1167,11 +1271,13 @@ class Github(TorngitBaseAdapter):
         token = self.get_token_by_type_if_none(token, TokenType.admin)
         # https://developer.github.com/v3/repos/hooks/#create-a-hook
         async with self.get_client() as client:
-            self.github_post_webhook_call_counter.inc()
+            url = count_and_get_url_template(url_name="post_webhook").substitute(
+                slug=self.slug
+            )
             res = await self.api(
                 client,
                 "post",
-                "/repos/%s/hooks" % self.slug,
+                url,
                 body=dict(
                     name="web",
                     active=True,
@@ -1187,11 +1293,13 @@ class Github(TorngitBaseAdapter):
         # https://developer.github.com/v3/repos/hooks/#edit-a-hook
         try:
             async with self.get_client() as client:
-                self.github_edit_webhook_call_counter.inc()
+                url = count_and_get_url_template(url_name="edit_webhook").substitute(
+                    slug=self.slug, hookid=hookid
+                )
                 return await self.api(
                     client,
                     "patch",
-                    "/repos/%s/hooks/%s" % (self.slug, hookid),
+                    url,
                     body=dict(
                         name="web",
                         active=True,
@@ -1213,13 +1321,10 @@ class Github(TorngitBaseAdapter):
         # https://developer.github.com/v3/repos/hooks/#delete-a-hook
         try:
             async with self.get_client() as client:
-                self.github_delete_webhook_call_counter.inc()
-                await self.api(
-                    client,
-                    "delete",
-                    "/repos/%s/hooks/%s" % (self.slug, hookid),
-                    token=token,
+                url = count_and_get_url_template(url_name="delete_webhook").substitute(
+                    slug=self.slug, hookid=hookid
                 )
+                await self.api(client, "delete", url, token=token)
         except TorngitClientError as ce:
             if ce.code == 404:
                 raise TorngitObjectNotFoundError(
@@ -1235,14 +1340,10 @@ class Github(TorngitBaseAdapter):
         token = self.get_token_by_type_if_none(token, TokenType.comment)
         # https://developer.github.com/v3/issues/comments/#create-a-comment
         async with self.get_client() as client:
-            self.github_post_comment_call_counter.inc()
-            res = await self.api(
-                client,
-                "post",
-                "/repos/%s/issues/%s/comments" % (self.slug, issueid),
-                body=dict(body=body),
-                token=token,
+            url = count_and_get_url_template(url_name="post_comment").substitute(
+                slug=self.slug, issueid=issueid
             )
+            res = await self.api(client, "post", url, body=dict(body=body), token=token)
             return res
 
     async def edit_comment(self, issueid, commentid, body, token=None):
@@ -1250,13 +1351,11 @@ class Github(TorngitBaseAdapter):
         # https://developer.github.com/v3/issues/comments/#edit-a-comment
         try:
             async with self.get_client() as client:
-                self.github_edit_comment_call_counter.inc()
+                url = count_and_get_url_template(url_name="edit_comment").substitute(
+                    slug=self.slug, commentid=commentid
+                )
                 res = await self.api(
-                    client,
-                    "patch",
-                    "/repos/%s/issues/comments/%s" % (self.slug, commentid),
-                    body=dict(body=body),
-                    token=token,
+                    client, "patch", url, body=dict(body=body), token=token
                 )
                 return res
         except TorngitClientError as ce:
@@ -1272,13 +1371,10 @@ class Github(TorngitBaseAdapter):
         # https://developer.github.com/v3/issues/comments/#delete-a-comment
         try:
             async with self.get_client() as client:
-                self.github_delete_comment_call_counter.inc()
-                await self.api(
-                    client,
-                    "delete",
-                    "/repos/%s/issues/comments/%s" % (self.slug, commentid),
-                    token=token,
+                url = count_and_get_url_template(url_name="delete_comment").substitute(
+                    slug=self.slug, commentid=commentid
                 )
+                await self.api(client, "delete", url, token=token)
         except TorngitClientError as ce:
             if ce.code == 404:
                 raise TorngitObjectNotFoundError(
@@ -1306,11 +1402,13 @@ class Github(TorngitBaseAdapter):
         assert status in ("pending", "success", "error", "failure"), "status not valid"
         async with self.get_client() as client:
             try:
-                self.github_set_commit_status_call_counter.inc()
+                url = count_and_get_url_template(
+                    url_name="set_commit_status"
+                ).substitute(slug=self.slug, commit=commit)
                 res = await self.api(
                     client,
                     "post",
-                    "/repos/%s/statuses/%s" % (self.slug, commit),
+                    url,
                     body=dict(
                         state=status,
                         target_url=url,
@@ -1322,11 +1420,13 @@ class Github(TorngitBaseAdapter):
             except TorngitClientError as ce:
                 raise
             if merge_commit:
-                self.github_set_commit_status_merge_commit_call_counter.inc()
+                url = count_and_get_url_template(
+                    url_name="set_commit_status_merge_commit"
+                ).substitute(slug=self.slug, merge_commit=merge_commit[0])
                 await self.api(
                     client,
                     "post",
-                    "/repos/%s/statuses/%s" % (self.slug, merge_commit[0]),
+                    url,
                     body=dict(
                         state=status,
                         target_url=url,
@@ -1350,11 +1450,13 @@ class Github(TorngitBaseAdapter):
             while True:
                 page += 1
                 # https://developer.github.com/v3/repos/statuses/#list-statuses-for-a-specific-ref
-                self.github_get_commit_statuses_call_counter.inc()
+                url = count_and_get_url_template(
+                    url_name="get_commit_statuses"
+                ).substitute(slug=self.slug, commit=commit)
                 res = await self.api(
                     client,
                     "get",
-                    "/repos/%s/commits/%s/status" % (self.slug, commit),
+                    url,
                     page=page,
                     per_page=100,
                     token=token,
@@ -1383,16 +1485,10 @@ class Github(TorngitBaseAdapter):
         # https://developer.github.com/v3/repos/contents/#get-contents
         try:
             async with self.get_client() as client:
-                self.github_get_source_call_counter.inc()
-                content = await self.api(
-                    client,
-                    "get",
-                    "/repos/{0}/contents/{1}".format(
-                        self.slug, path.replace(" ", "%20")
-                    ),
-                    ref=ref,
-                    token=token,
+                url = count_and_get_url_template(url_name="get_source").substitute(
+                    slug=self.slug, path=path.replace(" ", "%20")
                 )
+                content = await self.api(client, "get", url, ref=ref, token=token)
 
                 # When file size is greater than 1MB, content would not populate,
                 # instead we have to retrieve it from the download_url
@@ -1401,7 +1497,8 @@ class Github(TorngitBaseAdapter):
                     and content.get("download_url")
                     and content.get("encoding") == "none"
                 ):
-                    self.github_get_source_content_call_counter.inc()
+                    # not a templated url, count separately
+                    count_and_get_url_template(url_name="get_source_again")
                     content["content"] = await self.api(
                         client=client, method="get", url=content["download_url"]
                     )
@@ -1423,11 +1520,13 @@ class Github(TorngitBaseAdapter):
         # https://developer.github.com/v3/repos/commits/#get-a-single-commit
         try:
             async with self.get_client() as client:
-                self.github_get_commit_diff_call_counter.inc()
+                url = count_and_get_url_template(url_name="get_commit_diff").substitute(
+                    slug=self.slug, commit=commit
+                )
                 res = await self.api(
                     client,
                     "get",
-                    "/repos/%s/commits/%s" % (self.slug, commit),
+                    url,
                     headers={"Accept": "application/vnd.github.v3.diff"},
                     token=token,
                 )
@@ -1451,13 +1550,10 @@ class Github(TorngitBaseAdapter):
         token = self.get_token_by_type_if_none(token, TokenType.read)
         # https://developer.github.com/v3/repos/commits/#compare-two-commits
         async with self.get_client() as client:
-            self.github_get_compare_call_counter.inc()
-            res = await self.api(
-                client,
-                "get",
-                "/repos/%s/compare/%s...%s" % (self.slug, base, head),
-                token=token,
+            url = count_and_get_url_template(url_name="get_compare").substitute(
+                slug=self.slug, base=base, head=head
             )
+            res = await self.api(client, "get", url, token=token)
         files = {}
         for f in res["files"]:
             diff = self.diff_to_json(
@@ -1514,13 +1610,10 @@ class Github(TorngitBaseAdapter):
         token = self.get_token_by_type_if_none(token, TokenType.read)
         # https://developer.github.com/v3/repos/commits/#compare-two-commits
         async with self.get_client() as client:
-            self.github_get_distance_in_commits_call_counter.inc()
-            res = await self.api(
-                client,
-                "get",
-                "/repos/%s/compare/%s...%s" % (self.slug, base_branch, base),
-                token=token,
-            )
+            url = count_and_get_url_template(
+                url_name="get_distance_in_commits"
+            ).substitute(slug=self.slug, base_branch=base_branch, base=base)
+            res = await self.api(client, "get", url, token=token)
         behind_by = res.get("behind_by")
         behind_by_commit = res["base_commit"]["sha"] if "base_commit" in res else None
         if behind_by is None or behind_by_commit is None:
@@ -1606,13 +1699,10 @@ class Github(TorngitBaseAdapter):
         # https://developer.github.com/v3/pulls/#get-a-single-pull-request
         async with self.get_client() as client:
             try:
-                self.github_get_pull_request_call_counter.inc()
-                res = await self.api(
-                    client,
-                    "get",
-                    "/repos/%s/pulls/%s" % (self.slug, pullid),
-                    token=token,
-                )
+                url = count_and_get_url_template(
+                    url_name="get_pull_request"
+                ).substitute(slug=self.slug, pullid=pullid)
+                res = await self.api(client, "get", url, token=token)
             except TorngitClientError as ce:
                 if ce.code == 404:
                     raise TorngitObjectNotFoundError(
@@ -1661,11 +1751,13 @@ class Github(TorngitBaseAdapter):
         async with self.get_client() as client:
             while True:
                 page += 1
-                self.github_get_pull_requests_call_counter.inc()
+                url = count_and_get_url_template(
+                    url_name="get_pull_requests"
+                ).substitute(slug=self.slug)
                 res = await self.api(
                     client,
                     "get",
-                    "/repos/%s/pulls" % self.slug,
+                    url,
                     page=page,
                     per_page=25,
                     state=state,
@@ -1690,13 +1782,10 @@ class Github(TorngitBaseAdapter):
         async with self.get_client() as client:
             # https://docs.github.com/en/rest/commits/commits#list-pull-requests-associated-with-a-commit
             try:
-                self.github_find_pull_request_call_counter.inc()
-                res = await self.api(
-                    client,
-                    "get",
-                    f"/repos/{self.slug}/commits/{commit}/pulls",
-                    token=token,
-                )
+                url = count_and_get_url_template(
+                    url_name="find_pull_request"
+                ).substitute(slug=self.slug, commit=commit)
+                res = await self.api(client, "get", url, token=token)
                 prs_with_commit = [
                     data["number"] for data in res if data["state"] == state
                 ]
@@ -1724,13 +1813,10 @@ class Github(TorngitBaseAdapter):
         async with self.get_client() as client:
             # https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#list-pull-requests-files
             try:
-                self.github_get_pull_request_files_call_counter.inc()
-                res = await self.api(
-                    client,
-                    "get",
-                    f"/repos/{self.slug}/pulls/{pullid}/files",
-                    token=token,
-                )
+                url = count_and_get_url_template(
+                    url_name="get_pull_request_files"
+                ).substitute(slug=self.slug, pullid=pullid)
+                res = await self.api(client, "get", url, token=token)
                 filenames = [data.get("filename") for data in res]
                 return filenames
             except TorngitClientError as ce:
@@ -1748,11 +1834,14 @@ class Github(TorngitBaseAdapter):
         token = self.get_token_by_type_if_none(token, TokenType.read)
         # https://developer.github.com/v3/repos/contents/#get-contents
         if dir_path:
-            url = f"/repos/{self.slug}/contents/{dir_path}"
+            url = count_and_get_url_template(
+                url_name="list_files_with_dir_path"
+            ).substitute(slug=self.slug, dir_path=dir_path)
         else:
-            url = f"/repos/{self.slug}/contents"
+            url = count_and_get_url_template(url_name="list_files").substitute(
+                slug=self.slug
+            )
         async with self.get_client() as client:
-            self.github_list_files_call_counter.inc()
             content = await self.api(client, "get", url, ref=ref, token=token)
         return [
             {
@@ -1773,21 +1862,20 @@ class Github(TorngitBaseAdapter):
     async def get_ancestors_tree(self, commitid, token=None):
         token = self.get_token_by_type_if_none(token, TokenType.read)
         async with self.get_client() as client:
-            self.github_get_ancestors_tree_call_counter.inc()
-            res = await self.api(
-                client,
-                "get",
-                "/repos/%s/commits" % self.slug,
-                token=token,
-                sha=commitid,
+            url = count_and_get_url_template(url_name="get_ancestors_tree").substitute(
+                slug=self.slug
             )
+            res = await self.api(client, "get", url, token=token, sha=commitid)
         start = res[0]["sha"]
         commit_mapping = {val["sha"]: [k["sha"] for k in val["parents"]] for val in res}
         return self.build_tree_from_commits(start, commit_mapping)
 
     def get_external_endpoint(self, endpoint: Endpoints, **kwargs):
+        # used in parent obj to get_href
+        # I think this is for creating a clickable link,
+        # not a token-using call by us, so not counting these calls.
         if endpoint == Endpoints.commit_detail:
-            return "{username}/{name}/commit/{commitid}".format(
+            return external_endpoint_template.substitute(
                 username=self.data["owner"]["username"],
                 name=self.data["repo"]["name"],
                 commitid=kwargs["commitid"],
@@ -1800,11 +1888,13 @@ class Github(TorngitBaseAdapter):
         self, check_name, head_sha, status="in_progress", token=None
     ):
         async with self.get_client() as client:
-            self.github_create_check_run_call_counter.inc()
+            url = count_and_get_url_template(url_name="create_check_run").substitute(
+                slug=self.slug
+            )
             res = await self.api(
                 client,
                 "post",
-                "/repos/{}/check-runs".format(self.slug),
+                url,
                 body=dict(name=check_name, head_sha=head_sha, status=status),
                 token=token,
             )
@@ -1827,29 +1917,25 @@ class Github(TorngitBaseAdapter):
             )
         url = ""
         if check_suite_id is not None:
-            url = (
-                "/repos/{}/check-suites/{}/check-runs".format(
-                    self.slug, check_suite_id
-                ),
-            )
+            url = count_and_get_url_template(
+                url_name="get_check_runs_with_check_suite_id"
+            ).substitute(slug=self.slug, check_suite_id=check_suite_id)
         elif head_sha is not None:
-            url = "/repos/{}/commits/{}/check-runs".format(self.slug, head_sha)
+            url = count_and_get_url_template(
+                url_name="get_check_runs_with_head_sha"
+            ).substitute(slug=self.slug, head_sha=head_sha)
         if name is not None:
-            url += "?check_name={}".format(name)
+            url += f"?check_name={name}"
         async with self.get_client() as client:
-            self.github_get_check_runs_call_counter.inc()
             res = await self.api(client, "get", url, token=token)
             return res
 
     async def get_check_suites(self, git_sha, token=None):
         async with self.get_client() as client:
-            self.github_get_check_suites_call_counter.inc()
-            res = await self.api(
-                client,
-                "get",
-                "/repos/{}/commits/{}/check-suites".format(self.slug, git_sha),
-                token=token,
+            url = count_and_get_url_template(url_name="get_check_suites").substitute(
+                slug=self.slug, git_sha=git_sha
             )
+            res = await self.api(client, "get", url, token=token)
             return res
 
     # TODO: deprecated - favour the get_repos_with_languages_graphql() method instead
@@ -1861,11 +1947,11 @@ class Github(TorngitBaseAdapter):
         Returns:
             List[str]: A list of language names
         """
-        self.github_get_repo_languages_call_counter.inc()
         async with self.get_client() as client:
-            res = await self.api(
-                client, "get", "/repos/{}/languages".format(self.slug), token=token
+            url = count_and_get_url_template(url_name="get_repo_languages").substitute(
+                slug=self.slug
             )
+            res = await self.api(client, "get", url, token=token)
         return list(k.lower() for k in res.keys())
 
     async def get_repos_with_languages_graphql(
@@ -1894,14 +1980,10 @@ class Github(TorngitBaseAdapter):
                         "first": first,
                     },
                 )
-                self.github_get_repos_with_languages_graphql_call_counter.inc()
-                res = await self.api(
-                    client,
-                    "post",
-                    "/graphql",
-                    body=query,
-                    token=token,
-                )
+                url = count_and_get_url_template(
+                    url_name="get_repos_with_languages_graphql"
+                ).substitute()
+                res = await self.api(client, "post", url, body=query, token=token)
                 repoOwner = res["data"]["repositoryOwner"]
                 if not repoOwner:
                     hasNextPage = False
@@ -1933,14 +2015,10 @@ class Github(TorngitBaseAdapter):
         if url:
             body["details_url"] = url
         async with self.get_client() as client:
-            self.github_update_check_run_call_counter.inc()
-            res = await self.api(
-                client,
-                "patch",
-                "/repos/{}/check-runs/{}".format(self.slug, check_run_id),
-                body=body,
-                token=token,
+            url = count_and_get_url_template(url_name="update_check_run").substitute(
+                slug=self.slug, check_run_id=check_run_id
             )
+            res = await self.api(client, "patch", url, body=body, token=token)
             return res
 
     # Get information for a GitHub Actions build/workflow run
@@ -1970,13 +2048,10 @@ class Github(TorngitBaseAdapter):
         Run = one instance when the workflow was triggered
         """
         async with self.get_client() as client:
-            self.github_get_workflow_run_call_counter.inc()
-            res = await self.api(
-                client,
-                "get",
-                "/repos/%s/actions/runs/%s" % (self.slug, run_id),
-                token=token,
+            url = count_and_get_url_template(url_name="get_workflow_run").substitute(
+                slug=self.slug, run_id=run_id
             )
+            res = await self.api(client, "get", url, token=token)
         return self.actions_run_info(res)
 
     def loggable_token(self, token) -> str:
@@ -2025,9 +2100,10 @@ class Github(TorngitBaseAdapter):
             List[str]: A list of branch names
         """
         token = self.get_token_by_type_if_none(token, TokenType.read)
-        url = f"/repos/{self.slug}/commits/{commit_sha}/branches-where-head"
+        url = count_and_get_url_template(
+            url_name="get_best_effort_branches"
+        ).substitute(slug=self.slug, commit_sha=commit_sha)
         async with self.get_client() as client:
-            self.github_get_best_effort_branches_call_counter.inc()
             res = await self.api(
                 client,
                 "get",
@@ -2040,10 +2116,8 @@ class Github(TorngitBaseAdapter):
     async def is_student(self):
         async with self.get_client([3, 3]) as client:
             try:
-                self.github_is_student_call_counter.inc()
-                res = await self.api(
-                    client, "get", "https://education.github.com/api/user"
-                )
+                url = count_and_get_url_template(url_name="is_student").substitute()
+                res = await self.api(client, "get", url)
                 return res["student"]
             except TorngitServerUnreachableError:
                 log.warning("Timeout on Github Education API for is_student")
@@ -2061,17 +2135,16 @@ class Github(TorngitBaseAdapter):
         This is a generator function that yields the pages from webhook deliveries until all have been requested.
         Page size is 50.
         """
-        base_url = "/app/hook/deliveries"
-        url = base_url + "?per_page=50"
         headers = {
             "Accept": "application/vnd.github+json",
             "Authorization": f"Bearer {self.token['key']}",
         }
         async with self.get_client() as client:
+            # count_and_get_url_template is called in paginated_api_generator
             async for response in self.paginated_api_generator(
                 client,
                 "get",
-                url,
+                url_name="list_webhook_deliveries",
                 headers=headers,
             ):
                 yield response
@@ -2081,14 +2154,15 @@ class Github(TorngitBaseAdapter):
         Request redelivery of a webhook from github app. Returns True if request is successful, False otherwise.
         docs: https://docs.github.com/en/rest/apps/webhooks?apiVersion=2022-11-28#redeliver-a-delivery-for-an-app-webhook
         """
-        url = f"/app/hook/deliveries/{delivery_id}/attempts"
+        url = count_and_get_url_template(
+            url_name="request_webhook_redelivery"
+        ).substitute(delivery_id=delivery_id)
         headers = {
             "Accept": "application/vnd.github+json",
             "Authorization": f"Bearer {self.token['key']}",
         }
         async with self.get_client() as client:
             try:
-                self.github_request_webhook_redelivery_call_counter.inc()
                 await self.api(client, "post", url, headers=headers)
                 return True
             except (TorngitClientError, TorngitServer5xxCodeError):

--- a/shared/torngit/github.py
+++ b/shared/torngit/github.py
@@ -43,6 +43,15 @@ GITHUB_API_CALL_COUNTER = Counter(
     ["endpoint"],
 )
 
+GITHUB_API_ENDPOINTS = {
+    "test_2": GITHUB_API_CALL_COUNTER.labels(endpoint="test_2"),
+    "test_4": GITHUB_API_CALL_COUNTER.labels(endpoint="test_4"),
+}
+
+GITHUB_API_CALL_COUNTER.labels(endpoint="test_3")
+GITHUB_API_CALL_COUNTER.labels(endpoint="test_3").inc()
+GITHUB_API_ENDPOINTS["test_4"].inc()
+
 
 class GitHubGraphQLQueries(object):
     _queries = dict(
@@ -134,6 +143,7 @@ class Github(TorngitBaseAdapter):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         # call each counter/label combination to initialize it
+        GITHUB_API_CALL_COUNTER.labels(endpoint="test_1")
         self.github_request_webhook_redelivery_call_counter = (
             GITHUB_API_CALL_COUNTER.labels(endpoint="request_webhook_redelivery")
         )

--- a/tests/unit/test_github.py
+++ b/tests/unit/test_github.py
@@ -1,4 +1,5 @@
 import pytest
+from prometheus_client import REGISTRY
 
 from shared.github import InvalidInstallationError, get_github_integration_token
 
@@ -23,6 +24,10 @@ C/tY+lZIEO1Gg/FxSMB+hwwhwfSuE3WohZfEcSy+R48=
 
 class TestGithubSpecificLogic(object):
     def test_get_github_integration_token_enterprise(self, mocker, mock_configuration):
+        before = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total",
+            labels={"endpoint": "get_github_integration_token"},
+        )
         service = "github_enterprise"
         mock_configuration._params[service] = {"url": "http://legit-github"}
         integration_id = 1
@@ -38,10 +43,19 @@ class TestGithubSpecificLogic(object):
                 "User-Agent": "Codecov",
             },
         )
+        after = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total",
+            labels={"endpoint": "get_github_integration_token"},
+        )
+        assert after - before == 0
 
     def test_get_github_integration_token_enterprise_host_override(
         self, mocker, mock_configuration
     ):
+        before = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total",
+            labels={"endpoint": "get_github_integration_token"},
+        )
         service = "github_enterprise"
         mock_configuration._params[service] = {
             "url": "https://legit-github",
@@ -61,8 +75,17 @@ class TestGithubSpecificLogic(object):
                 "Host": "some-other-github.com",
             },
         )
+        after = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total",
+            labels={"endpoint": "get_github_integration_token"},
+        )
+        assert after - before == 0
 
     def test_get_github_integration_token_production(self, mocker, mock_configuration):
+        before = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total",
+            labels={"endpoint": "get_github_integration_token"},
+        )
         service = "github"
         mock_configuration._params["github_enterprise"] = {"url": "http://legit-github"}
         integration_id = 1
@@ -78,10 +101,19 @@ class TestGithubSpecificLogic(object):
                 "User-Agent": "Codecov",
             },
         )
+        after = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total",
+            labels={"endpoint": "get_github_integration_token"},
+        )
+        assert after - before == 1
 
     def test_get_github_integration_token_production_host_override(
         self, mocker, mock_configuration
     ):
+        before = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total",
+            labels={"endpoint": "get_github_integration_token"},
+        )
         service = "github"
         api_url = "https://legit-github"
         mock_configuration._params["github"] = {
@@ -102,8 +134,17 @@ class TestGithubSpecificLogic(object):
                 "Host": "api.github.com",
             },
         )
+        after = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total",
+            labels={"endpoint": "get_github_integration_token"},
+        )
+        assert after - before == 1
 
     def test_get_github_integration_token_not_found(self, mocker, mock_configuration):
+        before = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total",
+            labels={"endpoint": "get_github_integration_token"},
+        )
         service = "github"
         mock_configuration._params["github_enterprise"] = {"url": "http://legit-github"}
         integration_id = 1
@@ -120,10 +161,19 @@ class TestGithubSpecificLogic(object):
                 "User-Agent": "Codecov",
             },
         )
+        after = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total",
+            labels={"endpoint": "get_github_integration_token"},
+        )
+        assert after - before == 1
 
     def test_get_github_integration_token_unauthorized(
         self, mocker, mock_configuration
     ):
+        before = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total",
+            labels={"endpoint": "get_github_integration_token"},
+        )
         service = "github"
         mock_configuration._params["github_enterprise"] = {"url": "http://legit-github"}
         integration_id = 1
@@ -144,3 +194,8 @@ class TestGithubSpecificLogic(object):
                 "User-Agent": "Codecov",
             },
         )
+        after = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total",
+            labels={"endpoint": "get_github_integration_token"},
+        )
+        assert after - before == 1

--- a/tests/unit/torngit/test_base.py
+++ b/tests/unit/torngit/test_base.py
@@ -1,5 +1,7 @@
 import textwrap
 
+import pytest
+
 from shared.torngit.base import TokenType, TorngitBaseAdapter
 
 
@@ -39,6 +41,12 @@ class TestTorngitBaseAdapter(object):
         assert instance.get_token_by_type(TokenType.admin) == {"key": "admin"}
         assert instance.get_token_by_type(TokenType.comment) == {"key": "token"}
         assert instance.get_token_by_type(TokenType.status) == {"key": "token"}
+
+    def test_no_token(self):
+        instance = TorngitBaseAdapter()
+        with pytest.raises(Exception) as exp:
+            instance.token
+        assert str(exp.value) == "Oauth consumer token not present"
 
     def test_diff_to_json_no_newline(self):
         instance = TorngitBaseAdapter()

--- a/tests/unit/torngit/test_github.py
+++ b/tests/unit/torngit/test_github.py
@@ -7,10 +7,10 @@ import httpx
 import pytest
 import respx
 from mock import MagicMock
+from prometheus_client import REGISTRY
 
 from shared.torngit.base import TokenType
 from shared.torngit.exceptions import (
-    TorngitCantRefreshTokenError,
     TorngitClientError,
     TorngitClientGeneralError,
     TorngitMisconfiguredCredentials,
@@ -63,7 +63,7 @@ def ghapp_handler():
 # to the tests that we want to see if Github refreshes the tokens
 # other tests won't retry to refresh (cause the handlers dont have callbacks by default)
 async def token_refresh_fake_callback(new_token: Dict) -> None:
-    print("Saving new token after refresh")
+    pass
 
 
 class TestUnitGithub(object):
@@ -193,11 +193,9 @@ class TestUnitGithub(object):
         assert res == "kowabunga"
         assert client.request.call_count == 1
         args, kwargs = client.request.call_args
-        print(args)
         assert len(args) == 2
         built_url = args[1]
         parsed_url = urlparse(built_url)
-        print(parsed_url)
         assert parsed_url.scheme == "https"
         assert parsed_url.netloc == "api.github.com"
         assert parsed_url.path == url
@@ -228,14 +226,11 @@ class TestUnitGithub(object):
         assert res == "kowabunga"
         assert client.request.call_count == 1
         args, kwargs = client.request.call_args
-        print(args)
-        print(kwargs)
         assert kwargs.get("headers") is not None
         assert kwargs.get("headers").get("Host") == "api.github.com"
         assert len(args) == 2
         built_url = args[1]
         parsed_url = urlparse(built_url)
-        print(parsed_url)
         assert parsed_url.scheme == "https"
         assert parsed_url.netloc == mock_host
         assert parsed_url.path == url
@@ -262,14 +257,11 @@ class TestUnitGithub(object):
         await valid_handler.make_http_call(client, method, url, **query_params)
         assert client.request.call_count == 1
         args, kwargs = client.request.call_args
-        print(args)
-        print(kwargs)
         assert kwargs.get("headers") is not None
         assert kwargs.get("headers").get("Host") == "github.com"
         assert len(args) == 2
         built_url = args[1]
         parsed_url = urlparse(built_url)
-        print(parsed_url)
         assert parsed_url.scheme == "https"
         assert parsed_url.netloc == mock_host
         assert parsed_url.path == "/random_url"
@@ -412,6 +404,10 @@ class TestUnitGithub(object):
 
     @pytest.mark.asyncio
     async def test_find_pull_request_success(self, mocker):
+        before = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total",
+            labels={"endpoint": "find_pull_request"},
+        )
         handler = Github(
             repo=dict(name="repo_name"),
             owner=dict(username="username"),
@@ -481,9 +477,18 @@ class TestUnitGithub(object):
                     state="open",
                 ),
             )
+            after = REGISTRY.get_sample_value(
+                "git_provider_api_calls_github_total",
+                labels={"endpoint": "find_pull_request"},
+            )
+            assert after - before == 1
 
     @pytest.mark.asyncio
     async def test_find_pr_by_pulls_failfast_if_no_commit(self, mocker):
+        before = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total",
+            labels={"endpoint": "find_pull_request"},
+        )
         handler = Github(
             repo=dict(name="repo_name"),
             owner=dict(username="username"),
@@ -491,9 +496,18 @@ class TestUnitGithub(object):
         )
         res = await handler.find_pull_request(commit=None)
         assert res is None
+        after = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total",
+            labels={"endpoint": "find_pull_request"},
+        )
+        assert after - before == 0
 
     @pytest.mark.asyncio
     async def test_find_pr_by_pulls_failfast_if_no_slug(self, mocker):
+        before = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total",
+            labels={"endpoint": "find_pull_request"},
+        )
         handler = Github(
             owner=dict(username="username"),
             token=dict(key="aaaaa"),
@@ -502,9 +516,18 @@ class TestUnitGithub(object):
         assert handler.slug is None
         res = await handler.find_pull_request(None, commit_sha, None)
         assert res is None
+        after = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total",
+            labels={"endpoint": "find_pull_request"},
+        )
+        assert after - before == 0
 
     @pytest.mark.asyncio
     async def test_find_pr_by_pulls_raise_exp_if_not_422(self, mocker):
+        before = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total",
+            labels={"endpoint": "find_pull_request"},
+        )
         handler = Github(
             repo=dict(name="repo_name"),
             owner=dict(username="username"),
@@ -522,13 +545,22 @@ class TestUnitGithub(object):
                     headers={"Content-Type": "application/json; charset=utf-8"},
                 )
             )
-            client = handler.get_client()
             token = handler.get_token_by_type(TokenType.read)
             with pytest.raises(TorngitClientGeneralError):
                 await handler.find_pull_request(commit=commit_sha, token=token)
+            after = REGISTRY.get_sample_value(
+                "git_provider_api_calls_github_total",
+                labels={"endpoint": "find_pull_request"},
+            )
+            assert after - before == 1
 
     @pytest.mark.asyncio
     async def test_distance_in_commits(self, mocker):
+
+        before = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total",
+            labels={"endpoint": "get_distance_in_commits"},
+        )
         handler = Github(
             repo=dict(name="repo_name"),
             owner=dict(username="username"),
@@ -566,9 +598,18 @@ class TestUnitGithub(object):
                 repos_default_branch, base_commit_sha
             )
             assert res == expected_result
+            after = REGISTRY.get_sample_value(
+                "git_provider_api_calls_github_total",
+                labels={"endpoint": "get_distance_in_commits"},
+            )
+            assert after - before == 1
 
     @pytest.mark.asyncio
     async def test_null_distance_in_commits(self, mocker):
+        before = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total",
+            labels={"endpoint": "get_distance_in_commits"},
+        )
         handler = Github(
             repo=dict(name="repo_name"),
             owner=dict(username="username"),
@@ -603,9 +644,17 @@ class TestUnitGithub(object):
                 repos_default_branch, base_commit_sha
             )
             assert res == expected_result
+            after = REGISTRY.get_sample_value(
+                "git_provider_api_calls_github_total",
+                labels={"endpoint": "get_distance_in_commits"},
+            )
+            assert after - before == 1
 
     @pytest.mark.asyncio
     async def test_post_comment(self, respx_vcr, valid_handler):
+        before = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total", labels={"endpoint": "post_comment"}
+        )
         mocked_response = respx_vcr.post(
             url="https://api.github.com/repos/ThiagoCodecov/example-python/issues/1/comments",
             json={"body": "Hello world"},
@@ -682,9 +731,20 @@ class TestUnitGithub(object):
         res = await valid_handler.post_comment("1", "Hello world")
         assert res == expected_result
         assert mocked_response.called is True
+        after = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total", labels={"endpoint": "post_comment"}
+        )
+        assert after - before == 1
 
     @pytest.mark.asyncio
     async def test_list_teams(self, valid_handler, respx_vcr):
+        before_first_call = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total", labels={"endpoint": "list_teams"}
+        )
+        before_second_call = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total",
+            labels={"endpoint": "list_teams_org_name"},
+        )
         mocked_response = respx_vcr.get(
             url="https://api.github.com/user/memberships/orgs?state=active&page=1"
         ).respond(
@@ -867,9 +927,25 @@ class TestUnitGithub(object):
         res = await valid_handler.list_teams()
         assert res == expected_result
         assert mocked_response.called is True
+        after_first_call = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total", labels={"endpoint": "list_teams"}
+        )
+        assert after_first_call - before_first_call == 1
+        after_second_call = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total",
+            labels={"endpoint": "list_teams_org_name"},
+        )
+        assert after_second_call - before_second_call == 2  # len(mocked_response[json]
 
     @pytest.mark.asyncio
     async def test_list_team_with_org_response_404(self, valid_handler, respx_vcr):
+        before_first_call = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total", labels={"endpoint": "list_teams"}
+        )
+        before_second_call = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total",
+            labels={"endpoint": "list_teams_org_name"},
+        )
         mocked_response = respx_vcr.get(
             url="https://api.github.com/user/memberships/orgs?state=active&page=1"
         ).respond(
@@ -927,9 +1003,22 @@ class TestUnitGithub(object):
         res = await valid_handler.list_teams()
         assert res == []
         assert mocked_response.called is True
+        after_first_call = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total", labels={"endpoint": "list_teams"}
+        )
+        assert after_first_call - before_first_call == 1
+        after_second_call = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total",
+            labels={"endpoint": "list_teams_org_name"},
+        )
+        assert after_second_call - before_second_call == 1  # len(mocked_response[json]
 
     @pytest.mark.asyncio
     async def test_update_check_run_no_url(self, valid_handler):
+        before = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total",
+            labels={"endpoint": "update_check_run"},
+        )
         with respx.mock:
             mocked_response = respx.patch(
                 url="https://api.github.com/repos/ThiagoCodecov/example-python/check-runs/1256232357",
@@ -946,9 +1035,18 @@ class TestUnitGithub(object):
             res = await valid_handler.update_check_run(1256232357, "success")
 
         assert mocked_response.call_count == 1
+        after = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total",
+            labels={"endpoint": "update_check_run"},
+        )
+        assert after - before == 1
 
     @pytest.mark.asyncio
     async def test_update_check_run_url(self, valid_handler):
+        before = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total",
+            labels={"endpoint": "update_check_run"},
+        )
         url = "https://app.codecov.io/gh/codecov/example-python/compare/1?src=pr"
         with respx.mock:
             mocked_response = respx.patch(
@@ -969,6 +1067,11 @@ class TestUnitGithub(object):
             )
             res = await valid_handler.update_check_run(1256232357, "success", url=url)
         assert mocked_response.call_count == 1
+        after = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total",
+            labels={"endpoint": "update_check_run"},
+        )
+        assert after - before == 1
 
     @pytest.mark.asyncio
     async def test_update_check_run_url_fallback(self, valid_handler):
@@ -1013,6 +1116,10 @@ class TestUnitGithub(object):
 
     @pytest.mark.asyncio
     async def test_get_general_exception_pickle(self, valid_handler, mocker):
+        before = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total",
+            labels={"endpoint": "get_pull_requests"},
+        )
         mock_refresh = mocker.patch.object(Github, "refresh_token")
         valid_handler._on_token_refresh = token_refresh_fake_callback
         with respx.mock:
@@ -1036,6 +1143,11 @@ class TestUnitGithub(object):
 
         assert mocked_response.call_count == 2
         assert mock_refresh.call_count == 1
+        after = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total",
+            labels={"endpoint": "get_pull_requests"},
+        )
+        assert after - before == 1
 
     @pytest.mark.asyncio
     async def test_api_no_token(self):
@@ -1054,6 +1166,11 @@ class TestUnitGithub(object):
 
     @pytest.mark.asyncio
     async def test_list_webhook_deliveries(self, ghapp_handler):
+        before = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total",
+            labels={"endpoint": "list_webhook_deliveries"},
+        )
+
         def side_effect(request):
             assert request.headers.get("Accept") == "application/vnd.github+json"
             assert (
@@ -1131,9 +1248,18 @@ class TestUnitGithub(object):
             async for res in ghapp_handler.list_webhook_deliveries():
                 assert len(res) == 4
         assert mocked_response.call_count == 1
+        after = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total",
+            labels={"endpoint": "list_webhook_deliveries"},
+        )
+        assert after - before == 1
 
     @pytest.mark.asyncio
     async def test_list_webhook_deliveries_multiple_pages(self, ghapp_handler):
+        before = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total",
+            labels={"endpoint": "list_webhook_deliveries"},
+        )
         with respx.mock:
             mocked_response_1 = respx.get(
                 url="https://api.github.com/app/hook/deliveries?per_page=50"
@@ -1219,10 +1345,19 @@ class TestUnitGithub(object):
         assert len(aggregate_res) == 4
         assert mocked_response_1.call_count == 1
         assert mocked_response_2.call_count == 1
+        after = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total",
+            labels={"endpoint": "list_webhook_deliveries"},
+        )
+        assert after - before == 2
 
     @pytest.mark.asyncio
     async def test_webhook_redelivery_success(self, ghapp_handler):
         delivery_id = 17323228732
+        before = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total",
+            labels={"endpoint": "request_webhook_redelivery"},
+        )
 
         def side_effect(request):
             assert request.headers.get("Accept") == "application/vnd.github+json"
@@ -1242,10 +1377,19 @@ class TestUnitGithub(object):
             ans = await ghapp_handler.request_webhook_redelivery(delivery_id)
             assert ans is True
         assert mocked_response.call_count == 1
+        after = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total",
+            labels={"endpoint": "request_webhook_redelivery"},
+        )
+        assert after - before == 1
 
     @pytest.mark.asyncio
     async def test_webhook_redelivery_fail(self, ghapp_handler):
         delivery_id = 17323228732
+        before = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total",
+            labels={"endpoint": "request_webhook_redelivery"},
+        )
         with respx.mock:
             mocked_response = respx.post(
                 url=f"https://api.github.com/app/hook/deliveries/{delivery_id}/attempts"
@@ -1257,9 +1401,18 @@ class TestUnitGithub(object):
             ans = await ghapp_handler.request_webhook_redelivery(delivery_id)
             assert ans is False
         assert mocked_response.call_count == 1
+        after = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total",
+            labels={"endpoint": "request_webhook_redelivery"},
+        )
+        assert after - before == 1
 
     @pytest.mark.asyncio
     async def test_get_pull_request_files_404(self, mocker):
+        before = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total",
+            labels={"endpoint": "get_pull_request_files"},
+        )
         mock_refresh = mocker.patch.object(Github, "refresh_token")
         with respx.mock:
             my_route = respx.get(
@@ -1284,9 +1437,18 @@ class TestUnitGithub(object):
             assert excinfo.value.code == 404
             assert excinfo.value.message == "PR with id 4 does not exist"
         assert mock_refresh.call_count == 1
+        after = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total",
+            labels={"endpoint": "get_pull_request_files"},
+        )
+        assert after - before == 1
 
     @pytest.mark.asyncio
     async def test_get_pull_request_files_403(self):
+        before = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total",
+            labels={"endpoint": "get_pull_request_files"},
+        )
         with respx.mock:
             my_route = respx.get(
                 "https://api.github.com/repos/codecove2e/example-python/pulls/4/files"
@@ -1308,9 +1470,18 @@ class TestUnitGithub(object):
                 res = await handler.get_pull_request_files(4)
             assert excinfo.value.code == 403
             assert excinfo.value.message == "Github API rate limit error: Forbidden"
+            after = REGISTRY.get_sample_value(
+                "git_provider_api_calls_github_total",
+                labels={"endpoint": "get_pull_request_files"},
+            )
+            assert after - before == 1
 
     @pytest.mark.asyncio
     async def test_get_pull_request_files_403_secondary_limit(self):
+        before = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total",
+            labels={"endpoint": "get_pull_request_files"},
+        )
         with respx.mock:
             my_route = respx.get(
                 "https://api.github.com/repos/codecove2e/example-python/pulls/4/files"
@@ -1335,11 +1506,19 @@ class TestUnitGithub(object):
                 == "Github API rate limit error: secondary rate limit"
             )
             assert excinfo.value.retry_after == 60
+            after = REGISTRY.get_sample_value(
+                "git_provider_api_calls_github_total",
+                labels={"endpoint": "get_pull_request_files"},
+            )
+            assert after - before == 1
 
     @pytest.mark.asyncio
     async def test_github_refresh_fail_terminates_unavailable(
         self, mocker, valid_handler
     ):
+        before = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total", labels={"endpoint": "refresh_token"}
+        )
         with pytest.raises(TorngitRefreshTokenFailedError) as exp:
             with respx.mock:
                 mocked_refresh = respx.post(
@@ -1354,11 +1533,18 @@ class TestUnitGithub(object):
                 )
             assert exp.code == 555
         assert mocked_refresh.call_count == 1
+        after = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total", labels={"endpoint": "refresh_token"}
+        )
+        assert after - before == 1
 
     @pytest.mark.asyncio
     async def test_github_refresh_fail_terminates_unauthorized(
         self, mocker, valid_handler
     ):
+        before = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total", labels={"endpoint": "refresh_token"}
+        )
         with pytest.raises(TorngitRefreshTokenFailedError) as exp:
             with respx.mock:
                 mocked_refresh = respx.post(
@@ -1373,6 +1559,10 @@ class TestUnitGithub(object):
                 )
             assert exp.code == 555
         assert mocked_refresh.call_count == 1
+        after = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total", labels={"endpoint": "refresh_token"}
+        )
+        assert after - before == 1
 
     @pytest.mark.asyncio
     async def test_github_refresh_fail_terminates_no_refresh_token(
@@ -1388,6 +1578,9 @@ class TestUnitGithub(object):
 
     @pytest.mark.asyncio
     async def test_github_double_refresh(self, mocker, valid_handler):
+        before = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total", labels={"endpoint": "refresh_token"}
+        )
         def side_effect(request, *args, **kwargs):
             url_parts = urlparse(str(request.url))
             query = url_parts.query
@@ -1431,9 +1624,17 @@ class TestUnitGithub(object):
 
         # Make sure that changing the token doesn't change the _oauth
         assert valid_handler._oauth == dict(key="client_id", secret="client_secret")
+        after = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total", labels={"endpoint": "refresh_token"}
+        )
+        assert after - before == 2
 
     @pytest.mark.asyncio
     async def test_github_is_student_timeout(self, ghapp_handler):
+        before = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total", labels={"endpoint": "is_student"}
+        )
+
         def side_effect(*args, **kwargs):
             raise httpx.TimeoutException("timeout")
 
@@ -1444,9 +1645,17 @@ class TestUnitGithub(object):
             res = await ghapp_handler.is_student()
             assert mocked_route.call_count == 1
             assert res == False
+        after = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total", labels={"endpoint": "is_student"}
+        )
+        assert after - before == 1
 
     @pytest.mark.asyncio
     async def test_github_is_student_network_error(self, ghapp_handler):
+        before = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total", labels={"endpoint": "is_student"}
+        )
+
         def side_effect(*args, **kwargs):
             raise httpx.NetworkError("timeout")
 
@@ -1457,11 +1666,25 @@ class TestUnitGithub(object):
             res = await ghapp_handler.is_student()
             assert mocked_route.call_count == 1
             assert res == False
+        after = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total", labels={"endpoint": "is_student"}
+        )
+        assert after - before == 1
 
     @pytest.mark.asyncio
     async def test_github_refresh_after_failed_request(self, mocker, valid_handler):
+        before = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total", labels={"endpoint": "get_is_admin"}
+        )
+        before_retries = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total",
+            labels={"endpoint": "make_http_call_retry"},
+        )
+        before_token_refresh = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total", labels={"endpoint": "refresh_token"}
+        )
+
         def side_effect(request, *args, **kwargs):
-            print(f"Received request with headers {request.headers['Authorization']}")
             token = request.headers["Authorization"]
             if token == "token some_key":
                 return httpx.Response(
@@ -1504,9 +1727,26 @@ class TestUnitGithub(object):
                 "refresh_token": "new_refresh_token",
             }
         )
+        after = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total", labels={"endpoint": "get_is_admin"}
+        )
+        assert after - before == 1
+        after_retries = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total",
+            labels={"endpoint": "make_http_call_retry"},
+        )
+        assert after_retries - before_retries == 1
+        after_token_refresh = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total", labels={"endpoint": "refresh_token"}
+        )
+        assert after_token_refresh - before_token_refresh == 1
 
     @pytest.mark.asyncio
     async def test__get_owner_from_nodeid(self, ghapp_handler):
+        before = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total",
+            labels={"endpoint": "get_owner_from_nodeid_graphql"},
+        )
         with respx.mock:
             mocked_route = respx.post("https://api.github.com/graphql").mock(
                 return_value=httpx.Response(
@@ -1531,9 +1771,22 @@ class TestUnitGithub(object):
                 )
             assert res == {"username": "codecov", "service_id": 8226205}
             assert mocked_route.call_count == 1
+            after = REGISTRY.get_sample_value(
+                "git_provider_api_calls_github_total",
+                labels={"endpoint": "get_owner_from_nodeid_graphql"},
+            )
+            assert after - before == 1
 
     @pytest.mark.asyncio
     async def test_get_repos_from_nodeids(self, ghapp_handler):
+        before = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total",
+            labels={"endpoint": "get_repos_from_nodeids_generator_graphql"},
+        )
+        before_get_owner = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total",
+            labels={"endpoint": "get_owner_from_nodeid_graphql"},
+        )
         # Mocking different responses from the graphQL API
         # because it all goes to the same endpoint but this test expects a 2nd call
         # with owner by node_id query
@@ -1685,3 +1938,13 @@ class TestUnitGithub(object):
                 },
             ]
             assert mocked_route.call_count == 2
+        after = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total",
+            labels={"endpoint": "get_repos_from_nodeids_generator_graphql"},
+        )
+        assert after - before == 1
+        after_get_owner = REGISTRY.get_sample_value(
+            "git_provider_api_calls_github_total",
+            labels={"endpoint": "get_owner_from_nodeid_graphql"},
+        )
+        assert after_get_owner - before_get_owner == 1


### PR DESCRIPTION
<!-- Describe your PR here. -->
Part of https://github.com/codecov/engineering-team/issues/1167, this is for Github calls, the other git providers will be added next.

We want to know who's making all these calls! So I added some Counters.

This is a first implementation - the strategy I picked was to increment the Counter before the code makes the request to github - it uses a helper function and technically could error out somewhere along the way before it actually makes the call. So you could argue that the Counters are counting intended requests, but hopefully errors between intent-to-call-github and actually making the outgoing request are low, and if not, at least they are logged.

The counts are named for the functions that call them, so we can trace a`Counter` back to the place in our code where it is being called.

An additional task got pulled into this pr - organize and track the github urls we are using, which made the lines in this pr balloon (sorry!). Writing the `Counter` code, I realized that the `urls` dict on the `Github` object was not being used - each function that called an endpoint had a url written as a str. I removed those, put them in a collection, and made them into str `Templates` - now every url has a counter and a template, the counter is incremented when the url is built.

I learned a bit from the Prometheus docs - each label value on a Counter is an individual object that will live and wait around to be incremented (and take up resources). I'm going to try initializing them all on startup, I think this is the right way to use Counters ([reference](https://prometheus.github.io/client_python/instrumenting/labels/)). Additionally, the docs say a Counter shouldn't have more than 10 labels ([reference](https://prometheus.io/docs/practices/instrumentation/#use-labels)), and this one is >50, so we will need to monitor prometheus performance around this deploy.
