### PR TITLE
feat: improve fallback system

### DIFF
--- a/shared/github/__init__.py
+++ b/shared/github/__init__.py
@@ -5,6 +5,7 @@ from urllib.parse import urlparse
 
 import jwt
 import requests
+from redis import Redis
 
 import shared.torngit as torngit
 from shared.config import get_config, load_file_from_path_at_config
@@ -125,3 +126,15 @@ def get_github_integration_token(
         return res_json["token"]
     else:
         return token
+
+
+def mark_installation_as_rate_limited(
+    redis_connection: Redis, installation_id: int, ttl_seconds: int
+) -> None:
+    redis_connection.set(
+        name=f"rate_limited_installations_{installation_id}", value=1, ex=ttl_seconds
+    )
+
+
+def is_installation_rate_limited(redis_connection: Redis, installation_id: int) -> bool:
+    return redis_connection.exists(f"rate_limited_installations_{installation_id}")

--- a/shared/github/__init__.py
+++ b/shared/github/__init__.py
@@ -5,7 +5,7 @@ from urllib.parse import urlparse
 
 import jwt
 import requests
-from redis import Redis
+from redis import Redis, RedisError
 
 import shared.torngit as torngit
 from shared.config import get_config, load_file_from_path_at_config
@@ -131,10 +131,25 @@ def get_github_integration_token(
 def mark_installation_as_rate_limited(
     redis_connection: Redis, installation_id: int, ttl_seconds: int
 ) -> None:
-    redis_connection.set(
-        name=f"rate_limited_installations_{installation_id}", value=1, ex=ttl_seconds
-    )
+    try:
+        redis_connection.set(
+            name=f"rate_limited_installations_{installation_id}",
+            value=1,
+            ex=ttl_seconds,
+        )
+    except RedisError:
+        log.exception(
+            "Failed to mark installation ID as rate_limited due to RedisError",
+            extra=dict(installation_id=installation_id),
+        )
 
 
 def is_installation_rate_limited(redis_connection: Redis, installation_id: int) -> bool:
-    return redis_connection.exists(f"rate_limited_installations_{installation_id}")
+    try:
+        return redis_connection.exists(f"rate_limited_installations_{installation_id}")
+    except RedisError:
+        log.exception(
+            "Failed to check if installation ID is rate_limited due to RedisError",
+            extra=dict(installation_id=installation_id),
+        )
+        return False

--- a/shared/torngit/base.py
+++ b/shared/torngit/base.py
@@ -6,7 +6,11 @@ import httpx
 
 from shared.torngit.cache import torngit_cache
 from shared.torngit.enums import Endpoints
-from shared.typings.oauth_token_types import OauthConsumerToken, OnRefreshCallback
+from shared.typings.oauth_token_types import (
+    OauthConsumerToken,
+    OnRefreshCallback,
+    Token,
+)
 
 get_start_of_line = re.compile(r"@@ \-(\d+),?(\d*) \+(\d+),?(\d*).*").match
 
@@ -24,7 +28,7 @@ class TorngitBaseAdapter(object):
     _aws_key = None
     _oauth: OauthConsumerToken = None
     _on_token_refresh: OnRefreshCallback = None
-    _token = None
+    _token: Token = None
     verify_ssl = None
 
     valid_languages = (
@@ -54,7 +58,7 @@ class TorngitBaseAdapter(object):
         self,
         oauth_consumer_token: OauthConsumerToken = None,
         timeouts=None,
-        token=None,
+        token: Token = None,
         token_type_mapping: Dict[TokenType, Dict] = None,
         on_token_refresh: OnRefreshCallback = None,
         verify_ssl=None,

--- a/shared/torngit/github.py
+++ b/shared/torngit/github.py
@@ -1,5 +1,6 @@
 import asyncio
 import base64
+import datetime
 import hashlib
 import logging
 import os
@@ -12,10 +13,10 @@ import httpx
 from httpx import Response
 
 from shared.config import get_config
-from shared.github import get_github_jwt_token
+from shared.github import get_github_jwt_token, mark_installation_as_rate_limited
 from shared.metrics import Counter, metrics
 from shared.torngit.base import TokenType, TorngitBaseAdapter
-from shared.torngit.cache import torngit_cache
+from shared.torngit.cache import get_redis_connection, torngit_cache
 from shared.torngit.enums import Endpoints
 from shared.torngit.exceptions import (
     TorngitClientError,
@@ -30,7 +31,7 @@ from shared.torngit.exceptions import (
     TorngitUnauthorizedError,
 )
 from shared.torngit.status import Status
-from shared.typings.oauth_token_types import OauthConsumerToken
+from shared.typings.oauth_token_types import OauthConsumerToken, Token
 from shared.utils.urls import url_concat
 
 log = logging.getLogger(__name__)
@@ -411,6 +412,10 @@ class Github(TorngitBaseAdapter):
     service = "github"
     graphql = GitHubGraphQLQueries()
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._redis_connection = get_redis_connection()
+
     @classmethod
     def get_service_url(cls):
         return get_config("github", "url", default="https://github.com").strip("/")
@@ -518,16 +523,64 @@ class Github(TorngitBaseAdapter):
                 )
                 return res.text
 
-    def _get_next_fallback_token(self, fallback_idx: int) -> Optional[str]:
+    def _possibly_mark_current_installation_as_rate_limited(
+        self,
+        *,
+        reset_timestamp: Optional[str] = None,
+        retry_in_seconds: Optional[int] = None,
+    ) -> None:
+        current_token = self.token
+        if current_token.get("installation_id") is not None:
+            installation_id = current_token["installation_id"]
+            if retry_in_seconds is None and reset_timestamp is None:
+                log.warning(
+                    "Can't mark installation as rate limited because TTL is missing",
+                    extra=dict(installation_id=installation_id),
+                )
+                return
+            ttl_seconds = retry_in_seconds
+            if ttl_seconds is None:
+                # https://docs.github.com/en/rest/using-the-rest-api/best-practices-for-using-the-rest-api?apiVersion=2022-11-28#handle-rate-limit-errors-appropriately
+                ttl_seconds = int(reset_timestamp) - int(
+                    datetime.datetime.now(datetime.timezone.utc).timestamp()
+                )
+            log.info(
+                "Marking installation as rate limited",
+                extra=dict(
+                    installation_id=installation_id,
+                    rate_limit_duration_seconds=ttl_seconds,
+                ),
+            )
+            mark_installation_as_rate_limited(
+                self._redis_connection, installation_id, ttl_seconds
+            )
+
+    def _get_next_fallback_token(
+        self,
+        *,
+        reset_timestamp: Optional[str] = None,
+        retry_in_seconds: Optional[int] = None,
+    ) -> Optional[str]:
         """If additional fallback tokens were passed to this instance of GitHub
         select the next token in line to retry the previous request.
+
+        !side effect: Marks the current token as rate limited in redis
+        !side effect: Updates the self._token value
+        !side effect: Consumes one of the fallback_tokens
         """
-        fallback_tokens: List[str] = self.data.get("fallback_tokens", None)
-        if fallback_tokens is None:
+        fallback_tokens: List[Token] = self.data.get("fallback_tokens", None)
+        if fallback_tokens is None or fallback_tokens == []:
             # No tokens to fallback on
             return None
-        if fallback_idx < len(fallback_tokens):
-            return fallback_tokens[fallback_idx]
+        # ! side effect: mark current token as rate limited
+        self._possibly_mark_current_installation_as_rate_limited(
+            reset_timestamp=reset_timestamp, retry_in_seconds=retry_in_seconds
+        )
+        # ! side effect: consume one of the fallback tokens (makes it the token of this instance)
+        token_to_use = fallback_tokens.pop(0)
+        # ! side effect: update the token so subsequent requests won't fail
+        self._token = token_to_use
+        return token_to_use["key"]
 
     async def make_http_call(
         self,
@@ -573,7 +626,6 @@ class Github(TorngitBaseAdapter):
         )
         max_number_retries = 3
         tried_refresh = False
-        fallback_idx = 0
         for current_retry in range(1, max_number_retries + 1):
             retry_reason = "retriable_status"
             try:
@@ -636,6 +688,46 @@ class Github(TorngitBaseAdapter):
                     # It does consume one of the retries
                     retry_reason = "token_was_refreshed"
                     continue
+            # Rate limit errors - we might fallback on other available tokens and retry
+            # If we do fallback the token with rate limit is marked as 'rate limited' in Redis
+            elif (res.status_code == 403 or res.status_code == 429) and (
+                (
+                    # Primary rate limit
+                    int(res.headers.get("X-RateLimit-Remaining", -1)) == 0
+                    or
+                    # Secondary rate limit
+                    res.headers.get("Retry-After") is not None
+                )
+            ):
+                is_primary_rate_limit = (
+                    int(res.headers.get("X-RateLimit-Remaining", -1)) == 0
+                )
+                metrics.incr(f"{METRICS_PREFIX}.api.ratelimiterror")
+                reset_timestamp = res.headers.get("X-RateLimit-Reset")
+                retry_after = res.headers.get("Retry-After")
+                fallback_token_key = self._get_next_fallback_token(
+                    reset_timestamp=reset_timestamp,
+                    retry_in_seconds=(
+                        int(retry_after) if retry_after is not None else None
+                    ),
+                )
+                if fallback_token_key:
+                    # Update header and try again
+                    # Consumes one of the retries
+                    prefix, _ = _headers["Authorization"].split(" ")
+                    _headers["Authorization"] = f"{prefix} {fallback_token_key}"
+                    retry_reason = "fallback_token_attempt"
+                    continue
+                else:
+                    message = f"Github API rate limit error: {res.reason_phrase if is_primary_rate_limit else 'secondary rate limit'}"
+                    raise TorngitRateLimitError(
+                        response_data=res.text,
+                        message=message,
+                        reset=res.headers.get("X-RateLimit-Reset"),
+                        retry_after=(
+                            int(retry_after) if retry_after is not None else None
+                        ),
+                    )
             if (
                 not statuses_to_retry
                 or res.status_code not in statuses_to_retry
@@ -649,38 +741,6 @@ class Github(TorngitBaseAdapter):
                 elif res.status_code >= 500:
                     metrics.incr(f"{METRICS_PREFIX}.api.5xx")
                     raise TorngitServer5xxCodeError("Github is having 5xx issues")
-                elif (res.status_code == 403 or res.status_code == 429) and int(
-                    res.headers.get("X-RateLimit-Remaining", -1)
-                ) == 0:
-                    metrics.incr(f"{METRICS_PREFIX}.api.ratelimiterror")
-                    fallback_token = self._get_next_fallback_token(fallback_idx)
-                    if fallback_token:
-                        fallback_idx += 1
-                        # Update header and try again
-                        # Consumes one of the retries
-                        prefix, _ = _headers["Authorization"].split(" ")
-                        _headers["Authorization"] = f"{prefix} {fallback_token}"
-                        retry_reason = "fallback_token_attempt"
-                        continue
-                    else:
-                        message = f"Github API rate limit error: {res.reason_phrase}"
-                        raise TorngitRateLimitError(
-                            response_data=res.text,
-                            message=message,
-                            reset=res.headers.get("X-RateLimit-Reset"),
-                        )
-                elif (
-                    res.status_code == 403 or res.status_code == 429
-                ) and res.headers.get("Retry-After") is not None:
-                    # https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#secondary-rate-limits
-                    message = f"Github API rate limit error: secondary rate limit"
-                    retry_after = int(res.headers.get("Retry-After"))
-                    metrics.incr(f"{METRICS_PREFIX}.api.ratelimiterror")
-                    raise TorngitRateLimitError(
-                        response_data=res.text,
-                        message=message,
-                        retry_after=retry_after,
-                    )
                 elif res.status_code == 401:
                     message = f"Github API unauthorized error: {res.reason_phrase}"
                     metrics.incr(f"{METRICS_PREFIX}.api.unauthorizederror")

--- a/shared/torngit/github.py
+++ b/shared/torngit/github.py
@@ -1,10 +1,10 @@
 import asyncio
 import base64
-import datetime
 import hashlib
 import logging
 import os
 from base64 import b64decode
+from datetime import datetime, timezone
 from string import Template
 from typing import Dict, List, Optional
 from urllib.parse import parse_qs, urlencode
@@ -546,7 +546,7 @@ class Github(TorngitBaseAdapter):
             if ttl_seconds is None:
                 # https://docs.github.com/en/rest/using-the-rest-api/best-practices-for-using-the-rest-api?apiVersion=2022-11-28#handle-rate-limit-errors-appropriately
                 ttl_seconds = int(reset_timestamp) - int(
-                    datetime.datetime.now(datetime.timezone.utc).timestamp()
+                    datetime.now(timezone.utc).timestamp()
                 )
             log.info(
                 "Marking installation as rate limited",

--- a/shared/typings/oauth_token_types.py
+++ b/shared/typings/oauth_token_types.py
@@ -1,10 +1,16 @@
 from typing import Any, Awaitable, Callable, Optional, TypedDict
 
 
-class OauthConsumerToken(TypedDict):
+class Token(TypedDict):
     key: str
-    secret: str
-    refresh_token: str
+    # The installation ID that this token belongs to
+    # Used to mark them as rate-limited
+    installation_id: Optional[int] = None
+
+
+class OauthConsumerToken(Token):
+    secret: Optional[str]
+    refresh_token: Optional[str]
 
 
 OnRefreshCallback = Optional[Callable[[OauthConsumerToken], Awaitable[None]]]

--- a/shared/typings/oauth_token_types.py
+++ b/shared/typings/oauth_token_types.py
@@ -1,6 +1,16 @@
 from typing import Any, Awaitable, Callable, Optional, TypedDict
 
 
+class GithubInstallationInfo(TypedDict):
+    """Required info to get a token from Github for a given installation"""
+
+    installation_id: int
+    # The default app (configured via yaml) doesn't need this info.
+    # All other apps need app_id and pem_path
+    app_id: Optional[int] = None
+    pem_path: Optional[str] = None
+
+
 class Token(TypedDict):
     key: str
     # The installation ID that this token belongs to

--- a/tests/unit/torngit/test_github.py
+++ b/tests/unit/torngit/test_github.py
@@ -1,4 +1,5 @@
 import asyncio
+import datetime
 import pickle
 from typing import Dict
 from urllib.parse import parse_qs, parse_qsl, urlparse
@@ -36,7 +37,7 @@ def valid_handler():
     return Github(
         repo=dict(name="example-python"),
         owner=dict(username="ThiagoCodecov"),
-        token=dict(key="some_key", refresh_token="refresh_token"),
+        token=dict(key="some_key", refresh_token="refresh_token", installation_id=0),
         oauth_consumer_token=dict(
             key="client_id",
             secret="client_secret",
@@ -49,7 +50,7 @@ def ghapp_handler():
     return Github(
         repo=dict(name="example-python", using_integration=True),
         owner=dict(username="codecov-e2e", integration_id=10000),
-        token=dict(key="integration_token"),
+        token=dict(key="integration_token", installation_id=1111),
         oauth_consumer_token=dict(
             key="client_id",
             secret="client_secret",
@@ -1074,9 +1075,34 @@ class TestUnitGithub(object):
         assert after - before == 1
 
     @pytest.mark.asyncio
-    async def test_update_check_run_url_fallback(self, valid_handler):
+    async def test_update_check_run_url_fallback(self, mocker):
+        mock_redis_conn = MagicMock(name="fake_redis")
+        mocker.patch(
+            "shared.torngit.github.get_redis_connection", return_value=mock_redis_conn
+        )
+
+        handler = Github(
+            repo=dict(name="example-python"),
+            owner=dict(username="ThiagoCodecov"),
+            token=dict(
+                key="some_key", refresh_token="refresh_token", installation_id=0
+            ),
+            oauth_consumer_token=dict(
+                key="client_id",
+                secret="client_secret",
+            ),
+            fallback_tokens=[{"key": "fallback_token", "installation_id": 12342}],
+        )
+
         url = "https://app.codecov.io/gh/codecov/example-python/compare/1?src=pr"
-        valid_handler.data.update({"fallback_tokens": ["fallback_token"]})
+        five_min_from_now = datetime.datetime.now(
+            datetime.timezone.utc
+        ) + datetime.timedelta(minutes=5)
+        timestamp = int(five_min_from_now.timestamp())
+        assert (
+            timestamp - int(datetime.datetime.now(datetime.timezone.utc).timestamp())
+            == 300
+        )
         with respx.mock:
             mocked_response = respx.patch(
                 "https://api.github.com/repos/ThiagoCodecov/example-python/check-runs/1256232357",
@@ -1090,7 +1116,10 @@ class TestUnitGithub(object):
             ).mock(
                 return_value=httpx.Response(
                     status_code=429,
-                    headers={"X-RateLimit-Remaining": "0"},
+                    headers={
+                        "X-RateLimit-Remaining": "0",
+                        "X-RateLimit-Reset": str(timestamp),
+                    },
                 )
             )
             mocked_response_fallback = respx.patch(
@@ -1110,9 +1139,19 @@ class TestUnitGithub(object):
                     headers={"Content-Type": "application/json; charset=utf-8"},
                 )
             )
-            res = await valid_handler.update_check_run(1256232357, "success", url=url)
+            res = await handler.update_check_run(1256232357, "success", url=url)
         assert mocked_response.call_count == 1
         assert mocked_response_fallback.call_count == 1
+        # The installation from the original token (rate limited) is marked so
+        mock_redis_conn.set.assert_called_with(
+            name="rate_limited_installations_0", value=True, ex=300
+        )
+        # The token in the GitHub instance is updated for subsequent requests
+        assert handler._token == {
+            "key": "fallback_token",
+            "installation_id": 12342,
+        }
+        assert handler.data["fallback_tokens"] == []
 
     @pytest.mark.asyncio
     async def test_get_general_exception_pickle(self, valid_handler, mocker):


### PR DESCRIPTION
These changes improve the github token fallback system by:
1. Updating the instance's `self._token` to be a not-rate-limited one,
  so that if the instance make subsequent requests they won't be immediately
  rate limited and have to go through the fallback process again
2. Propagates to other parts of the system that a given installation is rate limited.
  This is done via redis (apparently shared can access redis now)

Sadly the function that fallsbakc if other tokens are available is full of
side effects, as documented.

Also did a small refactor in the code aggregating the primary and secondary rate limit errors.

<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.