### PR TITLE
Checks for Adding User to Account

### DIFF
--- a/shared/celery_config.py
+++ b/shared/celery_config.py
@@ -18,6 +18,9 @@ sync_repo_languages_gql_task_name = (
     f"app.tasks.{TaskConfigGroup.sync_repo_languages_gql.value}.SyncLanguagesGQL"
 )
 delete_owner_task_name = f"app.tasks.{TaskConfigGroup.delete_owner.value}.DeleteOwner"
+activate_account_user_task_name = (
+    f"app.tasks.{TaskConfigGroup.sync_account.value}.ActivateAccountUser"
+)
 notify_task_name = f"app.tasks.{TaskConfigGroup.notify.value}.Notify"
 pulls_task_name = f"app.tasks.{TaskConfigGroup.pulls.value}.Sync"
 status_set_error_task_name = f"app.tasks.{TaskConfigGroup.status.value}.SetError"
@@ -276,6 +279,15 @@ class BaseCeleryConfig(object):
                 "setup",
                 "tasks",
                 TaskConfigGroup.delete_owner.value,
+                "queue",
+                default=task_default_queue,
+            )
+        },
+        activate_account_user_task_name: {
+            "queue": get_config(
+                "setup",
+                "tasks",
+                TaskConfigGroup.sync_account.value,
                 "queue",
                 default=task_default_queue,
             )

--- a/shared/django_apps/codecov_auth/tests/factories.py
+++ b/shared/django_apps/codecov_auth/tests/factories.py
@@ -58,6 +58,7 @@ class OwnerFactory(DjangoModelFactory):
     oauth_token = factory.LazyAttribute(
         lambda o: encryptor.encode(o.unencrypted_oauth_token).decode()
     )
+    student = False
     user = factory.SubFactory(UserFactory)
     trial_status = TrialStatus.NOT_STARTED.value
 

--- a/shared/utils/enums.py
+++ b/shared/utils/enums.py
@@ -38,6 +38,7 @@ class TaskConfigGroup(Enum):
     send_email = "send_email"
     static_analysis = "static_analysis"
     status = "status"
+    sync_account = "sync_account"
     sync_plans = "sync_plans"
     sync_repos = "sync_repos"
     sync_teams = "sync_teams"

--- a/tests/unit/test_celery_config.py
+++ b/tests/unit/test_celery_config.py
@@ -42,6 +42,7 @@ def test_celery_config():
         "app.tasks.remove_webhook.RemoveOldHook",
         "app.tasks.static_analysis.*",
         "app.tasks.status.*",
+        "app.tasks.sync_account.ActivateAccountUser",
         "app.tasks.sync_plans.SyncPlans",
         "app.tasks.sync_repo_languages.SyncLanguages",
         "app.tasks.sync_repo_languages_gql.SyncLanguagesGQL",


### PR DESCRIPTION
* Adds some methods to check that a user can be added to an account. It replicates the logic in owners. 
* Adds task boilerplate for the activate account user task

This PR blocks: https://github.com/codecov/worker/pull/556
ticket ref: https://github.com/codecov/engineering-team/issues/1993

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.