### PR TITLE
dev: Add most E, all PLC and PLE ruff rules

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -37,7 +37,7 @@ target-version = "py312"
 
 [lint]
 # Currently only enabled for F (Pyflakes), I (isort), E (pycodestyle:Error), PLC (Pylint:Convention) 
-# and PLE (Pylint:Convention) rules: https://docs.astral.sh/ruff/rules/
+# and PLE (Pylint:Error) rules: https://docs.astral.sh/ruff/rules/
 select = ["F", "I", "E", "PLC", "PLE"]
 ignore = ["F841", "F401","F405", "F403", "E501", "E712", "E711", "E741"]
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -36,9 +36,10 @@ indent-width = 4
 target-version = "py312"
 
 [lint]
-# Currently only enabled for F (Pyflakes) and I (isort) rules: https://docs.astral.sh/ruff/rules/
-select = ["F", "I"]
-ignore = ["F841", "F401","F405", "F403"]
+# Currently only enabled for F (Pyflakes), I (isort), E (pycodestyle:Error), and PLC (Pylint:Convention) 
+# rules: https://docs.astral.sh/ruff/rules/
+select = ["F", "I", "E", "PLC"]
+ignore = ["F841", "F401","F405", "F403", "E501", "E712", "E711", "E741"]
 
 # Allow fix for all enabled rules (when `--fix`) is provided.
 # The preferred method (for now) w.r.t. fixable rules is to manually update the makefile

--- a/ruff.toml
+++ b/ruff.toml
@@ -36,9 +36,9 @@ indent-width = 4
 target-version = "py312"
 
 [lint]
-# Currently only enabled for F (Pyflakes), I (isort), E (pycodestyle:Error), and PLC (Pylint:Convention) 
-# rules: https://docs.astral.sh/ruff/rules/
-select = ["F", "I", "E", "PLC"]
+# Currently only enabled for F (Pyflakes), I (isort), E (pycodestyle:Error), PLC (Pylint:Convention) 
+# and PLE (Pylint:Convention) rules: https://docs.astral.sh/ruff/rules/
+select = ["F", "I", "E", "PLC", "PLE"]
 ignore = ["F841", "F401","F405", "F403", "E501", "E712", "E711", "E741"]
 
 # Allow fix for all enabled rules (when `--fix`) is provided.

--- a/shared/analytics_tracking/__init__.py
+++ b/shared/analytics_tracking/__init__.py
@@ -10,7 +10,7 @@ from shared.analytics_tracking.segment import Segment
 
 log = logging.getLogger("__name__")
 
-__all__ = "analytics_manager"
+__all__ = ["analytics_manager"]
 
 
 def get_list_of_analytic_tools() -> List[BaseAnalyticsTool]:

--- a/shared/django_apps/codecov_auth/helpers.py
+++ b/shared/django_apps/codecov_auth/helpers.py
@@ -41,7 +41,7 @@ class History:
         if action_flag is None:
             action_flag = CHANGE
 
-        if type(objects) is not list:
+        if not isinstance(objects, list):
             objects = [objects]
 
         if add_traceback:

--- a/shared/django_apps/dummy_settings.py
+++ b/shared/django_apps/dummy_settings.py
@@ -1,8 +1,9 @@
 from pathlib import Path
 
+from shared.django_apps.db_settings import *
+
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent
-from shared.django_apps.db_settings import *
 
 ALLOWED_HOSTS = []
 

--- a/shared/django_apps/legacy_migrations/management/commands/migrate.py
+++ b/shared/django_apps/legacy_migrations/management/commands/migrate.py
@@ -83,7 +83,7 @@ class Command(MigrateCommand):
             result = cursor.fetchone()
             if result[0] < 2:
                 self._run_initial_timeseries_migrations(args=args, options=options)
-        except:
+        except Exception:
             self._run_initial_codecov_migrations(args=args, options=options)
             self._run_initial_timeseries_migrations(args=args, options=options)
 

--- a/shared/helpers/yaml.py
+++ b/shared/helpers/yaml.py
@@ -9,20 +9,20 @@ def walk(_dict, keys, _else=None):
             else:
                 _dict = getattr(_dict, key)
         return _dict
-    except:
+    except Exception:
         return _else
 
 
 def default_if_true(value):
     if value is True:
         yield "default", {}
-    elif type(value) is dict:
+    elif isinstance(value, dict):
         for key, data in value.items():
             if data is False:
                 continue
             elif data is True:
                 yield key, {}
-            elif type(data) is not dict or data.get("enabled") is False:
+            elif not isinstance(data, dict) or data.get("enabled") is False:
                 continue
             else:
                 yield key, data

--- a/shared/reports/filtered.py
+++ b/shared/reports/filtered.py
@@ -118,7 +118,7 @@ class FilteredReportFile(object):
         if not c:
             # no coverage data provided
             return (0, 0)
-        elif type(c) is int:
+        elif isinstance(c, int):
             # coverage is of type int
             return (c, 0)
         else:

--- a/shared/reports/resources.py
+++ b/shared/reports/resources.py
@@ -82,7 +82,7 @@ class ReportFile(object):
         self.name = name
         # lines = [<details dict()>, <Line #1>, ....]
         if lines:
-            if type(lines) is list:
+            if isinstance(lines, list):
                 self._details = None
                 self._lines = lines
 
@@ -116,14 +116,14 @@ class ReportFile(object):
                 self.name,
                 len(self),
             )
-        except:
+        except Exception:
             return "<%s name=%s lines=n/a>" % (self.__class__.__name__, self.name)
 
     def _line(self, line):
         if isinstance(line, ReportLine):
             # line is already mapped to obj
             return line
-        elif type(line) is list:
+        elif isinstance(line, list):
             # line needs to be mapped to ReportLine
             # line = [1, 'b', [], null, null] = ReportLine.create()
             return ReportLine.create(*line)
@@ -224,9 +224,9 @@ class ReportFile(object):
         """Return a single line or None"""
         if ln == "totals":
             return self.totals
-        if type(ln) is slice:
+        if isinstance(ln, slice):
             return self._getslice(ln.start, ln.stop)
-        if not type(ln) is int:
+        if not isinstance(ln, int):
             raise TypeError("expecting type int got %s" % type(ln))
         elif ln < 1:
             raise ValueError("Line number must be greater then 0. Got %s" % ln)
@@ -237,7 +237,7 @@ class ReportFile(object):
 
     def __setitem__(self, ln, line):
         """Append line to file, without merging if previously set"""
-        if not type(ln) is int:
+        if not isinstance(ln, int):
             raise TypeError("expecting type int got %s" % type(ln))
         elif not isinstance(line, ReportLine):
             raise TypeError("expecting type ReportLine got %s" % type(line))
@@ -302,7 +302,7 @@ class ReportFile(object):
                 yield ln, line
 
     def __contains__(self, ln):
-        if not type(ln) is int:
+        if not isinstance(ln, int):
             raise TypeError("expecting type int got %s" % type(ln))
         try:
             return self.get(ln) is not None
@@ -313,7 +313,7 @@ class ReportFile(object):
         return self.totals.lines > 0
 
     def get(self, ln):
-        if not type(ln) is int:
+        if not isinstance(ln, int):
             raise TypeError("expecting type int got %s" % type(ln))
         elif ln < 1:
             raise ValueError("Line number must be greater then 0. Got %s" % ln)
@@ -340,7 +340,7 @@ class ReportFile(object):
         """Append a line to the report
         if the line exists it will merge it
         """
-        if not type(ln) is int:
+        if not isinstance(ln, int):
             raise TypeError("expecting type int got %s" % type(ln))
         elif not isinstance(line, ReportLine):
             raise TypeError("expecting type ReportLine got %s" % type(line))
@@ -442,7 +442,7 @@ class ReportFile(object):
             if not c:
                 # no coverage data provided
                 return (0, 0)
-            elif type(c) is int:
+            elif isinstance(c, int):
                 # coverage is of type int
                 return (c, 0)
             else:
@@ -738,7 +738,7 @@ class Report(object):
                 self.__class__.__name__,
                 len(getattr(self, "_files", [])),
             )
-        except:
+        except Exception:
             return "<%s files=n/a>" % self.__class__.__name__
 
     @property

--- a/shared/reports/types.py
+++ b/shared/reports/types.py
@@ -114,9 +114,10 @@ class CoverageDatapoint(object):
 
     def __post_init__(self):
         if self.label_ids is not None:
-            possibly_cast_to_int = (
-                lambda el: int(el) if (type(el) == str and el.isnumeric()) else el
-            )
+
+            def possibly_cast_to_int(el):
+                return int(el) if isinstance(el, str) and el.isnumeric() else el
+
             self.label_ids = [possibly_cast_to_int(el) for el in self.label_ids]
 
     def key_sorting_tuple(self):

--- a/shared/reports/types.py
+++ b/shared/reports/types.py
@@ -259,7 +259,7 @@ class SessionTotalsArray(object):
             return SessionTotalsArray()
         log.warning(
             "Tried to build SessionArray from unknown encoded data.",
-            dict(data=sessions_array, data_type=type(sessions_array)),
+            extra=dict(data=sessions_array, data_type=type(sessions_array)),
         )
         return None
 

--- a/shared/rollouts/__init__.py
+++ b/shared/rollouts/__init__.py
@@ -231,11 +231,9 @@ class Feature:
         return (
             (sum(map(lambda x: x.proportion, self.ff_variants)) == 1.0)
             and (
-                not (
-                    True
-                    in map(
-                        lambda x: x.proportion < 0 or x.proportion > 1, self.ff_variants
-                    )
+                True
+                not in map(
+                    lambda x: x.proportion < 0 or x.proportion > 1, self.ff_variants
                 )
             )
             and (

--- a/shared/torngit/gitlab.py
+++ b/shared/torngit/gitlab.py
@@ -638,7 +638,7 @@ class Gitlab(TorngitBaseAdapter):
             body=dict(
                 url=url,
                 enable_ssl_verification=self.verify_ssl
-                if type(self.verify_ssl) is bool
+                if isinstance(self.verify_ssl, bool)
                 else True,
                 token=secret,
                 **events,
@@ -668,7 +668,7 @@ class Gitlab(TorngitBaseAdapter):
         return True
 
     def diff_to_json(self, diff):
-        if type(diff) is list:
+        if isinstance(diff, list):
             for d in diff:
                 mode = ""
                 if d["deleted_file"]:

--- a/shared/utils/merge.py
+++ b/shared/utils/merge.py
@@ -289,7 +289,7 @@ def cast_ints_float(value):
     When doing a merge we'd like to convert all ints to floats. this method takes in a value and
     converts it to flaot if type(value) is int
     """
-    return value if type(value) is not int else float(value)
+    return value if not isinstance(value, int) else float(value)
 
 
 class LineType(IntEnum):

--- a/shared/utils/migrate.py
+++ b/shared/utils/migrate.py
@@ -36,7 +36,7 @@ TOTALS_MAP_v1 = (
 
 def migrate_totals(totals):
     if totals:
-        if type(totals) is list:
+        if isinstance(totals, list):
             # v3
             return totals
 
@@ -48,7 +48,7 @@ def migrate_totals(totals):
             return data
 
         else:
-            tg = totals.get if type(totals) is dict else loads(totals).get
+            tg = totals.get if isinstance(totals, dict) else loads(totals).get
             # v2
             return [tg(k, 0) for k in TOTALS_MAP]
     return []
@@ -75,7 +75,7 @@ def v3_to_v2(report, path=None):
 
 
 def totals_to_dict(totals):
-    if type(totals) is dict:
+    if isinstance(totals, dict):
         # turn into list for zipping
         totals = [totals.get(k, 0) for k in TOTALS_MAP]
 

--- a/shared/utils/totals.py
+++ b/shared/utils/totals.py
@@ -45,7 +45,7 @@ def _sum(array):
         if not isinstance(array[0], (type(None), str)):
             try:
                 return sum(array)
-            except:
+            except Exception:
                 # https://sentry.io/codecov/v4/issues/159966549/
-                return sum([a if type(a) is int else 0 for a in array])
+                return sum([a if isinstance(a, int) else 0 for a in array])
     return None

--- a/tests/unit/bundle_analysis/test_bundle_analysis.py
+++ b/tests/unit/bundle_analysis/test_bundle_analysis.py
@@ -87,8 +87,8 @@ def test_create_bundle_report():
 
         for ar in asset_reports:
             for module in ar.modules():
-                assert type(module.name) == str
-                assert type(module.size) == int
+                assert isinstance(module.name, str)
+                assert isinstance(module.size, int)
 
         assert bundle_report.total_size() == 150572
         assert report.session_count() == 1

--- a/tests/unit/utils/test_flare.py
+++ b/tests/unit/utils/test_flare.py
@@ -117,7 +117,7 @@ def test_report_to_flare():
         helper method to compare nested dicts, if an item of a dict is a list, the list is sorted and then compared
         agaisnt the expected result
         """
-        if type(result) == list:
+        if isinstance(result, list):
             sorted_list = sorted(result, key=lambda k: k["name"])
             sorted_expected = sorted(excpected, key=lambda k: k["name"])
             for i in range(len(sorted_list)):

--- a/tests/unit/utils/test_merge.py
+++ b/tests/unit/utils/test_merge.py
@@ -281,7 +281,7 @@ def test_merge_line(l1, l2, expected_res):
     )
     try:
         assert res == ReportLine.create(*expected_res)
-    except:
+    except Exception:
         res.sessions.reverse()
         assert res == ReportLine.create(*expected_res)
 


### PR DESCRIPTION
### Purpose/Motivation

Part of the lint enhancement epic, this PR aims to add the Pycodestyle error rules, and the Pylint Convention and Pylint Error rules.
These can be found here:
- https://docs.astral.sh/ruff/rules/#error-e
- https://docs.astral.sh/ruff/rules/#error-e_1
- https://docs.astral.sh/ruff/rules/#convention-c

A majority of the fixes were related to E721 (isinstance comparisons), E722 (bare except) and E713 (test for membership should be not in)

There were also one for PLE0605 and one for PLE1205

### Links to relevant tickets

Closes https://github.com/codecov/engineering-team/issues/1845

### What does this PR do?

This PR adds the rules listed above and fixes any errors that stemmed from them.

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.