### PR TITLE
feat: prevent the app from destroying itself

### DIFF
--- a/shared/django_apps/codecov_auth/models.py
+++ b/shared/django_apps/codecov_auth/models.py
@@ -520,6 +520,12 @@ class GithubAppInstallation(
             return False
         # The default app is configured in the installation YAML
         installation_default_app_id = get_config("github", "integration", "id")
+        if installation_default_app_id is None:
+            log.error(
+                "Can't find default app ID in the YAML. Assuming installation is configured to prevent the app from breaking itself.",
+                extra=dict(installation_id=self.id, installation_name=self.name),
+            )
+            return True
         return str(self.app_id) == str(installation_default_app_id)
 
     def repository_queryset(self) -> BaseManager[Repository]:

--- a/tests/unit/django_apps/codecov_auth/test_codecov_auth_models.py
+++ b/tests/unit/django_apps/codecov_auth/test_codecov_auth_models.py
@@ -595,7 +595,7 @@ class TestGithubAppInstallationModel(TransactionTestCase):
         )
 
 
-class TestGitguvAppInstallationNoDefaultAppIdConfig(TransactionTestCase):
+class TestGitHubAppInstallationNoDefaultAppIdConfig(TransactionTestCase):
     @pytest.fixture(autouse=True)
     def mock_no_default_app_id(self, mocker):
         mock_config_helper(mocker, configs={"github.integration.id": None})

--- a/tests/unit/django_apps/codecov_auth/test_codecov_auth_models.py
+++ b/tests/unit/django_apps/codecov_auth/test_codecov_auth_models.py
@@ -470,6 +470,7 @@ class TestOrganizationLevelTokenModel(TransactionTestCase):
 
 
 class TestGithubAppInstallationModel(TransactionTestCase):
+
     DEFAULT_APP_ID = 12345
 
     @pytest.fixture(autouse=True)
@@ -592,3 +593,21 @@ class TestGithubAppInstallationModel(TransactionTestCase):
         assert (
             installation_default_name_not_default_id_configured.is_configured() == True
         )
+
+
+class TestGitguvAppInstallationNoDefaultAppIdConfig(TransactionTestCase):
+    @pytest.fixture(autouse=True)
+    def mock_no_default_app_id(self, mocker):
+        mock_config_helper(mocker, configs={"github.integration.id": None})
+
+    def test_is_configured_no_default(self):
+        owner = OwnerFactory()
+        installation_default = GithubAppInstallation(
+            owner=owner,
+            repository_service_ids=None,
+            installation_id=123,
+            app_id=1200,
+            name=GITHUB_APP_INSTALLATION_DEFAULT_NAME,
+        )
+        installation_default.save()
+        assert installation_default.is_configured() == True


### PR DESCRIPTION
in a few occasions we had in staging (and 1 cloud customer) scenarios that
lead us to believe that the default app_id at times might not be present for the api pods
config.

The bad side_effect is that installations change name to 'unconfigured_app' and that's
only manually reversible. To prevent the app from destroying itself if the default
app id is not present we assume apps are configured in this scenario.

<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.