### PR TITLE
undo notation only available from pyhon 3.10 because api is still in 3.9

### DIFF
--- a/shared/github/__init__.py
+++ b/shared/github/__init__.py
@@ -130,7 +130,7 @@ def mark_installation_as_rate_limited(
     redis_connection: Redis,
     installation_id: int,
     ttl_seconds: int,
-    app_id: int | None,
+    app_id: Optional[int],
 ) -> None:
     """Marks a installation as being rate-limited in Redis.
     Use is_installation_rate_limited to check if it is rate-limited or not.
@@ -157,7 +157,7 @@ def mark_installation_as_rate_limited(
 
 
 def is_installation_rate_limited(
-    redis_connection: Redis, installation_id: int, app_id: int | None = None
+    redis_connection: Redis, installation_id: int, app_id: Optional[int] = None
 ) -> bool:
     app_id = app_id or "default_app"
     try:

--- a/shared/typings/torngit.py
+++ b/shared/typings/torngit.py
@@ -1,9 +1,9 @@
-from typing import Dict, List, TypedDict
+from typing import Dict, List, Optional, TypedDict
 
 
 class OwnerInfo(TypedDict):
     service_id: str
-    ownerid: int | None
+    ownerid: Optional[int]
     username: str
 
 
@@ -12,7 +12,7 @@ class RepoInfo(TypedDict):
     using_integration: bool
     service_id: str
     repoid: int
-    private: bool | None
+    private: Optional[bool]
 
 
 class GithubInstallationInfo(TypedDict):
@@ -21,12 +21,12 @@ class GithubInstallationInfo(TypedDict):
     installation_id: int
     # The default app (configured via yaml) doesn't need this info.
     # All other apps need app_id and pem_path
-    app_id: int | None = None
-    pem_path: str | None = None
+    app_id: Optional[int] = None
+    pem_path: Optional[str] = None
 
 
 class TorngitInstanceData(TypedDict):
     owner: OwnerInfo | Dict
     repo: RepoInfo | Dict
-    fallback_installations: List[GithubInstallationInfo] | None
-    installation: GithubInstallationInfo | None
+    fallback_installations: List[Optional[GithubInstallationInfo]]
+    installation: Optional[GithubInstallationInfo]


### PR DESCRIPTION
<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.