### PR TITLE
feat: add test results config group to celery config

### DIFF
--- a/shared/celery_config.py
+++ b/shared/celery_config.py
@@ -35,6 +35,10 @@ test_results_processor_task_name = (
     f"app.tasks.{TaskConfigGroup.test_results.value}.TestResultsProcessor"
 )
 
+test_results_finisher_task_name = (
+    f"app.tasks.{TaskConfigGroup.test_results.value}.TestResultsFinisherTask"
+)
+
 manual_upload_completion_trigger_task_name = (
     f"app.tasks.{TaskConfigGroup.upload.value}.ManualUploadCompletionTrigger"
 )
@@ -303,6 +307,15 @@ class BaseCeleryConfig(object):
                 "setup",
                 "tasks",
                 TaskConfigGroup.upload.value,
+                "queue",
+                default=task_default_queue,
+            )
+        },
+        f"app.tasks.{TaskConfigGroup.test_results.value}.*": {
+            "queue": get_config(
+                "setup",
+                "tasks",
+                TaskConfigGroup.test_results.value,
                 "queue",
                 default=task_default_queue,
             )

--- a/tests/unit/test_celery_config.py
+++ b/tests/unit/test_celery_config.py
@@ -47,6 +47,7 @@ def test_celery_config():
         "app.tasks.sync_repos.SyncRepos",
         "app.tasks.sync_teams.SyncTeams",
         "app.tasks.synchronize.Synchronize",
+        "app.tasks.test_results.*",
         "app.tasks.timeseries.*",
         "app.tasks.upload.*",
         "app.tasks.verify_bot.VerifyBot",


### PR DESCRIPTION
- add the test results tasks to the task routes in the celery config so we can configure which queue those tasks are routed to from the config
- defines the upload finisher task name in celery_config.py so we can have it defined in one place and use it in the worker

Fixes: https://github.com/codecov/engineering-team/issues/1538