### PR TITLE
fix: make patch cuttoff date timezone aware

### DIFF
--- a/shared/config/__init__.py
+++ b/shared/config/__init__.py
@@ -41,7 +41,7 @@ LEGACY_DEFAULT_SITE_CONFIG = {
     "github_checks": {"annotations": True},
 }
 
-PATCH_CENTRIC_DEFAULT_TIME_START = datetime.fromisoformat("2024-04-30 00:00:00.000")
+PATCH_CENTRIC_DEFAULT_TIME_START = datetime.fromisoformat("2024-04-30 00:00:00.000+00:00")
 
 PATCH_CENTRIC_DEFAULT_CONFIG = {
     **LEGACY_DEFAULT_SITE_CONFIG,

--- a/tests/unit/yaml/test_user_yaml.py
+++ b/tests/unit/yaml/test_user_yaml.py
@@ -1,5 +1,7 @@
 import datetime
 
+from freezegun import freeze_time
+
 from shared.components import Component
 from shared.config import (
     LEGACY_DEFAULT_SITE_CONFIG,
@@ -342,14 +344,15 @@ class TestUserYaml(object):
             == expected_result
         )
 
+    @freeze_time("2024-04-30 00:00:00.000")
     def test_default_yaml_behavior_change(self):
         current_yaml = LEGACY_DEFAULT_SITE_CONFIG
         day_timedelta = datetime.timedelta(days=1)
         patch_centric_expected_onboarding_date = (
-            PATCH_CENTRIC_DEFAULT_TIME_START + day_timedelta
+            datetime.datetime.now(datetime.timezone.utc) + day_timedelta
         )
         no_change_expected_onboarding_date = (
-            PATCH_CENTRIC_DEFAULT_TIME_START - day_timedelta
+            datetime.datetime.now(datetime.timezone.utc) - day_timedelta
         )
         no_change = _fix_yaml_defaults_based_on_owner_onboarding_date(
             current_yaml, no_change_expected_onboarding_date


### PR DESCRIPTION
aka "the missing Z"

I wrongfully assumed that `fromisoformat` would generate a timezone aware datetime.
This is an issue because we generate those from the worker and api (that is, the
createstamp of owners saved in the database is pulled as being timezone aware)

And you can't compare timezone-aware and timezone-naive datetimes :clown:

So this errors out and it's pretty critical.

<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.