### PR TITLE
add tracker for commit model for shelter signals

### DIFF
--- a/shared/django_apps/core/models.py
+++ b/shared/django_apps/core/models.py
@@ -243,6 +243,9 @@ class Commit(ExportModelOperationsMixin("core.commit"), models.Model):
         null=True, choices=CommitStates.choices
     )  # Really an ENUM in db
 
+    # tracks field changes being saved for signals
+    tracker = FieldTracker()
+
     def save(self, *args, **kwargs):
         self.updatestamp = timezone.now()
         super().save(*args, **kwargs)


### PR DESCRIPTION


### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.