### PR TITLE
fix: include region when initializing storage

### DIFF
--- a/shared/api_archive/storage.py
+++ b/shared/api_archive/storage.py
@@ -29,6 +29,8 @@ class StorageService(MinioStorageService):
             self.minio_config["iam_auth"] = False
         if "iam_endpoint" not in self.minio_config:
             self.minio_config["iam_endpoint"] = None
+        if "region" not in self.minio_config:
+            self.minio_config["region"] = None
 
         if not MINIO_CLIENT:
             MINIO_CLIENT = self.init_minio_client(
@@ -39,6 +41,7 @@ class StorageService(MinioStorageService):
                 self.minio_config["verify_ssl"],
                 self.minio_config["iam_auth"],
                 self.minio_config["iam_endpoint"],
+                self.minio_config["region"],
             )
             log.info("----- created minio_client: ---- ")
         self.minio_client = MINIO_CLIENT


### PR DESCRIPTION
the `api_archive.storage` module isn't pulling in the region as expected which causes the region to be ignored in some cases

this adds the region back similar to the `codecov-api` repo

<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.