### PR TITLE
dev: Add perf rules for ruff on shared

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -39,7 +39,7 @@ target-version = "py312"
 [lint]
 # Currently only enabled for F (Pyflakes), I (isort), E,W, (pycodestyle:Error/Warning),
 # and PLC/E/W (Pylint:Convention/Error/Warning) rules: https://docs.astral.sh/ruff/rules/
-select = ["F", "I", "E", "W", "PLC", "PLE", "PLW"]
+select = ["F", "I", "E", "W", "PLC", "PLE", "PLW", "PERF"]
 ignore = ["E501"]
 
 # Allow fix for all enabled rules (when `--fix`) is provided.

--- a/shared/django_apps/utils/model_utils.py
+++ b/shared/django_apps/utils/model_utils.py
@@ -149,11 +149,8 @@ class ArchiveField:
 
 
 def default_random_salt():
-    chars = []
     ALPHABET = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
-    for _ in range(16):
-        chars.append(choice(ALPHABET))
-    return "".join(chars)
+    return "".join([choice(ALPHABET) for _ in range(16)])
 
 
 def rollout_universe_to_override_string(rollout_universe: RolloutUniverse):

--- a/shared/helpers/cache.py
+++ b/shared/helpers/cache.py
@@ -209,10 +209,9 @@ class FunctionCacher(object):
         return self.cache_synchronous_function(func)
 
     def _log_hits(self, func, args, kwargs, key) -> None:
-        args_to_log = []
-        for idx in self.log_map.args_indexes_to_log:
-            if idx < len(args):
-                args_to_log.append(args[idx])
+        args_to_log = [
+            args[idx] for idx in self.log_map.args_indexes_to_log if idx < len(args)
+        ]
         kwargs_to_log = {}
         for lkey in self.log_map.kwargs_keys_to_log:
             if lkey in kwargs:

--- a/shared/reports/api_report_service.py
+++ b/shared/reports/api_report_service.py
@@ -33,7 +33,7 @@ class ReportMixin:
     def flags(self):
         """returns dict(:name=<Flag>)"""
         flags_dict = {}
-        for sid, session in self.sessions.items():
+        for session in self.sessions.values():
             if session.flags is not None:
                 carriedforward = session.session_type.value == "carriedforward"
                 carriedforward_from = session.session_extras.get("carriedforward_from")

--- a/shared/reports/editable.py
+++ b/shared/reports/editable.py
@@ -177,9 +177,9 @@ class EditableReport(Report):
     @metrics.timer("services.report.EditableReport.delete_multiple_sessions")
     def delete_multiple_sessions(self, session_ids_to_delete: List[int]):
         self._totals = None
-        deleted_sessions = []
-        for sessionid in session_ids_to_delete:
-            deleted_sessions.append(self.sessions.pop(sessionid))
+        deleted_sessions = [
+            self.sessions.pop(sessionid) for sessionid in session_ids_to_delete
+        ]
         for file in self._chunks:
             if file is not None:
                 file.delete_multiple_sessions(session_ids_to_delete)

--- a/shared/reports/filtered.py
+++ b/shared/reports/filtered.py
@@ -213,7 +213,7 @@ class FilteredReport(object):
 
     @property
     def network(self):
-        for fname, data in self.report._files.items():
+        for fname in self.report._files.keys():
             file = self.get(fname)
             if file:
                 yield fname, make_network_file(file.totals)
@@ -257,7 +257,7 @@ class FilteredReport(object):
         return not any(self.should_include(x) for x in self.report._files.keys())
 
     def _iter_totals(self):
-        for filename, data in self.report._files.items():
+        for filename in self.report._files.keys():
             if self.should_include(filename):
                 res = self.get(filename).totals
                 if res and res.lines > 0:

--- a/shared/reports/resources.py
+++ b/shared/reports/resources.py
@@ -760,7 +760,7 @@ class Report(object):
     def flags(self):
         """returns dict(:name=<Flag>)"""
         flags_dict = {}
-        for sid, session in self.sessions.items():
+        for session in self.sessions.values():
             if session.flags:
                 # If the session was carriedforward, mark its flags as carriedforward
                 session_carriedforward = (
@@ -781,7 +781,7 @@ class Report(object):
 
     def get_flag_names(self):
         all_flags = set()
-        for _, session in self.sessions.items():
+        for session in self.sessions.values():
             if session and session.flags:
                 all_flags.update(session.flags)
         return sorted(all_flags)
@@ -1399,7 +1399,7 @@ class Report(object):
         """
         Returns boolean: if the flag is found
         """
-        for sid, data in self.sessions.items():
+        for data in self.sessions.values():
             if flag_name in (data.flags or []):
                 return True
         return False
@@ -1434,7 +1434,7 @@ class Report(object):
             )
         )
         chunks_mapping = {b: a for (a, b) in notnull_chunks_new_location}
-        for filename, summary in self._files.items():
+        for summary in self._files.values():
             summary.file_index = chunks_mapping.get(summary.file_index)
         self._chunks = new_chunks
         log.info("Repacked files in report")

--- a/shared/storage/memory.py
+++ b/shared/storage/memory.py
@@ -178,10 +178,10 @@ class MemoryStorageService(BaseStorageService):
         Raises:
             NotImplementedError: If the current instance did not implement this method
         """
-        res = []
-        for key in self.storage[bucket_name]:
-            if prefix is None or key.startswith(prefix):
-                res.append(
-                    {"name": key, "size": len(self.storage[bucket_name][key].decode())}
-                )
+        res = [
+            {"name": key, "size": len(self.storage[bucket_name][key].decode())}
+            for key in self.storage[bucket_name]
+            if prefix is None or key.startswith(prefix)
+        ]
+
         return res

--- a/shared/torngit/base.py
+++ b/shared/torngit/base.py
@@ -144,9 +144,10 @@ class TorngitBaseAdapter(object):
                 )
 
     def build_tree_from_commits(self, start, commit_mapping):
-        parents = []
-        for p in commit_mapping.get(start, []):
-            parents.append(self.build_tree_from_commits(p, commit_mapping))
+        parents = [
+            self.build_tree_from_commits(p, commit_mapping)
+            for p in commit_mapping.get(start, [])
+        ]
         return {"commitid": start, "parents": parents}
 
     def diff_to_json(self, diff):
@@ -243,7 +244,7 @@ class TorngitBaseAdapter(object):
             return dict(files=self._add_diff_totals(results))
 
     def _add_diff_totals(self, diff):
-        for fname, data in diff.items():
+        for data in diff.values():
             rm = 0
             add = 0
             if "segments" in data:

--- a/shared/torngit/bitbucket.py
+++ b/shared/torngit/bitbucket.py
@@ -444,15 +444,13 @@ class Bitbucket(TorngitBaseAdapter):
                     page=page,
                     token=token,
                 )
-                if len(res["values"]) == 0:
+                if not res["values"]:
                     page = 0
-                    break
-                for permission in res["values"]:
-                    data.append(permission)
-
-                if not res.get("next"):
-                    page = 0
-                    break
+                else:
+                    data.extend(res["values"])
+                    if not res.get("next"):
+                        page = 0
+                        break
         return data
 
     async def get_pull_request(self, pullid, token=None):

--- a/shared/torngit/github.py
+++ b/shared/torngit/github.py
@@ -2238,9 +2238,9 @@ class Github(TorngitBaseAdapter):
 
                     for repo in repositories["nodes"]:
                         languages = repo["languages"]["edges"]
-                        res_languages = []
-                        for language in languages:
-                            res_languages.append(language["node"]["name"].lower())
+                        res_languages = [
+                            language["node"]["name"].lower() for language in languages
+                        ]
 
                         all_repositories[repo["name"]] = res_languages
 

--- a/shared/torngit/gitlab.py
+++ b/shared/torngit/gitlab.py
@@ -1405,10 +1405,8 @@ class Gitlab(TorngitBaseAdapter):
             token=token,
             counter_name="get_best_effort_branches",
         )
-        all_results = []
-        async for page in async_generator:
-            for res in page:
-                all_results.append(res["name"])
+
+        all_results = [res["name"] async for page in async_generator for res in page]
         return all_results
 
     async def is_student(self):

--- a/shared/yaml/user_yaml.py
+++ b/shared/yaml/user_yaml.py
@@ -62,7 +62,7 @@ class UserYaml(object):
     def has_any_carryforward(self):
         all_flags = self.inner_dict.get("flags")
         if all_flags:
-            for flag_name, flag_info in all_flags.items():
+            for flag_info in all_flags.values():
                 if flag_info.get("carryforward"):
                     return True
         flag_management = self.inner_dict.get("flag_management", {})


### PR DESCRIPTION
### Purpose/Motivation

Part of the lint enhancement epic, this PR aims to add the PerfLint PERF rules.
These can be found here:
- https://docs.astral.sh/ruff/rules/#perflint-perf

All of the fixes were either doing list comprehensions where possible, or using .values() or .keys() when we only needed one or the other. The latter is definitely a micro-optimization, but it improves the clarity of the code as well.

Resources:
- Why list comprehensions are much faster in python 3.12: https://peps.python.org/pep-0709/

### Links to relevant tickets

Closes https://github.com/codecov/engineering-team/issues/1931

### What does this PR do?

This PR adds the rules listed above and fixes any errors that stemmed from them.

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.