### PR TITLE
fix: Don't rate limit installation for 0 seconds

### DIFF
--- a/shared/github/__init__.py
+++ b/shared/github/__init__.py
@@ -142,6 +142,10 @@ def mark_installation_as_rate_limited(
     We require the `app_id` as well because it's possible (albeit unlikely) that 2 installation_id are
     the same for different apps.
     """
+    if ttl_seconds <= 0:
+        # ttl_seconds is the time until the RateLimit ends
+        # Makes no sense to mark an installation rate limited if it's not anymore
+        return
     app_id = app_id or "default_app"
     try:
         redis_connection.set(

--- a/tests/unit/test_github.py
+++ b/tests/unit/test_github.py
@@ -294,6 +294,16 @@ class TestGithubSpecificLogic(object):
             ex=10,
         )
 
+    def test_mark_installation_as_rate_limited_ttl_zero(self, mocker):
+        mock_redis = MagicMock(name="fake_redis")
+        mock_redis.set.side_effect = RedisError
+        INSTALLATION_ID = 1000
+        APP_ID = 250
+        # This actually asserts that the error is not raised
+        # Despite the call failing
+        mark_installation_as_rate_limited(mock_redis, INSTALLATION_ID, 0, app_id=APP_ID)
+        mock_redis.set.assert_not_called()
+
     def test_is_installation_rate_limited(self, mocker):
         mock_redis = MagicMock(name="fake_redis")
         keys_in_redis = {


### PR DESCRIPTION
fixes issue https://l.codecov.dev/OGL5z9

It's possible that an installation is still rate limited but for a very
short period of time (less than 1 second). In this case we'd attemp to
set it as rate limited with a TTL of 0.
That causes a `RedisError`

<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.