### PR TITLE
feat: bundle status config

### DIFF
--- a/shared/rollouts/features.py
+++ b/shared/rollouts/features.py
@@ -1,3 +1,5 @@
 from . import Feature
 
 LIST_REPOS_PAGE_SIZE = Feature("list_repos_page_size")
+
+BUNDLE_THRESHOLD_FLAG = Feature("bundle_threshold_flag")

--- a/shared/validation/user_schema.py
+++ b/shared/validation/user_schema.py
@@ -212,9 +212,9 @@ bundle_analysis_comment_config = {
         },
     },
     "bundle_change_threshold": {
-        "coerce": "byte_size",
+        "coerce": "bundle_analysis_threshold",
         "meta": {
-            "description": "Threshold for 'require_bundle_changes'. Notifications will only be triggered if the change is larger than the threshold."
+            "description": "Threshold for 'require_bundle_changes'. Notifications will only be triggered if the change is larger than the threshold. Can also be configured using bundle_analysis.bundle_change_threshold"
         },
     },
 }
@@ -416,6 +416,35 @@ schema = {
                     "no_upload_behavior": {
                         "type": "string",
                         "allowed": ("pass", "fail"),
+                    },
+                },
+            },
+        },
+    },
+    "bundle_analysis": {
+        "type": "dict",
+        "schema": {
+            "bundle_change_threshold": {
+                "coerce": "bundle_analysis_threshold",
+                "meta": {
+                    "description": "Notifications will only be triggered if the change is larger than the threshold."
+                },
+            },
+            "status": {
+                "allowed": (True, False, "informational"),
+                "meta": {
+                    "description": "Configure commit checks for bundle analysis",
+                    "options": {
+                        True: {
+                            "type": bool,
+                            "description": "Enable status. Status can fail.",
+                        },
+                        False: {"type": bool, "description": "Disable status."},
+                        "informational": {
+                            "type": str,
+                            "description": "Enable status. Status will always be success.",
+                            "default": True,
+                        },
                     },
                 },
             },


### PR DESCRIPTION
extends the user_schema config with the bundle_status entries.

It requires a feature flag not for any experiment, but to gate the release
of the coercion in bundle_threshold. The change is not forwards compatible,
so in the middle of deploying it's possible that old deploys would break
if the yaml was parsed by new deploys.
After a full rollout the value can be turned to True and the feature flag removed.

closes https://github.com/codecov/shared/pull/287