### PR TITLE
bundle analysis catch rate limit error

### DIFF
--- a/shared/storage/exceptions.py
+++ b/shared/storage/exceptions.py
@@ -4,3 +4,7 @@ class BucketAlreadyExistsError(Exception):
 
 class FileNotInStorageError(Exception):
     pass
+
+
+class PutRequestRateLimitError(Exception):
+    pass

--- a/tests/unit/bundle_analysis/test_bundle_analysis.py
+++ b/tests/unit/bundle_analysis/test_bundle_analysis.py
@@ -221,3 +221,22 @@ def test_bundle_name_not_valid():
         assert (
             excinfo.bundle_analysis_plugin_name == "codecov-vite-bundle-analysis-plugin"
         )
+
+
+def test_bundle_rate_limit_error():
+    with patch(
+        "shared.storage.memory.MemoryStorageService.write_file",
+        side_effect=Exception("TooManyRequests"),
+    ):
+        with pytest.raises(Exception) as excinfo:
+            report = BundleAnalysisReport()
+            report.ingest(sample_bundle_stats_path)
+
+            loader = BundleAnalysisReportLoader(
+                storage_service=MemoryStorageService({}),
+                repo_key="testing",
+            )
+            test_key = "8d1099f1-ba73-472f-957f-6908eced3f42"
+            loader.save(report, test_key)
+
+            assert str(excinfo) == "TooManyRequests"


### PR DESCRIPTION
1 of 2 PRs of the fix.

When encountering a rate limit error by GCS when doing save file to the BA bucket, instead of failing the processor step completely, it will now retry.

GCS has a 1 PUT request per second rate limit when updating an existing object in storage, the BA processor may encounter this edge case when multiple BA processing tasks are running in parallel to update multiple bundle stats files. And when this is encountered, we don't update the SQLite file for this stats file therefore causing incorrect data. This fix will retry the task after a short 20s cooldown to once again attempt to upload, at this time most likely the rate limit threshold would be passed. Note that there can still be cases when multiple retried tasks run at the same time again, but the probability of this would be really low considering the existing issue of rate limiting error from GCS is also seen very rarely.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.