### PR TITLE
Sync Account Users when Activating/Deactivating Users

### DIFF
--- a/shared/torngit/gitlab.py
+++ b/shared/torngit/gitlab.py
@@ -370,6 +370,10 @@ GITLAB_API_ENDPOINTS = {
 external_endpoint_template = Template("${username}/${name}/commit/${commitid}")
 
 
+class OwnerNotFoundError:
+    pass
+
+
 class Gitlab(TorngitBaseAdapter):
     service = "gitlab"
     service_url = "https://gitlab.com"
@@ -701,7 +705,7 @@ class Gitlab(TorngitBaseAdapter):
                 "/", ":"
             )  # full path required for subgroup support
         else:
-            raise
+            raise OwnerNotFoundError()
 
         return (service_id, username)
 

--- a/tests/unit/django_apps/codecov_auth/test_codecov_auth_models.py
+++ b/tests/unit/django_apps/codecov_auth/test_codecov_auth_models.py
@@ -292,6 +292,19 @@ class TestOwnerModel(TransactionTestCase):
         self.owner.refresh_from_db()
         assert self.owner.plan_activated_users == [to_activate.ownerid]
 
+    def test_activate_user_updates_account_user(self):
+        to_activate = OwnerFactory()
+        account = AccountFactory()
+        self.owner.account = account
+        self.owner.save()
+
+        self.owner.activate_user(to_activate)
+        self.owner.refresh_from_db()
+
+        assert to_activate.ownerid in self.owner.plan_activated_users
+        user = to_activate.user
+        assert AccountsUsers.objects.filter(user=user, account=account).first()
+
     def test_deactivate_removes_ownerid_from_plan_activated_users(self):
         to_deactivate = OwnerFactory()
         self.owner.plan_activated_users = [3, 4, to_deactivate.ownerid]
@@ -305,6 +318,19 @@ class TestOwnerModel(TransactionTestCase):
         self.owner.plan_activated_users = []
         self.owner.save()
         self.owner.deactivate_user(to_deactivate)
+
+    def test_deactivate_user_updates_account_user(self):
+        to_deactivate = OwnerFactory()
+        self.owner.account = AccountFactory()
+        self.owner.user = UserFactory()
+        self.owner.save()
+        AccountsUsers(user=self.owner.user, account=self.owner.account).save()
+
+        self.owner.deactivate_user(to_deactivate)
+        self.owner.refresh_from_db()
+
+        assert AccountsUsers.objects.filter(user=self.owner.user, account=self.owner.account).first() is None
+
 
     def test_can_activate_user_returns_true_if_user_is_student(self):
         student = OwnerFactory(student=True)
@@ -836,3 +862,116 @@ class TestAccountModel(TransactionTestCase):
         )
         self.assertFalse(enterprise_account.stripe_billing.first().is_active)
         self.assertTrue(enterprise_account.invoice_billing.first().is_active)
+
+    def test_activate_user_onto_account(self):
+        user = UserFactory()
+        user.save()
+        account = AccountFactory()
+        account.save()
+
+        assert AccountsUsers.objects.filter(user=user, account=account).first() is None
+        account.activate_user_onto_account(user)
+        account.refresh_from_db()
+
+        assert AccountsUsers.objects.filter(user=user, account=account).first()
+
+    def test_activate_owner_user_onto_account_create_user(self):
+        owner = OwnerFactory()
+        account = AccountFactory()
+        account.save()
+
+        account.activate_owner_user_onto_account(owner)
+        account.refresh_from_db()
+
+        new_user = User.objects.get(id=owner.user_id)
+        assert AccountsUsers.objects.filter(user=new_user, account=account).first()
+
+    def test_activate_owner_user_onto_account_with_user(self):
+        owner = OwnerFactory()
+        user = UserFactory()
+        owner.user = user
+        account = AccountFactory()
+        account.save()
+
+        account.activate_owner_user_onto_account(owner)
+        account.refresh_from_db()
+
+        assert AccountsUsers.objects.filter(user=user, account=account).first()
+
+    def test_activate_owner_user_onto_account_existing_account_user(self):
+        owner = OwnerFactory()
+        user = UserFactory()
+        owner.user = user
+        account = AccountFactory()
+        account.save()
+
+        account.activate_owner_user_onto_account(owner)
+        account.refresh_from_db()
+
+        assert AccountsUsers.objects.filter(user=user, account=account).first()
+
+        account.activate_owner_user_onto_account(owner)
+        account.refresh_from_db()
+
+        assert AccountsUsers.objects.filter(user=user, account=account).first()
+
+    def test_deactivate_owner_user_from_account_remove_user(self):
+        # Set up User to be associated with an Org under an account
+        owner = OwnerFactory()
+        user = UserFactory()
+        owner.user = user
+        org = OwnerFactory(
+            plan=PlanName.CODECOV_PRO_YEARLY.value,
+            plan_activated_users=[owner.ownerid],
+        )
+        account = AccountFactory()
+        org.account = account
+        org.save()
+        account.users.add(user)
+        account.save()
+
+        # ensure that there exists an account user relationship before deactivating
+        assert AccountsUsers.objects.filter(user=user, account=account).first()
+
+        org.plan_activated_users = []
+        org.save()
+        account.deactivate_owner_user_from_account(owner)
+
+        assert AccountsUsers.objects.filter(user=user, account=account).first() is None
+
+    def test_deactivate_owner_user_from_account_do_not_remove_user(self):
+        # Set up User to be associated with an Org under an account
+        owner = OwnerFactory()
+        user = UserFactory()
+        owner.user = user
+        org1 = OwnerFactory(
+            plan=PlanName.CODECOV_PRO_YEARLY.value,
+            plan_activated_users=[owner.ownerid],
+        )
+        org2 = OwnerFactory(
+            plan=PlanName.CODECOV_PRO_YEARLY.value,
+            plan_activated_users=[owner.ownerid],
+        )
+        account = AccountFactory()
+        org1.account = account
+        org1.save()
+        org2.account = account
+        org2.save()
+        account.users.add(user)
+        account.save()
+
+        # ensure that there exists an account user relationship before deactivating
+        assert AccountsUsers.objects.filter(user=user, account=account).first()
+
+        # Only deactivate user for org1, org2 still has a reference to the user
+        org1.plan_activated_users = []
+        org1.save()
+        account.deactivate_owner_user_from_account(owner)
+
+        assert AccountsUsers.objects.filter(user=user, account=account).first()
+
+    def test_deactivate_owner_user_no_user_do_nothing(self):
+        owner_user = OwnerFactory()
+        account = AccountFactory()
+        account.save()
+        assert account.deactivate_owner_user_from_account(owner_user) is None


### PR DESCRIPTION
This adds the feature to add and remove users from an account if the organization that is connected to the account is activating and deactivating users. We want to make sure that users who are deactivated are only removed when they are not associated with _any_ other organization that the account is associated with.

ref: https://github.com/codecov/engineering-team/issues/1993

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.