### PR TITLE
dev: Unused import rule ruff

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -39,7 +39,7 @@ target-version = "py312"
 # Currently only enabled for F (Pyflakes), I (isort), E,W (pycodestyle:Error/Warning), PLC/PLE/PLW (Pylint:Convention/Error/Warning) 
 # and PERF (Perflint) rules: https://docs.astral.sh/ruff/rules/
 select = ["F", "I", "E", "W", "PLC", "PLE", "PLW", "PERF"]
-ignore = ["F401", "F403", "F405", "E501", "E712"]
+ignore = ["F403", "F405", "E501", "E712"]
 
 # Allow fix for all enabled rules (when `--fix`) is provided.
 # The preferred method (for now) w.r.t. fixable rules is to manually update the makefile

--- a/shared/utils/test_utils/__init__.py
+++ b/shared/utils/test_utils/__init__.py
@@ -1,2 +1,7 @@
 from .mock_config_helper import mock_config_helper
 from .mock_metrics import mock_metrics
+
+__all__ = [
+    "mock_metrics",
+    "mock_config_helper",
+]

--- a/tests/integration/test_bitbucket.py
+++ b/tests/integration/test_bitbucket.py
@@ -1,6 +1,3 @@
-import json
-from unittest.mock import patch
-
 import pytest
 import vcr
 

--- a/tests/integration/test_bitbucket_server.py
+++ b/tests/integration/test_bitbucket_server.py
@@ -1,5 +1,4 @@
-from asyncio import Future
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 import pytest
 

--- a/tests/unit/bundle_analysis/test_asset_association.py
+++ b/tests/unit/bundle_analysis/test_asset_association.py
@@ -1,13 +1,8 @@
 from pathlib import Path
 from typing import Dict
-from unittest.mock import patch
 
-import pytest
-
-from shared.bundle_analysis import BundleAnalysisReport, BundleAnalysisReportLoader
-from shared.bundle_analysis.models import Asset, AssetType, MetadataKey
-from shared.storage.exceptions import PutRequestRateLimitError
-from shared.storage.memory import MemoryStorageService
+from shared.bundle_analysis import BundleAnalysisReport
+from shared.bundle_analysis.models import Asset, AssetType
 
 bundle_stats_prev_a_path = (
     Path(__file__).parent.parent.parent / "samples" / "asset_link_prev_a.json"

--- a/tests/unit/bundle_analysis/test_bundle_comparison.py
+++ b/tests/unit/bundle_analysis/test_bundle_comparison.py
@@ -12,7 +12,7 @@ from shared.bundle_analysis import (
     MissingBundleError,
     MissingHeadReportError,
 )
-from shared.bundle_analysis.models import Bundle, Session
+from shared.bundle_analysis.models import Bundle
 from shared.storage.memory import MemoryStorageService
 
 here = Path(__file__)

--- a/tests/unit/django_apps/test_db_routers.py
+++ b/tests/unit/django_apps/test_db_routers.py
@@ -1,5 +1,3 @@
-from unittest.mock import patch
-
 from django.test import override_settings
 
 from shared.django_apps.codecov_auth.models import Owner

--- a/tests/unit/github/test_github_installation_helpers.py
+++ b/tests/unit/github/test_github_installation_helpers.py
@@ -5,7 +5,6 @@ import pytest
 from freezegun import freeze_time
 
 # This import here avoids a circular import issue
-import shared.torngit
 from shared.github import get_github_jwt_token, get_pem
 from shared.utils.test_utils import mock_config_helper
 

--- a/tests/unit/helpers/test_cache.py
+++ b/tests/unit/helpers/test_cache.py
@@ -1,5 +1,3 @@
-import pickle
-
 import pytest
 from redis.exceptions import TimeoutError
 

--- a/tests/unit/reports/test_types.py
+++ b/tests/unit/reports/test_types.py
@@ -1,5 +1,4 @@
 from copy import deepcopy
-from dataclasses import astuple
 from decimal import Decimal
 
 from shared.reports.types import (

--- a/tests/unit/storage/test_minio.py
+++ b/tests/unit/storage/test_minio.py
@@ -4,7 +4,7 @@ import tempfile
 import pytest
 
 from shared.storage.exceptions import BucketAlreadyExistsError, FileNotInStorageError
-from shared.storage.minio import Minio, MinioStorageService
+from shared.storage.minio import MinioStorageService
 from tests.base import BaseTestCase
 
 minio_config = {

--- a/tests/unit/test_report.py
+++ b/tests/unit/test_report.py
@@ -5,7 +5,6 @@ from shared.reports.editable import EditableReport, EditableReportFile
 from shared.reports.exceptions import LabelIndexNotFoundError, LabelNotFoundError
 from shared.reports.resources import (
     END_OF_CHUNK,
-    END_OF_HEADER,
     Report,
     ReportFile,
     _encode_chunk,

--- a/tests/unit/test_report_file.py
+++ b/tests/unit/test_report_file.py
@@ -1,5 +1,4 @@
 import pytest
-from mock import PropertyMock
 
 from shared.reports.resources import ReportFile, _ignore_to_func
 from shared.reports.types import ReportLine, ReportTotals

--- a/tests/unit/torngit/test_exceptions.py
+++ b/tests/unit/torngit/test_exceptions.py
@@ -1,7 +1,6 @@
 import pickle
 
 from shared.torngit.exceptions import (
-    TorngitClientError,
     TorngitClientGeneralError,
     TorngitObjectNotFoundError,
     TorngitRateLimitError,

--- a/tests/unit/validation/test_helpers.py
+++ b/tests/unit/validation/test_helpers.py
@@ -15,7 +15,6 @@ from shared.validation.helpers import (
     determine_path_pattern_type,
     translate_glob_to_regex,
 )
-from shared.validation.types import CoverageCommentRequiredChanges
 from shared.yaml.validation import pre_process_yaml
 from tests.base import BaseTestCase
 

--- a/tests/unit/validation/test_install_validation.py
+++ b/tests/unit/validation/test_install_validation.py
@@ -1,6 +1,5 @@
 from shared.validation.install import log as install_log
 from shared.validation.install import validate_install_configuration
-from shared.validation.types import CoverageCommentRequiredChanges
 from shared.yaml.validation import UserGivenSecret
 
 

--- a/tests/unit/validation/test_validation.py
+++ b/tests/unit/validation/test_validation.py
@@ -4,7 +4,6 @@ import pytest
 
 from shared.config import ConfigHelper, get_config
 from shared.validation.exceptions import InvalidYamlException
-from shared.validation.types import CoverageCommentRequiredChanges
 from shared.yaml.validation import (
     _calculate_error_location_and_message_from_error_dict,
     do_actual_validation,


### PR DESCRIPTION
Forgot to turn back on the unused import rule for Ruff on shared. This does that and fixes any errors


<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.