### PR TITLE
feat: bundle analysis comment threshold

### DIFF
--- a/shared/validation/user_schema.py
+++ b/shared/validation/user_schema.py
@@ -196,10 +196,30 @@ bundle_analysis_comment_config = {
     "require_bundle_changes": {
         "type": ["boolean", "string"],
         "allowed": ["bundle_increase", False, True],
+        "meta": {
+            "description": "require_bundle_changes instructs Codecov to only post a PR Comment if the requirements are met",
+            "options": {
+                False: {
+                    "type": bool,
+                    "description": "post comment even if there's no change in the bundle size",
+                    "default": True,
+                },
+                True: {
+                    "type": bool,
+                    "description": "only post comment if there are changes in bundle size (positive or negative)",
+                },
+                "bundle_increase": {
+                    "type": str,
+                    "description": "only post comment if the bundle size increases",
+                },
+            },
+        },
     },
     "bundle_change_threshold": {
-        "type": "string",
-        "regex": r"\d+\s*(mb|kb|gb|b|bytes))",
+        "coerce": "byte_size",
+        "meta": {
+            "description": "Threshold for 'require_bundle_changes'. Notifications will only be triggered if the change is larger than the threshold."
+        },
     },
 }
 

--- a/shared/validation/validator.py
+++ b/shared/validation/validator.py
@@ -2,6 +2,7 @@ from cerberus import Validator
 
 from shared.validation.helpers import (
     BranchSchemaField,
+    ByteSizeSchemaField,
     CoverageCommentRequirementSchemaField,
     CoverageRangeSchemaField,
     CustomFixPathSchemaField,
@@ -40,6 +41,9 @@ class CodecovYamlValidator(Validator):
 
     def _normalize_coerce_coverage_comment_required_changes(self, value):
         return CoverageCommentRequirementSchemaField().validate(value)
+
+    def _normalize_coerce_byte_size(self, value):
+        return ByteSizeSchemaField().validate(value)
 
     def _validate_comma_separated_strings(self, constraint, field, value):
         """Test the oddity of a value.

--- a/tests/unit/validation/test_validation.py
+++ b/tests/unit/validation/test_validation.py
@@ -822,6 +822,50 @@ class TestUserYamlValidation(BaseTestCase):
         result = validate_yaml(user_input)
         assert result == expected_result
 
+    @pytest.mark.parametrize(
+        "input, expected",
+        [
+            pytest.param(
+                {"comment": {"require_bundle_changes": False}},
+                {"comment": {"require_bundle_changes": False}},
+                id="no_bundle_changes_required",
+            ),
+            pytest.param(
+                {
+                    "comment": {
+                        "require_bundle_changes": True,
+                        "bundle_change_threshold": 1200,
+                    }
+                },
+                {
+                    "comment": {
+                        "require_bundle_changes": True,
+                        "bundle_change_threshold": 1200,
+                    }
+                },
+                id="bundle_changes_with_threshold",
+            ),
+            pytest.param(
+                {
+                    "comment": {
+                        "require_bundle_changes": "bundle_increase",
+                        "bundle_change_threshold": "1mb",
+                    }
+                },
+                {
+                    "comment": {
+                        "require_bundle_changes": "bundle_increase",
+                        "bundle_change_threshold": 1000000,
+                    }
+                },
+                id="bundle_increase_required_with_threshold",
+            ),
+        ],
+    )
+    def test_bundle_analysis_comment_config(self, input, expected):
+        result = validate_yaml(input)
+        assert result == expected
+
 
 class TestValidationConfig(object):
     def test_validate_default_config_yaml(self, mocker):
@@ -857,13 +901,6 @@ class TestValidationConfig(object):
             show_secrets_for=("github", "11934774", "154468867"),
         )
         assert res == expected_result
-
-
-@pytest.mark.parametrize(
-    "input,expected", [pytest.param("10bytes", True, id="bytes_valid")]
-)
-def test_bundle_change_threshold_regex(input, expected):
-    pass
 
 
 def test_validation_with_branches():


### PR DESCRIPTION
These changes improve documentation (and add unit tests) to `comment.require_bundle_changes`
and adds a new config key `bundle_change_threshold`.

The new key is a threshold size for the bundle in bytes. The input value
is preferably a string that accepts certain size extensions (kb, mb, gb, ...) and is
coerced into a size in bytes (as an integer)

closes: https://github.com/codecov/engineering-team/issues/2018

<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.