### PR TITLE
Update `idna` package to 3.7

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -37,7 +37,7 @@ httpx==0.23.0
     # via
     #   -r tests/requirements.in
     #   respx
-idna==3.3
+idna==3.7
     # via
     #   anyio
     #   requests
@@ -88,9 +88,7 @@ requests==2.31.0
 respx==0.19.2
     # via -r tests/requirements.in
 rfc3986[idna2008]==1.5.0
-    # via
-    #   httpx
-    #   rfc3986
+    # via httpx
 six==1.16.0
     # via python-dateutil
 sniffio==1.2.0


### PR DESCRIPTION
This mitigates [GHSA-jjg7-2v4v-x38h](https://github.com/advisories/GHSA-jjg7-2v4v-x38h) vulnerability.

I ran `pip-compile --upgrade-package idna` to generate this. The dependencies also don't pin the exact version, and 3.7 is within the ranges of downstream dependencies.

Since this is an update to the test, this is safe for release (but doesn't require a separate release, as I'm not adding any features).

Link to ticket: https://github.com/codecov/internal-issues/issues/415

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.