### PR TITLE
feat: extend configuration for `comment.required_changes`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ setup(
         "cachetools",
         "django-better-admin-arrayfield",
         "django-postgres-extra>=2.0.8",
+        "pyparsing",
         # API Deps
         "django-prometheus",
         "python-redis-lock",

--- a/shared/validation/helpers.py
+++ b/shared/validation/helpers.py
@@ -1,12 +1,16 @@
+import functools
 import logging
 import numbers
 import re
 from typing import Any, List
 
+import pyparsing as pp
+
 from shared.validation.types import (
     CoverageCommentRequiredChanges,
     CoverageCommentRequiredChangesANDGroup,
     CoverageCommentRequiredChangesORGroup,
+    ValidRawRequiredChange,
 )
 
 log = logging.getLogger(__name__)
@@ -97,63 +101,50 @@ class CoverageCommentRequirementSchemaField(object):
             return [CoverageCommentRequiredChanges.any_change.value]
         return [CoverageCommentRequiredChanges.no_requirements.value]
 
+    def _convert_to_binary_value(
+        self, valid_requirement: ValidRawRequiredChange
+    ) -> int:
+        """Gets the binary value of `valid_requirement` as defined in CoverageCommentRequiredChanges"""
+        return CoverageCommentRequiredChanges[valid_requirement].value
+
+    def _parse_or_group(
+        self, acc: int, value: ValidRawRequiredChange
+    ) -> CoverageCommentRequiredChangesORGroup:
+        """Combines the individual `valid_requirement` into a single value"""
+        return acc | self._convert_to_binary_value(value)
+
     def validate_str(self, data: str) -> CoverageCommentRequiredChangesANDGroup:
+        """Validates required_changes from a string that represents operations on valid_requirements
+        and returns the result.
+
+        Result is CoverageCommentRequiredChangesANDGroup, a list of ORGroups.
+        An ORGroup is 1 or more valid_requirements that are grouped together (using OR operations)
+        For the overall ANDGroup to be satisfied, ALL the ORGroups that are port of it need to also be satisfied.
+        """
         if data == "":
             raise Invalid("required_changes is empty")
-        pieces = list(map(str.lower, data.split(" ")))
-        and_groups: CoverageCommentRequiredChangesANDGroup = []
-        operands_stack: List[CoverageCommentRequiredChangesORGroup] = []
-        operations_stack: List[str] = []
-        is_higher_precedence_op = lambda me, other: (me == "and" and other == "or")  # noqa: E731
-        is_same_op = lambda me, other: me == other  # noqa: E731
-        for piece in pieces:
-            match piece:
-                case "coverage_drop":
-                    operands_stack.append(
-                        CoverageCommentRequiredChanges.coverage_drop.value
-                    )
-                case "uncovered_patch":
-                    operands_stack.append(
-                        CoverageCommentRequiredChanges.uncovered_patch.value
-                    )
-                case "any_change":
-                    operands_stack.append(
-                        CoverageCommentRequiredChanges.any_change.value
-                    )
-                case "and" | "or":
-                    while len(operations_stack) > 0 and (
-                        is_higher_precedence_op(piece, operations_stack[0])
-                        or is_same_op(piece, operations_stack[0])
-                    ):
-                        operation = operations_stack.pop()
-                        self._process_operation(and_groups, operands_stack, operation)
-                    operations_stack.append(piece)
-                case _:
-                    raise Invalid(f"Unknown operand for required_changes: {piece}")
-        while len(operations_stack) > 0:
-            operation = operations_stack.pop()
-            self._process_operation(and_groups, operands_stack, operation)
-        if len(operands_stack) > 1:
-            raise Invalid("Failed to process required_changes")
-        elif len(operands_stack) == 1:
-            and_groups.append(operands_stack[0])
-        return and_groups
+        data = data.lower()
 
-    def _process_operation(
-        self,
-        and_groups: CoverageCommentRequiredChangesANDGroup,
-        operands_stack: List[CoverageCommentRequiredChanges],
-        operation: str,
-    ):
-        if len(operands_stack) < 2:
-            raise Invalid("Failed to process required_changes")
-        rhs = operands_stack.pop()
-        lhs = operands_stack.pop()
-        if operation == "and":
-            and_groups.append(lhs)
-            operands_stack.append(rhs)
-        else:
-            operands_stack.append(lhs | rhs)
+        valid_requirements = pp.oneOf(
+            "coverage_drop uncovered_patch any_change", asKeyword=True
+        )
+        or_groups_parser = pp.delimitedList(valid_requirements, "or").setResultsName(
+            "or_groups", listAllMatches=True
+        )
+        and_groups_parser = pp.delimitedList(or_groups_parser, "and")
+
+        try:
+            raw_or_groups: List[pp.ParseResults] = and_groups_parser.parseString(
+                data, parseAll=True
+            )["or_groups"]
+            parsed_or_groups = [
+                functools.reduce(self._parse_or_group, raw_group, 0)
+                for raw_group in raw_or_groups
+            ]
+            return parsed_or_groups
+
+        except pp.ParseException:
+            raise Invalid("Failed to parse required_changes")
 
 
 class PercentSchemaField(object):

--- a/shared/validation/types.py
+++ b/shared/validation/types.py
@@ -1,0 +1,35 @@
+from enum import Enum
+from typing import List, Literal
+
+
+class CoverageCommentRequiredChanges(Enum):
+    """Concrete choices of requirements to post the coverage PR comment
+    See shared.validation.user_schema.py for description
+    """
+
+    no_requirements = 0b000
+    any_change = 0b001
+    coverage_drop = 0b010
+    uncovered_patch = 0b100
+
+
+CoverageCommentRequiredChangesORGroup = (
+    # This represents a grouping of CoverageCommentRequiredChanges through OR operations (bitwise).
+    # For the group to be satisfied ANY of the conditions should be satisfied
+    # To know if a CoverageCommentRequiredChanges you do a bitwise AND:
+    # Example:
+    #   0b110 & CoverageCommentRequiredChanges.uncovered_patch == True (so 'uncovered_patch' is a member of this OR group)
+    Literal[0b000]
+    | Literal[0b001]
+    | Literal[0b010]
+    | Literal[0b011]
+    | Literal[0b100]
+    | Literal[0b101]
+    | Literal[0b110]
+    | Literal[0b111]
+)
+
+# For the AND group to be satisfied ALL of the individual OR groups need to be satisfied
+# Example:
+#   [0b001, 0b100] - There has to be any change in coverage AND the patch can't be 100% covered
+CoverageCommentRequiredChangesANDGroup = List[CoverageCommentRequiredChangesORGroup]

--- a/shared/validation/types.py
+++ b/shared/validation/types.py
@@ -13,6 +13,9 @@ class CoverageCommentRequiredChanges(Enum):
     uncovered_patch = 0b100
 
 
+ValidRawRequiredChange = (
+    Literal["any_change"] | Literal["coverage_drop"] | Literal["uncovered_patch"]
+)
 CoverageCommentRequiredChangesORGroup = (
     # This represents a grouping of CoverageCommentRequiredChanges through OR operations (bitwise).
     # For the group to be satisfied ANY of the conditions should be satisfied

--- a/shared/validation/user_schema.py
+++ b/shared/validation/user_schema.py
@@ -141,6 +141,68 @@ component_rule_basic_properties = {
     "paths": path_list_structure,
 }
 
+coverage_comment_config = {
+    "layout": {
+        "type": "string",
+        "comma_separated_strings": True,
+        "nullable": True,
+    },
+    "require_changes": {
+        "coerce": "coverage_comment_required_changes",
+        "meta": {
+            "description": "require_changes instructs Codecov to only post a PR Comment if there are coverage changes in the PR.",
+            "options": {
+                False: {
+                    "type": bool,
+                    "description": "post comment even if there's no change in coverage",
+                    "default": True,
+                },
+                True: {
+                    "type": bool,
+                    "description": "only post comment if there are changes in coverage (positive or negative)",
+                },
+                "coverage_drop": {
+                    "type": str,
+                    "description": "[project coverage] only post comment if coverage drops more than <coverage.status.project.threshold> percent when comparing HEAD to BASE",
+                },
+                "uncovered_patch": {
+                    "type": str,
+                    "description": "[patch coverage] only post comment if the patch has uncovered lines",
+                },
+                "check_fails": {
+                    "type": str,
+                    "description": "only post comment if either the 'project' or 'patch' statuses fail",
+                },
+            },
+        },
+    },
+    "require_base": {"type": "boolean"},
+    "require_head": {"type": "boolean"},
+    "show_critical_paths": {"type": "boolean"},
+    "branches": branches_structure,
+    "paths": path_list_structure,  # DEPRECATED
+    "flags": flag_list_structure,  # DEPRECATED
+    "behavior": {
+        "type": "string",
+        "allowed": ("default", "once", "new", "spammy"),
+    },
+    "after_n_builds": {"type": "integer", "min": 0},
+    "show_carryforward_flags": {"type": "boolean"},
+    "hide_comment_details": {"type": "boolean"},
+    "hide_project_coverage": {"type": "boolean"},
+}
+
+bundle_analysis_comment_config = {
+    "require_bundle_changes": {
+        "type": ["boolean", "string"],
+        "allowed": ["bundle_increase", False, True],
+    },
+    "bundle_change_threshold": {
+        "type": "string",
+        "regex": r"\d+\s*(mb|kb|gb|b|bytes))",
+    },
+}
+
 schema = {
     "codecov": {
         "type": "dict",
@@ -448,29 +510,7 @@ schema = {
     },
     "comment": {
         "type": ["dict", "boolean"],
-        "schema": {
-            "layout": {
-                "type": "string",
-                "comma_separated_strings": True,
-                "nullable": True,
-            },
-            "require_changes": {"type": "boolean"},
-            "require_bundle_changes": {"type": "boolean"},
-            "require_base": {"type": "boolean"},
-            "require_head": {"type": "boolean"},
-            "show_critical_paths": {"type": "boolean"},
-            "branches": branches_structure,
-            "paths": path_list_structure,  # DEPRECATED
-            "flags": flag_list_structure,  # DEPRECATED
-            "behavior": {
-                "type": "string",
-                "allowed": ("default", "once", "new", "spammy"),
-            },
-            "after_n_builds": {"type": "integer", "min": 0},
-            "show_carryforward_flags": {"type": "boolean"},
-            "hide_comment_details": {"type": "boolean"},
-            "hide_project_coverage": {"type": "boolean"},
-        },
+        "schema": {**coverage_comment_config, **bundle_analysis_comment_config},
     },
     "slack_app": {
         "type": ["dict", "boolean"],

--- a/shared/validation/validator.py
+++ b/shared/validation/validator.py
@@ -2,6 +2,7 @@ from cerberus import Validator
 
 from shared.validation.helpers import (
     BranchSchemaField,
+    CoverageCommentRequirementSchemaField,
     CoverageRangeSchemaField,
     CustomFixPathSchemaField,
     Invalid,
@@ -36,6 +37,9 @@ class CodecovYamlValidator(Validator):
 
     def _normalize_coerce_branch_normalize(self, value):
         return BranchSchemaField().validate(value)
+
+    def _normalize_coerce_coverage_comment_required_changes(self, value):
+        return CoverageCommentRequirementSchemaField().validate(value)
 
     def _validate_comma_separated_strings(self, constraint, field, value):
         """Test the oddity of a value.

--- a/tests/unit/validation/test_helpers.py
+++ b/tests/unit/validation/test_helpers.py
@@ -3,6 +3,7 @@ import re
 import pytest
 
 from shared.validation.helpers import (
+    CoverageCommentRequirementSchemaField,
     CoverageRangeSchemaField,
     CustomFixPathSchemaField,
     Invalid,
@@ -13,6 +14,7 @@ from shared.validation.helpers import (
     determine_path_pattern_type,
     translate_glob_to_regex,
 )
+from shared.validation.types import CoverageCommentRequiredChanges
 from shared.yaml.validation import pre_process_yaml
 from tests.base import BaseTestCase
 
@@ -343,3 +345,120 @@ class TestCustomFixPathSchemaField(BaseTestCase):
         # No "::" separator
         with pytest.raises(Invalid):
             cfpsf.validate("beforeafter")
+
+
+class TestCoverageCommentRequirementSchemaField(object):
+
+    @pytest.mark.parametrize(
+        "input, expected",
+        [
+            # Old values
+            pytest.param(True, [0b001]),
+            pytest.param(False, [0b000]),
+            # Individual values
+            pytest.param("any_change", [0b001]),
+            pytest.param("coverage_drop", [0b010]),
+            pytest.param("uncovered_patch", [0b100]),
+            # Operators
+            pytest.param(
+                "uncovered_patch AND uncovered_patch",
+                [0b100, 0b100],
+            ),
+            pytest.param(
+                "uncovered_patch and uncovered_patch",
+                [0b100, 0b100],
+            ),
+            pytest.param(
+                "uncovered_patch OR uncovered_patch",
+                [0b100],
+            ),
+            pytest.param(
+                "uncovered_patch or uncovered_patch",
+                [0b100],
+            ),
+            # Combinations
+            pytest.param(
+                "coverage_drop or any_change",
+                [0b011],
+            ),
+            pytest.param(
+                "coverage_drop and any_change",
+                [0b010, 0b001],
+            ),
+            pytest.param(
+                "coverage_drop or uncovered_patch",
+                [0b110],
+            ),
+            pytest.param(
+                "any_change and uncovered_patch",
+                [0b001, 0b100],
+            ),
+            pytest.param(
+                "any_change and coverage_drop",
+                [0b001, 0b010],
+            ),
+            pytest.param(
+                "any_change or coverage_drop or uncovered_patch",
+                [0b111],
+            ),
+            pytest.param(
+                "any_change or coverage_drop and uncovered_patch",
+                [0b011, 0b100],
+            ),
+            pytest.param(
+                "any_change and coverage_drop and uncovered_patch",
+                [0b001, 0b010, 0b100],
+            ),
+        ],
+    )
+    def test_coverage_comment_requirement_coercion_success(self, input, expected):
+        validator = CoverageCommentRequirementSchemaField()
+        assert validator.validate(input) == expected
+
+    @pytest.mark.parametrize(
+        "input, exception_message",
+        [
+            pytest.param(
+                None, "Only bool and str are accepted values", id="invalid_input_None"
+            ),
+            pytest.param(
+                42, "Only bool and str are accepted values", id="invalid_input_int"
+            ),
+            pytest.param(
+                ["coverage_drop"],
+                "Only bool and str are accepted values",
+                id="invalid_input_list",
+            ),
+            pytest.param(
+                "coverage_drop+any_change",
+                "Unknown operand for required_changes: coverage_drop+any_change",
+                id="invalid_string_no_spaces",
+            ),
+            pytest.param(
+                "coverage_drop + any_change",
+                "Unknown operand for required_changes: +",
+                id="invalid_operation",
+            ),
+            pytest.param("", "required_changes is empty", id="empty_string"),
+            pytest.param(
+                "coverage_drop any_change",
+                "Failed to process required_changes",
+                id="no_operation",
+            ),
+            pytest.param(
+                "coverage_drop AND AND any_change",
+                "Failed to process required_changes",
+                id="too_many_operations",
+            ),
+            pytest.param(
+                "coverage_drop AND any_change AND",
+                "Failed to process required_changes",
+                id="incomplete_operation",
+            ),
+        ],
+    )
+    def test_coverage_comment_requirement_coercion_fail(self, input, exception_message):
+        validator = CoverageCommentRequirementSchemaField()
+        with pytest.raises(Invalid) as exp:
+            validator.validate(input)
+        assert exp.value.error_message == exception_message

--- a/tests/unit/validation/test_helpers.py
+++ b/tests/unit/validation/test_helpers.py
@@ -435,29 +435,49 @@ class TestCoverageCommentRequirementSchemaField(object):
             ),
             pytest.param(
                 "coverage_drop+any_change",
-                "Unknown operand for required_changes: coverage_drop+any_change",
+                "Failed to parse required_changes",
                 id="invalid_string_no_spaces",
             ),
             pytest.param(
                 "coverage_drop + any_change",
-                "Unknown operand for required_changes: +",
+                "Failed to parse required_changes",
                 id="invalid_operation",
             ),
             pytest.param("", "required_changes is empty", id="empty_string"),
             pytest.param(
                 "coverage_drop any_change",
-                "Failed to process required_changes",
+                "Failed to parse required_changes",
                 id="no_operation",
             ),
             pytest.param(
                 "coverage_drop AND AND any_change",
-                "Failed to process required_changes",
+                "Failed to parse required_changes",
                 id="too_many_operations",
             ),
             pytest.param(
                 "coverage_drop AND any_change AND",
-                "Failed to process required_changes",
+                "Failed to parse required_changes",
                 id="incomplete_operation",
+            ),
+            pytest.param(
+                "coverage_dropANDany_change",
+                "Failed to parse required_changes",
+                id="no_spaces",
+            ),
+            pytest.param(
+                "coverage_drop AND OR any_change",
+                "Failed to parse required_changes",
+                id="missing_middle_operand",
+            ),
+            pytest.param(
+                "AND",
+                "Failed to parse required_changes",
+                id="single_operation_no_operands",
+            ),
+            pytest.param(
+                "AND OR AND",
+                "Failed to parse required_changes",
+                id="only_operations_no_operands",
             ),
         ],
     )

--- a/tests/unit/validation/test_helpers.py
+++ b/tests/unit/validation/test_helpers.py
@@ -409,6 +409,10 @@ class TestCoverageCommentRequirementSchemaField(object):
                 "any_change and coverage_drop and uncovered_patch",
                 [0b001, 0b010, 0b100],
             ),
+            pytest.param(
+                "any_change and coverage_drop or uncovered_patch",
+                [0b001, 0b110],
+            ),
         ],
     )
     def test_coverage_comment_requirement_coercion_success(self, input, expected):

--- a/tests/unit/validation/test_install_validation.py
+++ b/tests/unit/validation/test_install_validation.py
@@ -1,5 +1,6 @@
 from shared.validation.install import log as install_log
 from shared.validation.install import validate_install_configuration
+from shared.validation.types import CoverageCommentRequiredChanges
 from shared.yaml.validation import UserGivenSecret
 
 
@@ -259,7 +260,7 @@ def test_validate_sample_production_config(mocker):
                 "behavior": "default",
                 "show_carryforward_flags": False,
                 "require_base": False,
-                "require_changes": False,
+                "require_changes": [0b000],
                 "require_head": True,
             },
             "github_checks": {"annotations": True},

--- a/tests/unit/validation/test_validation.py
+++ b/tests/unit/validation/test_validation.py
@@ -4,6 +4,7 @@ import pytest
 
 from shared.config import ConfigHelper, get_config
 from shared.validation.exceptions import InvalidYamlException
+from shared.validation.types import CoverageCommentRequiredChanges
 from shared.yaml.validation import (
     _calculate_error_location_and_message_from_error_dict,
     do_actual_validation,
@@ -135,7 +136,7 @@ class TestUserYamlValidation(BaseTestCase):
                         "require_head": True,
                         "require_base": True,
                         "layout": "diff",
-                        "require_changes": True,
+                        "require_changes": [0b001],
                         "branches": ["^master$"],
                         "behavior": "once",
                         "after_n_builds": 6,
@@ -551,7 +552,7 @@ class TestUserYamlValidation(BaseTestCase):
             "comment": {
                 "behavior": "default",
                 "layout": "header, diff",
-                "require_changes": False,
+                "require_changes": [0b000],
                 "show_carryforward_flags": False,
             },
             "parsers": {
@@ -672,7 +673,7 @@ class TestUserYamlValidation(BaseTestCase):
                 "branches": None,
                 "layout": "reach, diff, flags, files",
                 "require_base": False,
-                "require_changes": False,
+                "require_changes": [0b000],
                 "require_head": False,
             },
             "coverage": {
@@ -858,6 +859,13 @@ class TestValidationConfig(object):
         assert res == expected_result
 
 
+@pytest.mark.parametrize(
+    "input,expected", [pytest.param("10bytes", True, id="bytes_valid")]
+)
+def test_bundle_change_threshold_regex(input, expected):
+    pass
+
+
 def test_validation_with_branches():
     user_input = {
         "comment": {
@@ -885,7 +893,7 @@ def test_validation_with_branches():
             "require_head": True,
             "require_base": True,
             "layout": "diff",
-            "require_changes": True,
+            "require_changes": [0b001],
             "branches": ["^master$"],
             "behavior": "once",
             "after_n_builds": 6,


### PR DESCRIPTION
We are extending the configuration for required_changes.
ticket: https://github.com/codecov/engineering-team/issues/1966

I might have overengineered the different conditions, but being able to combine in both AND and OR
operations is somewhat tricky. In the end it's a satisfaction problem in that all the elements in the
conditions list need to be satisfied for the comment to occur, and the elements themselves express
and OR grouping.
