### PR TITLE
[fix] Fix analytics tracking datetime serialization issue 

### DIFF
--- a/shared/analytics_tracking/pubsub.py
+++ b/shared/analytics_tracking/pubsub.py
@@ -1,4 +1,4 @@
-import datetime
+from datetime import datetime
 import json
 import logging
 

--- a/shared/analytics_tracking/pubsub.py
+++ b/shared/analytics_tracking/pubsub.py
@@ -1,3 +1,4 @@
+import datetime
 import json
 import logging
 
@@ -9,6 +10,12 @@ from shared.analytics_tracking.events import Event
 from shared.config import get_config
 
 log = logging.getLogger("__name__")
+
+class CustomJSONEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, datetime):
+            return obj.isoformat()
+        return super().default(obj)
 
 
 class PubSub(BaseAnalyticsTool):
@@ -48,5 +55,5 @@ class PubSub(BaseAnalyticsTool):
             return
         if self.publisher is not None:
             self.publisher.publish(
-                self.topic, data=json.dumps(event.serialize()).encode("utf-8")
+                self.topic, data=json.dumps(event.serialize(), cls=CustomJSONEncoder).encode("utf-8")
             )

--- a/shared/analytics_tracking/pubsub.py
+++ b/shared/analytics_tracking/pubsub.py
@@ -1,6 +1,6 @@
-from datetime import datetime
 import json
 import logging
+from datetime import datetime
 
 from google.auth.exceptions import GoogleAuthError
 from google.cloud import pubsub_v1

--- a/shared/analytics_tracking/pubsub.py
+++ b/shared/analytics_tracking/pubsub.py
@@ -11,6 +11,7 @@ from shared.config import get_config
 
 log = logging.getLogger("__name__")
 
+
 class CustomJSONEncoder(json.JSONEncoder):
     def default(self, obj):
         if isinstance(obj, datetime):
@@ -55,5 +56,8 @@ class PubSub(BaseAnalyticsTool):
             return
         if self.publisher is not None:
             self.publisher.publish(
-                self.topic, data=json.dumps(event.serialize(), cls=CustomJSONEncoder).encode("utf-8")
+                self.topic,
+                data=json.dumps(event.serialize(), cls=CustomJSONEncoder).encode(
+                    "utf-8"
+                ),
             )

--- a/tests/unit/analytics_tracking/test_analytics_tracking.py
+++ b/tests/unit/analytics_tracking/test_analytics_tracking.py
@@ -178,7 +178,7 @@ class TestPubSub(object):
         )
 
     def test_pubsub_track_event_with_datetime(mock_pubsub_publisher):
-        dt = (datetime(2023, 9, 12, tzinfo=timezone.utc),)
+        dt = datetime(2023, 9, 12, tzinfo=timezone.utc)
         event = Event(
             event_name=Events.ACCOUNT_ACTIVATED_REPOSITORY.value,
             dt=dt,

--- a/tests/unit/analytics_tracking/test_analytics_tracking.py
+++ b/tests/unit/analytics_tracking/test_analytics_tracking.py
@@ -177,7 +177,9 @@ class TestPubSub(object):
             pubsub.topic, data=json.dumps(event.serialize()).encode("utf-8")
         )
 
-    def test_pubsub_track_event_with_datetime(self, mocker, mock_pubsub_publisher, mock_pubsub):
+    def test_pubsub_track_event_with_datetime(
+        self, mocker, mock_pubsub_publisher, mock_pubsub
+    ):
         other_timestamp = datetime(2023, 9, 12, tzinfo=timezone.utc)
         event = Event(
             event_name=Events.ACCOUNT_ACTIVATED_REPOSITORY.value,

--- a/tests/unit/analytics_tracking/test_analytics_tracking.py
+++ b/tests/unit/analytics_tracking/test_analytics_tracking.py
@@ -177,7 +177,7 @@ class TestPubSub(object):
             pubsub.topic, data=json.dumps(event.serialize()).encode("utf-8")
         )
 
-    def test_pubsub_track_event_with_datetime(self, mock_pubsub_publisher):
+    def test_pubsub_track_event_with_datetime(self, mocker, mock_pubsub_publisher, mock_pubsub):
         other_timestamp = datetime(2023, 9, 12, tzinfo=timezone.utc)
         event = Event(
             event_name=Events.ACCOUNT_ACTIVATED_REPOSITORY.value,
@@ -188,12 +188,11 @@ class TestPubSub(object):
         )
         pubsub = PubSub()
         pubsub.track_event(event)
-
         serialized_event = json.dumps(event.serialize(), cls=CustomJSONEncoder).encode(
             "utf-8"
         )
         mock_pubsub_publisher.publish.assert_called_with(
-            "test_topic", data=serialized_event
+            pubsub.topic, data=serialized_event
         )
 
 

--- a/tests/unit/analytics_tracking/test_analytics_tracking.py
+++ b/tests/unit/analytics_tracking/test_analytics_tracking.py
@@ -178,21 +178,24 @@ class TestPubSub(object):
         )
 
     def test_pubsub_track_event_with_datetime(mock_pubsub_publisher):
-        dt = datetime(2023, 9, 12, tzinfo=timezone.utc),
+        dt = (datetime(2023, 9, 12, tzinfo=timezone.utc),)
         event = Event(
             event_name=Events.ACCOUNT_ACTIVATED_REPOSITORY.value,
             dt=dt,
             user_id="1234",
             repo_id="1234",
-            branch="test_branch"
+            branch="test_branch",
         )
         pubsub = PubSub()
         pubsub.track_event(event)
 
-        serialized_event = json.dumps(event.serialize(), cls=CustomJSONEncoder).encode("utf-8")
+        serialized_event = json.dumps(event.serialize(), cls=CustomJSONEncoder).encode(
+            "utf-8"
+        )
         mock_pubsub_publisher.publish.assert_called_with(
             "test_topic", data=serialized_event
         )
+
 
 class TestEvent(object):
     def test_event(self, mocker):

--- a/tests/unit/analytics_tracking/test_analytics_tracking.py
+++ b/tests/unit/analytics_tracking/test_analytics_tracking.py
@@ -8,7 +8,7 @@ from shared.analytics_tracking import get_list_of_analytic_tools, get_tools_mana
 from shared.analytics_tracking.events import Event, Events
 from shared.analytics_tracking.manager import AnalyticsToolManager
 from shared.analytics_tracking.marketo import Marketo
-from shared.analytics_tracking.pubsub import PubSub
+from shared.analytics_tracking.pubsub import CustomJSONEncoder, PubSub
 from shared.config import ConfigHelper
 
 
@@ -177,6 +177,22 @@ class TestPubSub(object):
             pubsub.topic, data=json.dumps(event.serialize()).encode("utf-8")
         )
 
+    def test_pubsub_track_event_with_datetime(mock_pubsub_publisher):
+        dt = datetime(2023, 9, 12, tzinfo=timezone.utc),
+        event = Event(
+            event_name=Events.ACCOUNT_ACTIVATED_REPOSITORY.value,
+            dt=dt,
+            user_id="1234",
+            repo_id="1234",
+            branch="test_branch"
+        )
+        pubsub = PubSub()
+        pubsub.track_event(event)
+
+        serialized_event = json.dumps(event.serialize(), cls=CustomJSONEncoder).encode("utf-8")
+        mock_pubsub_publisher.publish.assert_called_with(
+            "test_topic", data=serialized_event
+        )
 
 class TestEvent(object):
     def test_event(self, mocker):

--- a/tests/unit/analytics_tracking/test_analytics_tracking.py
+++ b/tests/unit/analytics_tracking/test_analytics_tracking.py
@@ -177,11 +177,11 @@ class TestPubSub(object):
             pubsub.topic, data=json.dumps(event.serialize()).encode("utf-8")
         )
 
-    def test_pubsub_track_event_with_datetime(mock_pubsub_publisher):
-        dt = datetime(2023, 9, 12, tzinfo=timezone.utc)
+    def test_pubsub_track_event_with_datetime(self, mock_pubsub_publisher):
+        other_timestamp = datetime(2023, 9, 12, tzinfo=timezone.utc)
         event = Event(
             event_name=Events.ACCOUNT_ACTIVATED_REPOSITORY.value,
-            dt=dt,
+            other_timestamp=other_timestamp,
             user_id="1234",
             repo_id="1234",
             branch="test_branch",


### PR DESCRIPTION

<img width="533" alt="Screenshot 2024-05-29 at 11 17 16 AM" src="https://github.com/codecov/shared/assets/148245014/01bbde16-ad30-4849-be1e-2303fb2c1daf">

We've had quite a few issues on sentry due to `json.dumps()` not being able to recognize datetime objects. 
<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.