### PR TITLE
Allow filtering of bundle's assets

### DIFF
--- a/tests/samples/sample_bundle_stats.json
+++ b/tests/samples/sample_bundle_stats.json
@@ -56,7 +56,7 @@
       "id": "index",
       "uniqueId": "2-index",
       "entry": true,
-      "initial": false,
+      "initial": true,
       "files": ["assets/index-666d2e09.js"],
       "names": ["index"]
     }

--- a/tests/unit/bundle_analysis/test_bundle_analysis.py
+++ b/tests/unit/bundle_analysis/test_bundle_analysis.py
@@ -113,18 +113,21 @@ def test_bundle_report_asset_filtering():
         assert bundle_report is None
         bundle_report = report.bundle_report("sample")
 
-        asset_reports = list(bundle_report.asset_reports(
+        all_asset_reports = list(bundle_report.asset_reports())
+        assert len(all_asset_reports) == 5
+
+        filtered_asset_reports = list(bundle_report.asset_reports(
             asset_types=[AssetType.JAVASCRIPT],
             chunk_entry=True,
             chunk_initial=True,
         ))
 
-        for ar in asset_reports:
+        for ar in filtered_asset_reports:
             for module in ar.modules():
                 assert isinstance(module.name, str)
                 assert isinstance(module.size, int)
 
-        assert len(asset_reports) == 1
+        assert len(filtered_asset_reports) == 1
         assert bundle_report.total_size(
             asset_types=[AssetType.JAVASCRIPT],
             chunk_entry=True,


### PR DESCRIPTION
Update a bundle report's `assets` and `total_size` that allows the follow 3 filter options:
- the asset has at least one chunk whose `entry` value is the request boolean
- the asset has at least one chunk whose `initial` value is the request boolean
- the asset belongs to one of the request `asset_type`s

This filtering applies a intersection search, eg if all 3 are selected, all 3 clauses must be true.

closes https://github.com/codecov/engineering-team/issues/1924
closes https://github.com/codecov/engineering-team/issues/1897

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.