### PR TITLE
fix: fix fallback system in GH (again)

### DIFF
--- a/shared/torngit/base.py
+++ b/shared/torngit/base.py
@@ -1,5 +1,5 @@
 import re
-from enum import Enum, auto
+from enum import Enum
 from typing import Dict, List, Optional, Tuple
 
 import httpx

--- a/shared/torngit/github.py
+++ b/shared/torngit/github.py
@@ -739,6 +739,7 @@ class Github(TorngitBaseAdapter):
         installation_info = fallback_installations.pop(0)
         # The function arg is 'integration_id'
         installation_id = installation_info.pop("installation_id")
+        obj_id = installation_info.pop("id", None)
         token_to_use = get_github_integration_token(
             self.service, installation_id, **installation_info
         )
@@ -747,6 +748,7 @@ class Github(TorngitBaseAdapter):
         self.data["installation"] = {
             # Put the installation_id back into the info
             "installation_id": installation_id,
+            "id": obj_id,
             **installation_info,
         }
         return token_to_use

--- a/tests/unit/torngit/test_github.py
+++ b/tests/unit/torngit/test_github.py
@@ -1097,7 +1097,12 @@ class TestUnitGithub(object):
                 installation_id=1500,
             ),
             fallback_installations=[
-                {"installation_id": 12342, "app_id": 1200, "pem_path": "some_path"}
+                {
+                    "installation_id": 12342,
+                    "app_id": 1200,
+                    "pem_path": "some_path",
+                    "id": 20,
+                }
             ],
         )
 


### PR DESCRIPTION
I broke the GH fallback system again 😅
Fixes this issue: https://l.codecov.dev/dEsZeK

The problem is that since https://github.com/codecov/shared/pull/225
(technically https://github.com/codecov/worker/pull/470 actually) we include 1 extra piece of information in `GitHubAppInstallationInfo`, the `GitHubAppInstallation.id`.

This is breaking the function that gets tokens because we are destructuring the info dict
into the kwargs for the function (with the extra, unexpected `id` one).

To fix that we just pop it before calling the function.

<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.