### PR TITLE
torngit github: set up experiment for list_repos page size

### DIFF
--- a/shared/rollouts/features.py
+++ b/shared/rollouts/features.py
@@ -1,14 +1,3 @@
-# This file "defines" features which actually should live in the worker. It
-# serves as a model for how this feature flag utility is recommended to be used
-# in other repositories: with a central file in which all experiments are
-# declared so that it's easier to see how much runtime variability there is in
-# the way our service behaves. Unreproducible bug report from a customer? Check
-# if there have been any recent feature changes that sound related.
-#
-# PARALLEL_UPLOAD_PROCESSING_BY_ORG = Feature(
-#     "parllel_upload_processing", 0.2, overrides={"codecov's id": True}
-# )
-#
-# LIST_REPOS_GENERATOR_BY_ORG = Feature(
-#     "list_repos_generator", 0.5, overrides={"codecov's id": True)
-# )
+from . import Feature
+
+LIST_REPOS_PAGE_SIZE = Feature("list_repos_page_size")

--- a/shared/torngit/github.py
+++ b/shared/torngit/github.py
@@ -18,6 +18,7 @@ from shared.github import (
     mark_installation_as_rate_limited,
 )
 from shared.metrics import Counter, metrics
+from shared.rollouts.features import LIST_REPOS_PAGE_SIZE
 from shared.torngit.base import TokenType, TorngitBaseAdapter
 from shared.torngit.cache import get_redis_connection, torngit_cache
 from shared.torngit.enums import Endpoints
@@ -1258,10 +1259,12 @@ class Github(TorngitBaseAdapter):
         async with self.get_client() as client:
             max_index = len(repo_node_ids)
             curr_index = 0
-            PAGE_SIZE = 100
+            page_size = await LIST_REPOS_PAGE_SIZE.check_value_async(
+                identifier=self.data["owner"].get("ownerid"), default=100
+            )
             while curr_index < max_index:
-                chunk = repo_node_ids[curr_index : curr_index + PAGE_SIZE]
-                curr_index += PAGE_SIZE
+                chunk = repo_node_ids[curr_index : curr_index + page_size]
+                curr_index += page_size
                 query = self.graphql.prepare(
                     "REPOS_FROM_NODEIDS", variables={"node_ids": chunk}
                 )
@@ -1313,16 +1316,19 @@ class Github(TorngitBaseAdapter):
         """
         data = []
         page = 0
+        page_size = await LIST_REPOS_PAGE_SIZE.check_value_async(
+            identifier=self.data["owner"].get("ownerid"), default=100
+        )
         async with self.get_client() as client:
             while True:
                 page += 1
                 repos = await self._fetch_page_of_repos_using_installation(
-                    client, page=page
+                    client, page=page, page_size=page_size
                 )
 
                 data.extend(repos)
 
-                if len(repos) < 100:
+                if len(repos) < page_size:
                     break
 
             return data
@@ -1344,17 +1350,20 @@ class Github(TorngitBaseAdapter):
         """
         token = self.get_token_by_type_if_none(token, TokenType.read)
         page = 0
+        page_size = await LIST_REPOS_PAGE_SIZE.check_value_async(
+            identifier=self.data["owner"].get("ownerid"), default=100
+        )
         data = []
         async with self.get_client() as client:
             while True:
                 page += 1
                 repos = await self._fetch_page_of_repos(
-                    client, username, token, page=page
+                    client, username, token, page=page, page_size=page_size
                 )
 
                 data.extend(repos)
 
-                if len(repos) < 100:
+                if len(repos) < page_size:
                     break
 
             return data
@@ -1367,6 +1376,9 @@ class Github(TorngitBaseAdapter):
         rolling out in the worker.
         """
         token = self.get_token_by_type_if_none(token, TokenType.read)
+        page_size = await LIST_REPOS_PAGE_SIZE.check_value_async(
+            identifier=self.data["owner"].get("ownerid"), default=100
+        )
         async with self.get_client() as client:
             page = 0
             while True:
@@ -1374,17 +1386,17 @@ class Github(TorngitBaseAdapter):
 
                 repos = (
                     await self._fetch_page_of_repos_using_installation(
-                        client, page=page
+                        client, page=page, page_size=page_size
                     )
                     if using_installation
                     else await self._fetch_page_of_repos(
-                        client, username, token, page=page
+                        client, username, token, page=page, page_size=page_size
                     )
                 )
 
                 yield repos
 
-                if len(repos) < 100:
+                if len(repos) < page_size:
                     break
 
     # GH App Installation

--- a/tests/integration/test_github.py
+++ b/tests/integration/test_github.py
@@ -1113,6 +1113,7 @@ class TestGithubTestCase(object):
         assert mock_api.call_count == 2
 
     @pytest.mark.asyncio
+    @pytest.mark.django_db(databases={"default"})
     async def test_list_repos(self, valid_handler, codecov_vcr):
         res = await valid_handler.list_repos()
         assert len(res) == 115
@@ -1131,6 +1132,7 @@ class TestGithubTestCase(object):
         assert one_expected_result in res
 
     @pytest.mark.asyncio
+    @pytest.mark.django_db(databases={"default"})
     async def test_list_repos_generator(self, valid_handler, codecov_vcr):
         repos = []
         page_count = 0
@@ -1183,6 +1185,7 @@ class TestGithubTestCase(object):
         assert all(x in repos for x in some_expected_results)
 
     @pytest.mark.asyncio
+    @pytest.mark.django_db(databases={"default"})
     async def test_list_repos_using_installation(self, valid_handler, codecov_vcr):
         res = await valid_handler.list_repos_using_installation()
         assert res == [
@@ -1199,6 +1202,7 @@ class TestGithubTestCase(object):
         ]
 
     @pytest.mark.asyncio
+    @pytest.mark.django_db(databases={"default"})
     async def test_list_repos_using_installation_generator(
         self, valid_handler, codecov_vcr
     ):
@@ -1903,6 +1907,7 @@ class TestGithubTestCase(object):
         assert res is True
 
     @pytest.mark.asyncio
+    @pytest.mark.django_db(databases={"default"})
     async def test_get_repos_from_nodeids_generator(self, valid_handler, codecov_vcr):
         repo_node_ids = ["R_kgDOHrbKcg", "R_kgDOLEJx2g"]
         expected = [

--- a/tests/unit/torngit/test_github.py
+++ b/tests/unit/torngit/test_github.py
@@ -1827,6 +1827,7 @@ class TestUnitGithub(object):
             assert after - before == 1
 
     @pytest.mark.asyncio
+    @pytest.mark.django_db(databases={"default"})
     async def test_get_repos_from_nodeids(self, ghapp_handler):
         before = REGISTRY.get_sample_value(
             "git_provider_api_calls_github_total",


### PR DESCRIPTION
https://github.com/codecov/engineering-team/issues/1757

[github docs on timeouts](https://docs.github.com/en/rest/using-the-rest-api/troubleshooting-the-rest-api?apiVersion=2022-11-28#timeouts):
> If GitHub takes more than 10 seconds to process an API request, GitHub will terminate the request and you will receive a timeout response and a "Server Error" message.
> ...
> For example, if you are requesting 100 items on a page, you can try requesting fewer items.

`list_repos()` and family use a page size of 100, and we sometimes observe 502s/504s in response after 10 seconds which is github's cutoff. this PR sets up an experiment to test smaller page sizes

this should be running with a user oauth token that has its own rate limit. so this should probably not cause rate limit issues