### PR TITLE
feat: bundle threshold coercion

### DIFF
--- a/shared/validation/helpers.py
+++ b/shared/validation/helpers.py
@@ -7,6 +7,7 @@ from typing import Any, List
 import pyparsing as pp
 
 from shared.validation.types import (
+    BundleThreshold,
     CoverageCommentRequiredChanges,
     CoverageCommentRequiredChangesANDGroup,
     CoverageCommentRequiredChangesORGroup,
@@ -204,6 +205,33 @@ class PercentSchemaField(object):
             return float(value)
         except ValueError:
             raise Invalid(f"{value} should be a number")
+
+
+class BundleSizeThresholdSchemaField(object):
+    """
+    A field for bundle analysis threshold.
+    It can be either a ByteSizeSchemaField or PercentSchemaField.
+    ⚠️ integers are considered ByteSize ⚠️
+    ⚠️ floats are considered Percent ⚠️
+
+    Examples:
+      "10 mb" -> ("absolute", 1000000)
+      "100%" -> ("percentage", 100.0)
+      100 -> ("absolute", 100)
+      0.5 -> ("percentage", 50.0)
+    """
+
+    def validate(self, value: Any) -> BundleThreshold:
+        byte_size_schema = ByteSizeSchemaField()
+        percentage_schema = PercentSchemaField()
+        if isinstance(value, numbers.Integral):
+            value: int = byte_size_schema.validate(value)
+            return BundleThreshold("absolute", value)
+        if isinstance(value, numbers.Real) or isinstance(value, str) and "%" in value:
+            value: float = percentage_schema.validate(value, allow_auto=False)
+            return BundleThreshold("percentage", value)
+        value: int = byte_size_schema.validate(value)
+        return BundleThreshold("absolute", value)
 
 
 def determine_path_pattern_type(filepath_pattern):

--- a/shared/validation/helpers.py
+++ b/shared/validation/helpers.py
@@ -151,7 +151,7 @@ class CoverageCommentRequirementSchemaField(object):
 class ByteSizeSchemaField(object):
     """Converts a possible string with byte extension size into integer with number of bytes.
     Acceptable extensions are 'mb', 'kb', 'gb', 'b' and 'bytes' (case insensitive).
-    Also accepts integers, returning the value itself as the number of bytes.
+    Also accepts positive integers, returning the value itself as the number of bytes.
 
     Example:
         100 -> 100
@@ -174,6 +174,8 @@ class ByteSizeSchemaField(object):
 
     def validate(self, data: Any) -> int:
         if isinstance(data, int):
+            if data < 0:
+                raise Invalid("Only positive values accepted")
             return data
         if isinstance(data, str):
             return self._validate_str(data)

--- a/shared/validation/types.py
+++ b/shared/validation/types.py
@@ -1,5 +1,10 @@
 from enum import Enum
-from typing import List, Literal
+from typing import List, Literal, NamedTuple
+
+
+class BundleThreshold(NamedTuple):
+    type: Literal["absolute"] | Literal["percentage"]
+    threshold: int | float
 
 
 class CoverageCommentRequiredChanges(Enum):

--- a/tests/unit/validation/test_helpers.py
+++ b/tests/unit/validation/test_helpers.py
@@ -3,6 +3,7 @@ import re
 import pytest
 
 from shared.validation.helpers import (
+    BundleSizeThresholdSchemaField,
     ByteSizeSchemaField,
     CoverageCommentRequirementSchemaField,
     CoverageRangeSchemaField,
@@ -545,6 +546,64 @@ class TestByteSizeSchemaField(object):
     )
     def test_byte_size_coercion_fail(self, input, error_message):
         validator = ByteSizeSchemaField()
+        with pytest.raises(Invalid) as exp:
+            validator.validate(input)
+        assert exp.value.error_message == error_message
+
+
+class TestBundleSizeThresholdSchemaField(object):
+    @pytest.mark.parametrize(
+        "input, expected",
+        [
+            (100, ("absolute", 100)),
+            ("100b", ("absolute", 100)),
+            ("100 mb", ("absolute", 100000000)),
+            ("12KB", ("absolute", 12000)),
+            ("12%", ("percentage", 12.0)),
+            ("65%", ("percentage", 65.0)),
+            ("100%", ("percentage", 100.0)),
+            (5.5, ("percentage", 5.5)),
+            (60, ("absolute", 60)),
+            (60.0, ("percentage", 60.0)),
+        ],
+    )
+    def test_byte_size_coercion_success(self, input, expected):
+        validator = BundleSizeThresholdSchemaField()
+        assert validator.validate(input) == expected
+
+    @pytest.mark.parametrize(
+        "input, error_message",
+        [
+            pytest.param(
+                None, "Value should be int or str. Received NoneType", id="None_input"
+            ),
+            pytest.param(
+                [], "Value should be int or str. Received list", id="list_input"
+            ),
+            pytest.param(
+                "200",
+                "Value doesn't match expected regex. Acceptable extensions are mb, kb, gb, b or bytes",
+                id="no_extension",
+            ),
+            pytest.param(
+                "kb",
+                "Value doesn't match expected regex. Acceptable extensions are mb, kb, gb, b or bytes",
+                id="absolute_no_number",
+            ),
+            pytest.param(
+                "%",
+                "% should be a number",
+                id="percentage_no_number",
+            ),
+            pytest.param(
+                "100mb%",
+                "100mb should be a number",
+                id="percentage_and_absolute",
+            ),
+        ],
+    )
+    def test_byte_size_coercion_fail(self, input, error_message):
+        validator = BundleSizeThresholdSchemaField()
         with pytest.raises(Invalid) as exp:
             validator.validate(input)
         assert exp.value.error_message == error_message

--- a/tests/unit/validation/test_helpers.py
+++ b/tests/unit/validation/test_helpers.py
@@ -542,6 +542,16 @@ class TestByteSizeSchemaField(object):
                 "Value doesn't match expected regex. Acceptable extensions are mb, kb, gb, b or bytes",
                 id="invalid_extension",
             ),
+            pytest.param(
+                -200,
+                "Only positive values accepted",
+                id="negative_number",
+            ),
+            pytest.param(
+                "-200kb",
+                "Value doesn't match expected regex. Acceptable extensions are mb, kb, gb, b or bytes",
+                id="negative_number_with_extension",
+            ),
         ],
     )
     def test_byte_size_coercion_fail(self, input, error_message):
@@ -562,6 +572,7 @@ class TestBundleSizeThresholdSchemaField(object):
             ("12%", ("percentage", 12.0)),
             ("65%", ("percentage", 65.0)),
             ("100%", ("percentage", 100.0)),
+            ("200%", ("percentage", 200.0)),
             (5.5, ("percentage", 5.5)),
             (60, ("absolute", 60)),
             (60.0, ("percentage", 60.0)),
@@ -584,6 +595,11 @@ class TestBundleSizeThresholdSchemaField(object):
                 "200",
                 "Value doesn't match expected regex. Acceptable extensions are mb, kb, gb, b or bytes",
                 id="no_extension",
+            ),
+            pytest.param(
+                "-200%",
+                "-200% should be a number",
+                id="negative_percentage",
             ),
             pytest.param(
                 "kb",


### PR DESCRIPTION
ticket: https://github.com/codecov/engineering-team/issues/2004

The bundle threshold needs to also accept percentages.
To do that we are going to re-use the percentage schema field and the
byte size schema field, and just have a wrapper around them.

A new return type has been created to make the difference between
absolute and percentage values more explicit (although technically
the values are different - float vs int - it will be easier to distinguish
if we have the type explicitly
