### PR TITLE
add wait_for_ci to default site config

### DIFF
--- a/shared/config/__init__.py
+++ b/shared/config/__init__.py
@@ -20,7 +20,7 @@ class MissingConfigException(Exception):
 log = logging.getLogger(__name__)
 
 LEGACY_DEFAULT_SITE_CONFIG = {
-    "codecov": {"require_ci_to_pass": True},
+    "codecov": {"require_ci_to_pass": True, "notify": {"wait_for_ci": True}},
     "coverage": {
         "precision": 2,
         "round": "down",

--- a/tests/unit/validation/test_validation.py
+++ b/tests/unit/validation/test_validation.py
@@ -832,7 +832,7 @@ class TestValidationConfig(object):
         this_config = ConfigHelper()
         mocker.patch("shared.config._get_config_instance", return_value=this_config)
         expected_result = {
-            "codecov": {"require_ci_to_pass": True},
+            "codecov": {"require_ci_to_pass": True, "notify": {"wait_for_ci": True}},
             "coverage": {
                 "precision": 2,
                 "round": "down",

--- a/tests/unit/yaml/test_user_yaml.py
+++ b/tests/unit/yaml/test_user_yaml.py
@@ -381,7 +381,7 @@ class TestUserYaml(object):
             ),
         )
         assert legacy_default.to_dict() == {
-            "codecov": {"require_ci_to_pass": True},
+            "codecov": {"require_ci_to_pass": True, "notify": {"wait_for_ci": True}},
             "coverage": {
                 "precision": 2,
                 "round": "down",
@@ -410,7 +410,7 @@ class TestUserYaml(object):
             ),
         )
         assert patch_centric_default.to_dict() == {
-            "codecov": {"require_ci_to_pass": True},
+            "codecov": {"require_ci_to_pass": True, "notify": {"wait_for_ci": True}},
             "coverage": {
                 "precision": 2,
                 "round": "down",


### PR DESCRIPTION
<!-- Describe your PR here. -->
We tripped over this once already (fix [here](https://github.com/codecov/worker/pull/533)) - if we add it here it could save us from making the same mistake in the future.

This config is in our docs as defaulting to `True` so I don't see an issue with explicitly declaring it in the default configs.