### PR TITLE
torngit github: retry on 502/503/504

### DIFF
--- a/shared/torngit/github.py
+++ b/shared/torngit/github.py
@@ -758,7 +758,7 @@ class Github(TorngitBaseAdapter):
         body=None,
         headers=None,
         token_to_use=None,
-        statuses_to_retry=None,
+        statuses_to_retry=[502, 503, 504],
         **args,
     ) -> Response:
         _headers = {
@@ -2349,7 +2349,7 @@ class Github(TorngitBaseAdapter):
                 url = self.count_and_get_url_template(
                     url_name="is_student"
                 ).substitute()
-                res = await self.api(client, "get", url)
+                res = await self.api(client, "get", url, statuses_to_retry=[])
                 return res["student"]
             except TorngitServerUnreachableError:
                 log.warning("Timeout on Github Education API for is_student")


### PR DESCRIPTION
https://github.com/codecov/engineering-team/issues/1757

we sometimes observe 502s and 504s in `list_repos()`. https://github.com/codecov/shared/pull/232 attempts to mitigate that by testing a smaller page size, but also sometimes retrying 502/503/504 will just work