### PR TITLE
fix: default branch to "master" in torngit github

### DIFF
--- a/shared/torngit/github.py
+++ b/shared/torngit/github.py
@@ -1285,7 +1285,7 @@ class Github(TorngitBaseAdapter):
                         ),
                         "private": raw_repo_data["isPrivate"],
                         "branch": (
-                            default_branch.get("name") if default_branch else None
+                            default_branch.get("name") if default_branch else "master"
                         ),
                         "owner": {
                             "node_id": raw_repo_data["owner"]["id"],

--- a/tests/integration/test_github.py
+++ b/tests/integration/test_github.py
@@ -1923,7 +1923,7 @@ class TestGithubTestCase(object):
                 "name": "test-no-languages",
                 "language": None,
                 "private": False,
-                "branch": None,
+                "branch": "master",
                 "owner": {
                     "node_id": "U_kgDOBZOfKw",
                     "username": "codecove2e",


### PR DESCRIPTION
fixes a sentry issue https://l.codecov.dev/I8iSfU

we upsert a repo with `branch=None` due to this default value. that violates the nonnull constraint on that field

other places in the same file default to "master" as well: [one](https://github.com/codecov/shared/blob/5ada529179d25063f02e64be0a9cba3129d8d5d6/shared/torngit/github.py#L1175) and [two](https://github.com/codecov/shared/blob/5ada529179d25063f02e64be0a9cba3129d8d5d6/shared/torngit/github.py#L1159)