### PR TITLE
chore: typehints + comments

### DIFF
--- a/shared/torngit/base.py
+++ b/shared/torngit/base.py
@@ -17,11 +17,16 @@ get_start_of_line = re.compile(r"@@ \-(\d+),?(\d*) \+(\d+),?(\d*).*").match
 
 
 class TokenType(Enum):
-    read = auto()
-    admin = auto()
-    comment = auto()
-    status = auto()
-    tokenless = auto()
+    read = "read"
+    admin = "admin"
+    comment = "comment"
+    status = "status"
+    tokenless = "tokenless"
+    commit = "commit"
+    pull = "pull"
+
+
+TokenTypeMapping = Dict[TokenType, Token]
 
 
 class TorngitBaseAdapter(object):
@@ -60,7 +65,7 @@ class TorngitBaseAdapter(object):
         oauth_consumer_token: OauthConsumerToken = None,
         timeouts=None,
         token: Token = None,
-        token_type_mapping: Dict[TokenType, Dict] = None,
+        token_type_mapping: TokenTypeMapping = None,
         on_token_refresh: OnRefreshCallback = None,
         verify_ssl=None,
         **kwargs,
@@ -109,28 +114,28 @@ class TorngitBaseAdapter(object):
             return token
         return self.get_token_by_type(token_type)
 
-    def _oauth_consumer_token(self):
+    def _oauth_consumer_token(self) -> OauthConsumerToken:
         if not self._oauth:
             raise Exception("Oauth consumer token not present")
         return self._oauth
 
-    def _validate_language(self, language):
+    def _validate_language(self, language: str) -> str | None:
         if language:
             language = language.lower()
             if language in self.valid_languages:
                 return language
 
-    def set_token(self, token: OauthConsumerToken):
+    def set_token(self, token: OauthConsumerToken) -> None:
         self._token = token
 
     @property
-    def token(self):
+    def token(self) -> Token:
         if not self._token:
             self._token = self._oauth_consumer_token()
         return self._token
 
     @property
-    def slug(self):
+    def slug(self) -> str | None:
         if self.data.get("owner") and self.data.get("repo"):
             if self.data["owner"].get("username") and self.data["repo"].get("name"):
                 return "%s/%s" % (

--- a/shared/typings/oauth_token_types.py
+++ b/shared/typings/oauth_token_types.py
@@ -3,6 +3,8 @@ from typing import Any, Awaitable, Callable, Optional, TypedDict
 
 class Token(TypedDict):
     key: str
+    # This information is used to identify the token owner in the logs, if present
+    username: str | None
 
 
 class OauthConsumerToken(Token):

--- a/tests/unit/validation/test_install_validation.py
+++ b/tests/unit/validation/test_install_validation.py
@@ -341,6 +341,7 @@ def test_validate_sample_production_config(mocker):
     }
     mock_warning = mocker.patch.object(install_log, "warning")
     res = validate_install_configuration(user_input)
+    print(mock_warning.call_args)
     assert mock_warning.call_count == 0
     assert res["site"] == expected_result["site"]
     assert res == expected_result


### PR DESCRIPTION
Before started working on the revamping app usage I took some time to access what we currently have.
This ended up manifesting in type annotations and a small cleanup in the install docs.

The only real addition is `services.github.dedicated_apps` config values for the
dedicated apps.

<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.