### PR TITLE
bundle analysis: change parsed bundle to not cached

### DIFF
--- a/shared/bundle_analysis/parsers/v1.py
+++ b/shared/bundle_analysis/parsers/v1.py
@@ -213,6 +213,9 @@ class ParserV1:
             if bundle is None:
                 bundle = Bundle(name=value)
                 self.db_session.add(bundle)
+            else:
+                print("Flipping Bundle is_cached")
+                bundle.is_cached = False
             self.session.bundle = bundle
 
     def _parse_assets_event(self, prefix: str, event: str, value: str):

--- a/shared/bundle_analysis/parsers/v1.py
+++ b/shared/bundle_analysis/parsers/v1.py
@@ -213,9 +213,7 @@ class ParserV1:
             if bundle is None:
                 bundle = Bundle(name=value)
                 self.db_session.add(bundle)
-            else:
-                print("Flipping Bundle is_cached")
-                bundle.is_cached = False
+            bundle.is_cached = False
             self.session.bundle = bundle
 
     def _parse_assets_event(self, prefix: str, event: str, value: str):

--- a/shared/bundle_analysis/parsers/v2.py
+++ b/shared/bundle_analysis/parsers/v2.py
@@ -214,6 +214,9 @@ class ParserV2:
             if bundle is None:
                 bundle = Bundle(name=value)
                 self.db_session.add(bundle)
+            else:
+                print("Flipping Bundle is_cached")
+                bundle.is_cached = False
             self.session.bundle = bundle
 
     def _parse_assets_event(self, prefix: str, event: str, value: str):

--- a/shared/bundle_analysis/parsers/v2.py
+++ b/shared/bundle_analysis/parsers/v2.py
@@ -214,9 +214,7 @@ class ParserV2:
             if bundle is None:
                 bundle = Bundle(name=value)
                 self.db_session.add(bundle)
-            else:
-                print("Flipping Bundle is_cached")
-                bundle.is_cached = False
+            bundle.is_cached = False
             self.session.bundle = bundle
 
     def _parse_assets_event(self, prefix: str, event: str, value: str):

--- a/shared/bundle_analysis/report.py
+++ b/shared/bundle_analysis/report.py
@@ -301,7 +301,7 @@ class BundleAnalysisReport:
 
     def associate_previous_assets(
         self, prev_bundle_analysis_report: Any
-    ) -> "BundleAnalysisReport":
+    ) -> None:
         """
         Only associate past asset if it is Javascript or Typescript types
         and belonging to the same bundle name

--- a/shared/bundle_analysis/report.py
+++ b/shared/bundle_analysis/report.py
@@ -299,9 +299,7 @@ class BundleAnalysisReport:
                     )
         return ret
 
-    def associate_previous_assets(
-        self, prev_bundle_analysis_report: Any
-    ) -> None:
+    def associate_previous_assets(self, prev_bundle_analysis_report: Any) -> None:
         """
         Only associate past asset if it is Javascript or Typescript types
         and belonging to the same bundle name


### PR DESCRIPTION
Now that we have a field identifying whether a bundle is cached or not we need to set the value to false when processing a new upload.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.