### PR TITLE
fix: fix fallback system for GH

### DIFF
--- a/shared/github/__init__.py
+++ b/shared/github/__init__.py
@@ -129,11 +129,25 @@ def get_github_integration_token(
 
 
 def mark_installation_as_rate_limited(
-    redis_connection: Redis, installation_id: int, ttl_seconds: int
+    redis_connection: Redis,
+    installation_id: int,
+    ttl_seconds: int,
+    app_id: int | None,
 ) -> None:
+    """Marks a installation as being rate-limited in Redis.
+    Use is_installation_rate_limited to check if it is rate-limited or not.
+
+    @param `installation_id` - GithubAppInstallation.installation_id OR owner.integration_id
+    @param `app_id` - GithubAppInstallation.app_id OR 'default_app'
+    @param `ttl_seconds` - Should come from GitHub (in the request that was rate limited)
+
+    We require the `app_id` as well because it's possible (albeit unlikely) that 2 installation_id are
+    the same for different apps.
+    """
+    app_id = app_id or "default_app"
     try:
         redis_connection.set(
-            name=f"rate_limited_installations_{installation_id}",
+            name=f"rate_limited_installations_{app_id}_{installation_id}",
             value=1,
             ex=ttl_seconds,
         )
@@ -144,9 +158,14 @@ def mark_installation_as_rate_limited(
         )
 
 
-def is_installation_rate_limited(redis_connection: Redis, installation_id: int) -> bool:
+def is_installation_rate_limited(
+    redis_connection: Redis, installation_id: int, app_id: int | None = None
+) -> bool:
+    app_id = app_id or "default_app"
     try:
-        return redis_connection.exists(f"rate_limited_installations_{installation_id}")
+        return redis_connection.exists(
+            f"rate_limited_installations_{app_id}_{installation_id}"
+        )
     except RedisError:
         log.exception(
             "Failed to check if installation ID is rate_limited due to RedisError",

--- a/shared/torngit/base.py
+++ b/shared/torngit/base.py
@@ -11,6 +11,7 @@ from shared.typings.oauth_token_types import (
     OnRefreshCallback,
     Token,
 )
+from shared.typings.torngit import TorngitInstanceData
 
 get_start_of_line = re.compile(r"@@ \-(\d+),?(\d*) \+(\d+),?(\d*).*").match
 
@@ -69,7 +70,7 @@ class TorngitBaseAdapter(object):
         self._on_token_refresh = on_token_refresh
         self._token_type_mapping = token_type_mapping or {}
         self._oauth = oauth_consumer_token
-        self.data = {"owner": {}, "repo": {}}
+        self.data: TorngitInstanceData = {"owner": {}, "repo": {}}
         self.verify_ssl = verify_ssl
         self.data.update(kwargs)
         # This has the side effect of initializing the torngit_cache
@@ -90,9 +91,11 @@ class TorngitBaseAdapter(object):
         else:
             timeout = httpx.Timeout(self._timeouts[1], connect=self._timeouts[0])
         return httpx.AsyncClient(
-            verify=self.verify_ssl
-            if not isinstance(self.verify_ssl, bool)
-            else self.verify_ssl,
+            verify=(
+                self.verify_ssl
+                if not isinstance(self.verify_ssl, bool)
+                else self.verify_ssl
+            ),
             timeout=timeout,
         )
 

--- a/shared/torngit/github.py
+++ b/shared/torngit/github.py
@@ -35,7 +35,8 @@ from shared.torngit.exceptions import (
     TorngitUnauthorizedError,
 )
 from shared.torngit.status import Status
-from shared.typings.oauth_token_types import GithubInstallationInfo, OauthConsumerToken
+from shared.typings.oauth_token_types import OauthConsumerToken
+from shared.typings.torngit import GithubInstallationInfo
 from shared.utils.urls import url_concat
 
 log = logging.getLogger(__name__)
@@ -533,9 +534,10 @@ class Github(TorngitBaseAdapter):
         reset_timestamp: Optional[str] = None,
         retry_in_seconds: Optional[int] = None,
     ) -> None:
-        current_token = self.token
-        if current_token.get("installation_id") is not None:
-            installation_id = current_token["installation_id"]
+        current_installation = self.data.get("installation")
+        if current_installation and current_installation.get("installation_id"):
+            installation_id = current_installation["installation_id"]
+            app_id = current_installation.get("app_id")
             if retry_in_seconds is None and reset_timestamp is None:
                 log.warning(
                     "Can't mark installation as rate limited because TTL is missing",
@@ -552,11 +554,12 @@ class Github(TorngitBaseAdapter):
                 "Marking installation as rate limited",
                 extra=dict(
                     installation_id=installation_id,
+                    app_id=app_id,
                     rate_limit_duration_seconds=ttl_seconds,
                 ),
             )
             mark_installation_as_rate_limited(
-                self._redis_connection, installation_id, ttl_seconds
+                self._redis_connection, installation_id, ttl_seconds, app_id=app_id
             )
 
     def _get_next_fallback_token(
@@ -570,12 +573,12 @@ class Github(TorngitBaseAdapter):
 
         !side effect: Marks the current token as rate limited in redis
         !side effect: Updates the self._token value
-        !side effect: Consumes one of the fallback_tokens
+        !side effect: Consumes one of self.data.fallback_installations
         """
-        fallback_tokens: List[GithubInstallationInfo] = self.data.get(
-            "fallback_tokens", None
+        fallback_installations: List[GithubInstallationInfo] = self.data.get(
+            "fallback_installations", None
         )
-        if fallback_tokens is None or fallback_tokens == []:
+        if fallback_installations is None or fallback_installations == []:
             # No tokens to fallback on
             return None
         # ! side effect: mark current token as rate limited
@@ -583,14 +586,19 @@ class Github(TorngitBaseAdapter):
             reset_timestamp=reset_timestamp, retry_in_seconds=retry_in_seconds
         )
         # ! side effect: consume one of the fallback tokens (makes it the token of this instance)
-        installation_info = fallback_tokens.pop(0)
+        installation_info = fallback_installations.pop(0)
         # The function arg is 'integration_id'
         installation_id = installation_info.pop("installation_id")
         token_to_use = get_github_integration_token(
             self.service, installation_id, **installation_info
         )
         # ! side effect: update the token so subsequent requests won't fail
-        self._token = dict(key=token_to_use, installation_id=installation_id)
+        self.set_token(dict(key=token_to_use))
+        self.data["installation"] = {
+            # Put the installation_id back into the info
+            "installation_id": installation_id,
+            **installation_info,
+        }
         return token_to_use
 
     async def make_http_call(

--- a/shared/typings/oauth_token_types.py
+++ b/shared/typings/oauth_token_types.py
@@ -1,21 +1,8 @@
 from typing import Any, Awaitable, Callable, Optional, TypedDict
 
 
-class GithubInstallationInfo(TypedDict):
-    """Required info to get a token from Github for a given installation"""
-
-    installation_id: int
-    # The default app (configured via yaml) doesn't need this info.
-    # All other apps need app_id and pem_path
-    app_id: Optional[int] = None
-    pem_path: Optional[str] = None
-
-
 class Token(TypedDict):
     key: str
-    # The installation ID that this token belongs to
-    # Used to mark them as rate-limited
-    installation_id: Optional[int] = None
 
 
 class OauthConsumerToken(Token):

--- a/shared/typings/torngit.py
+++ b/shared/typings/torngit.py
@@ -1,0 +1,32 @@
+from typing import Dict, List, TypedDict
+
+
+class OwnerInfo(TypedDict):
+    service_id: str
+    ownerid: int | None
+    username: str
+
+
+class RepoInfo(TypedDict):
+    name: str
+    using_integration: bool
+    service_id: str
+    repoid: int
+    private: bool | None
+
+
+class GithubInstallationInfo(TypedDict):
+    """Required info to get a token from Github for a given installation"""
+
+    installation_id: int
+    # The default app (configured via yaml) doesn't need this info.
+    # All other apps need app_id and pem_path
+    app_id: int | None = None
+    pem_path: str | None = None
+
+
+class TorngitInstanceData(TypedDict):
+    owner: OwnerInfo | Dict
+    repo: RepoInfo | Dict
+    fallback_installations: List[GithubInstallationInfo] | None
+    installation: GithubInstallationInfo | None

--- a/tests/unit/test_github.py
+++ b/tests/unit/test_github.py
@@ -210,9 +210,16 @@ class TestGithubSpecificLogic(object):
     def test_mark_installation_as_rate_limited(self, mocker):
         mock_redis = MagicMock(name="fake_redis")
         INSTALLATION_ID = 1000
-        mark_installation_as_rate_limited(mock_redis, INSTALLATION_ID, 10)
-        assert mock_redis.set.called_with(
-            name=f"rate_limited_installations_{INSTALLATION_ID}",
+        APP_ID = 250
+        mark_installation_as_rate_limited(mock_redis, INSTALLATION_ID, 10, app_id=250)
+        mock_redis.set.assert_called_with(
+            name=f"rate_limited_installations_{APP_ID}_{INSTALLATION_ID}",
+            value=1,
+            ex=10,
+        )
+        mark_installation_as_rate_limited(mock_redis, INSTALLATION_ID, 10, app_id=None)
+        mock_redis.set.assert_called_with(
+            name=f"rate_limited_installations_default_app_{INSTALLATION_ID}",
             value=1,
             ex=10,
         )
@@ -221,27 +228,38 @@ class TestGithubSpecificLogic(object):
         mock_redis = MagicMock(name="fake_redis")
         mock_redis.set.side_effect = RedisError
         INSTALLATION_ID = 1000
+        APP_ID = 250
         # This actually asserts that the error is not raised
         # Despite the call failing
-        mark_installation_as_rate_limited(mock_redis, INSTALLATION_ID, 10)
-        assert mock_redis.set.called_with(
-            name=f"rate_limited_installations_{INSTALLATION_ID}",
+        mark_installation_as_rate_limited(
+            mock_redis, INSTALLATION_ID, 10, app_id=APP_ID
+        )
+        mock_redis.set.assert_called_with(
+            name=f"rate_limited_installations_{APP_ID}_{INSTALLATION_ID}",
             value=1,
             ex=10,
         )
 
     def test_is_installation_rate_limited(self, mocker):
         mock_redis = MagicMock(name="fake_redis")
-        keys_in_redis = {"rate_limited_installations_999": 1}
+        keys_in_redis = {
+            "rate_limited_installations_250_999": 1,
+            "rate_limited_installations_default_app_999": 1,
+        }
 
         def exists(key):
             return key in keys_in_redis
 
         mock_redis.exists.side_effect = exists
-        assert is_installation_rate_limited(mock_redis, 1000) == False
+        assert is_installation_rate_limited(mock_redis, 1000, 250) == False
+        assert is_installation_rate_limited(mock_redis, 999, 250) == True
         assert is_installation_rate_limited(mock_redis, 999) == True
+        assert is_installation_rate_limited(mock_redis, 999, app_id=None) == True
+        assert is_installation_rate_limited(mock_redis, 999, 200) == False
 
     def test_is_installation_rate_limited_error(self, mocker):
         mock_redis = MagicMock(name="fake_redis")
         mock_redis.exists.side_effect = RedisError
-        assert is_installation_rate_limited(mock_redis, 1000) == False
+        assert is_installation_rate_limited(mock_redis, 1000, 250) == False
+        assert is_installation_rate_limited(mock_redis, 999, 250) == False
+        assert is_installation_rate_limited(mock_redis, 999, 200) == False

--- a/tests/unit/torngit/test_github.py
+++ b/tests/unit/torngit/test_github.py
@@ -24,6 +24,7 @@ from shared.torngit.exceptions import (
 )
 from shared.torngit.github import Github, count_and_get_url_template
 from shared.torngit.github import log as gh_log
+from shared.typings.torngit import GithubInstallationInfo
 
 
 @pytest.fixture
@@ -1088,14 +1089,15 @@ class TestUnitGithub(object):
         handler = Github(
             repo=dict(name="example-python"),
             owner=dict(username="ThiagoCodecov"),
-            token=dict(
-                key="some_key", refresh_token="refresh_token", installation_id=0
-            ),
+            token=dict(key="some_key", refresh_token="refresh_token"),
             oauth_consumer_token=dict(
                 key="client_id",
                 secret="client_secret",
             ),
-            fallback_tokens=[
+            installation=GithubInstallationInfo(
+                installation_id=1500,
+            ),
+            fallback_installations=[
                 {"installation_id": 12342, "app_id": 1200, "pem_path": "some_path"}
             ],
         )
@@ -1150,7 +1152,7 @@ class TestUnitGithub(object):
         assert mocked_response_fallback.call_count == 1
         # The installation from the original token (rate limited) is marked so
         mock_redis_conn.set.assert_called_with(
-            name="rate_limited_installations_0", value=True, ex=300
+            name="rate_limited_installations_default_app_1500", value=True, ex=300
         )
         mock_get_token.assert_called_with(
             "github", 12342, app_id=1200, pem_path="some_path"
@@ -1158,9 +1160,8 @@ class TestUnitGithub(object):
         # The token in the GitHub instance is updated for subsequent requests
         assert handler._token == {
             "key": "fallback_token",
-            "installation_id": 12342,
         }
-        assert handler.data["fallback_tokens"] == []
+        assert handler.data["fallback_installations"] == []
 
     @pytest.mark.asyncio
     async def test_get_general_exception_pickle(self, valid_handler, mocker):
@@ -1836,6 +1837,7 @@ class TestUnitGithub(object):
             "git_provider_api_calls_github_total",
             labels={"endpoint": "get_owner_from_nodeid_graphql"},
         )
+
         # Mocking different responses from the graphQL API
         # because it all goes to the same endpoint but this test expects a 2nd call
         # with owner by node_id query


### PR DESCRIPTION
There's an integration issue with the fallback system: the worker is passing the extra installation info in `data.fallback_installations` not `data.fallback_tokens`.
Personally I think that `fallback_installations` makes more sense here.

To prevent this silly (totally my fault for not testing properly locally) issue from happening again I added typehints to the `data` of TorngitBaseAdapters.

One more issue is that what's being passed as `installation_id` (that is marked as rate-limited)is the integration_id (as GitHub passes down to us), not the GithubAppInstallation instance ID.
Because it's possible to have installations from different apps we need to pass the `app_id` as well.

<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.