### PR TITLE
Fix duplicate check in metrics service

### DIFF
--- a/shared/django_apps/codecov_metrics/service/codecov_metrics.py
+++ b/shared/django_apps/codecov_metrics/service/codecov_metrics.py
@@ -24,7 +24,7 @@ class UserOnboardingMetricsService:
             return
 
         if not UserOnboardingLifeCycleMetrics.objects.filter(
-            org_id=org_id, event=event
+            org_id=org_id, event=event, additional_data=payload
         ).exists():
             metric = UserOnboardingLifeCycleMetrics(
                 org_id=org_id,

--- a/shared/django_apps/codecov_metrics/service/codecov_metrics.py
+++ b/shared/django_apps/codecov_metrics/service/codecov_metrics.py
@@ -23,15 +23,11 @@ class UserOnboardingMetricsService:
             log.warning("Incompatible event type", extra=dict(event_name=event))
             return
 
-        if not UserOnboardingLifeCycleMetrics.objects.filter(
-            org_id=org_id, event=event, additional_data=payload
-        ).exists():
-            metric = UserOnboardingLifeCycleMetrics(
-                org_id=org_id,
-                event=event,
-                timestamp=timezone.now(),
-                additional_data=payload,
-            )
-            metric.save()
+        metric, created = UserOnboardingLifeCycleMetrics.objects.get_or_create(
+            org_id=org_id,
+            event=event,
+            additional_data=payload,
+        )
+        if created:
             return metric
         return None


### PR DESCRIPTION
<!-- Describe your PR here. -->

Also check that the payload is the same before skipping the write. Current tests should catch this logic already. 


<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.