### PR TITLE
track why we fail to get integration tokens

### DIFF
--- a/tests/unit/test_github.py
+++ b/tests/unit/test_github.py
@@ -198,8 +198,9 @@ class TestGithubSpecificLogic(object):
         mocked_post = mocker.patch("shared.github.requests.post")
         mocked_post.return_value.status_code = 404
         mocker.patch("shared.github.get_pem", return_value=fake_private_key)
-        with pytest.raises(InvalidInstallationError):
+        with pytest.raises(InvalidInstallationError) as exp:
             get_github_integration_token(service, integration_id)
+        assert exp.value.error_cause == "installation_not_found"
         mocked_post.assert_called_with(
             "https://api.github.com/app/installations/1/access_tokens",
             headers={
@@ -240,8 +241,9 @@ class TestGithubSpecificLogic(object):
             "documentation_url": "https://docs.github.com/rest/reference/apps#create-an-installation-access-token-for-an-app",
         }
         mocker.patch("shared.github.get_pem", return_value=fake_private_key)
-        with pytest.raises(InvalidInstallationError):
+        with pytest.raises(InvalidInstallationError) as exp:
             get_github_integration_token(service, integration_id)
+        assert exp.value.error_cause == "permission_error"
         mocked_post.assert_called_with(
             "https://api.github.com/app/installations/1/access_tokens",
             headers={


### PR DESCRIPTION
Investigating `RepoWithoutValidBotError` I discovered that about 1/3 of the errors come from `InvalidInstallationError`. This means we tried to get an `access_token` for a GitHub app but failed to do so.

I know that part of these errors (part of "permission_error") is from suspended apps. We don't track what installations are suspended, but we can't use them anymore (that is what being suspended means). Part of the errors come from that. Why would a used suspend Codecov and keep uploading? God knows. Maybe they just forgot to change the CI.

The other part ("installation_not_found") I suspect are actually deleted installations that we did not delete for some reason.

In any case I think that having this extra info would be helpful when debugging issues with GitHub apps. It also opens the possibility of reacting to errors in a more appropriate way. I'll work on better handling these cases so we don't get errors in the first place.

