### PR TITLE
[FIx] Update is admin API call for bitbucket

### DIFF
--- a/shared/torngit/bitbucket.py
+++ b/shared/torngit/bitbucket.py
@@ -212,21 +212,17 @@ class Bitbucket(TorngitBaseAdapter):
 
     async def get_is_admin(self, user, token=None):
         user_uuid = "{" + user["service_id"] + "}"
-        query = f'workspace.uuid="{{{self.data["owner"]["service_id"]}}}" AND permission="owner" AND user.uuid="{user_uuid}"'
+        workspace_uuid = f'{{{self.data["owner"]["service_id"]}}}'
         async with self.get_client() as client:
             groups = await self.api(
-                client, "2", "get", "/user/permissions/workspaces", token=token, q=query
+                client, "2", "get", "/user/permissions/workspaces", token=token
             )
         if groups["values"]:
             for group in groups["values"]:
-                assert group["permission"] == "owner"
-                assert (
-                    group["workspace"]["uuid"]
-                    == f'{{{self.data["owner"]["service_id"]}}}'
-                )
-                assert group["user"]["uuid"] == user_uuid
-                return True
+                if group["permission"] == "owner" and group["workspace"]["uuid"] == workspace_uuid and group["user"]["uuid"] == user_uuid:
+                    return True
         return False
+
 
     async def list_teams(self, token=None):
         teams, page = [], None

--- a/shared/torngit/bitbucket.py
+++ b/shared/torngit/bitbucket.py
@@ -219,10 +219,13 @@ class Bitbucket(TorngitBaseAdapter):
             )
         if groups["values"]:
             for group in groups["values"]:
-                if group["permission"] == "owner" and group["workspace"]["uuid"] == workspace_uuid and group["user"]["uuid"] == user_uuid:
+                if (
+                    group["permission"] == "owner"
+                    and group["workspace"]["uuid"] == workspace_uuid
+                    and group["user"]["uuid"] == user_uuid
+                ):
                     return True
         return False
-
 
     async def list_teams(self, token=None):
         teams, page = [], None

--- a/shared/torngit/bitbucket.py
+++ b/shared/torngit/bitbucket.py
@@ -217,8 +217,6 @@ class Bitbucket(TorngitBaseAdapter):
             groups = await self.api(
                 client, "2", "get", "/user/permissions/workspaces", token=token
             )
-        print("ASJJJAS")
-        print(groups)
         if groups["values"]:
             for group in groups["values"]:
                 if (

--- a/shared/torngit/bitbucket.py
+++ b/shared/torngit/bitbucket.py
@@ -212,7 +212,7 @@ class Bitbucket(TorngitBaseAdapter):
 
     async def get_is_admin(self, user, token=None):
         user_uuid = "{" + user["service_id"] + "}"
-        workspace_uuid = f'{{{self.data["owner"]["service_id"]}}}'
+        workspace_uuid = "{" + self.data["owner"]["service_id"] + "}"
         async with self.get_client() as client:
             groups = await self.api(
                 client, "2", "get", "/user/permissions/workspaces", token=token

--- a/shared/torngit/bitbucket.py
+++ b/shared/torngit/bitbucket.py
@@ -217,6 +217,8 @@ class Bitbucket(TorngitBaseAdapter):
             groups = await self.api(
                 client, "2", "get", "/user/permissions/workspaces", token=token
             )
+        print("ASJJJAS")
+        print(groups)
         if groups["values"]:
             for group in groups["values"]:
                 if (

--- a/tests/integration/cassetes/test_bitbucket/TestBitbucketTestCase/test_get_is_admin.yaml
+++ b/tests/integration/cassetes/test_bitbucket/TestBitbucketTestCase/test_get_is_admin.yaml
@@ -13,7 +13,7 @@ interactions:
       user-agent:
       - Default
     method: GET
-    uri: https://bitbucket.org/api/2.0/user/permissions/workspaces?q=workspace.uuid%3D%22%7B727d78e8-7431-4532-9519-1e5fe2b61d4b%7D%22+AND+permission%3D%22owner%22+AND+user.uuid%3D%22%7B9a01f37b-b1b2-40c5-8c5e-1a39f4b5e645%7D%22&oauth_consumer_key=arubajamaicaohiwan&oauth_token=testss3hxhcfqf1h6g&oauth_signature_method=HMAC-SHA1&oauth_timestamp=1617378487&oauth_nonce=fe94e338b0294054a6973e26fba8b158&oauth_version=1.0&oauth_signature=fuzvRwiZHcRKdYQdU2yvGg9jhnw%3D
+    uri: https://bitbucket.org/api/2.0/user/permissions/workspaces?oauth_consumer_key=arubajamaicaohiwan&oauth_token=testss3hxhcfqf1h6g&oauth_signature_method=HMAC-SHA1&oauth_timestamp=1617378487&oauth_nonce=fe94e338b0294054a6973e26fba8b158&oauth_version=1.0&oauth_signature=fuzvRwiZHcRKdYQdU2yvGg9jhnw%3D
   response:
     content: '{"pagelen": 50, "values": [{"links": {"self": {"href": "https://bitbucket.org/!api/2.0/workspaces/thiagorramosworkspace/members/%7B9a01f37b-b1b2-40c5-8c5e-1a39f4b5e645%7D"}},
       "permission": "owner", "last_accessed": null, "user": {"display_name": "Thiago

--- a/tests/integration/cassetes/test_bitbucket/TestBitbucketTestCase/test_get_is_admin_not_admin.yaml
+++ b/tests/integration/cassetes/test_bitbucket/TestBitbucketTestCase/test_get_is_admin_not_admin.yaml
@@ -13,7 +13,7 @@ interactions:
       user-agent:
       - Default
     method: GET
-    uri: https://bitbucket.org/api/2.0/user/permissions/workspaces?oauth_consumer_key=arubajamaicaohiwan&oauth_signature_method=HMAC-SHA1&oauth_token=testss3hxhcfqf1h6g&oauth_version=1.0&q=workspace.uuid%3D%22%7Bd7c73e87-90ab-450f-bb5f-39e6a5870456%7D%22+AND+permission%3D%22owner%22+AND+user.uuid%3D%22%7B9a01f37b-b1b2-40c5-8c5e-1a39f4b5e645%7D%22
+    uri: https://bitbucket.org/api/2.0/user/permissions/workspaces?oauth_consumer_key=arubajamaicaohiwan&oauth_signature_method=HMAC-SHA1&oauth_token=testss3hxhcfqf1h6g&oauth_version=1.0
   response:
     content: '{"pagelen": 50, "values": [], "page": 1, "size": 0}'
     headers:

--- a/tests/integration/cassetes/test_bitbucket/TestBitbucketTestCase/test_get_is_admin_not_admin.yaml
+++ b/tests/integration/cassetes/test_bitbucket/TestBitbucketTestCase/test_get_is_admin_not_admin.yaml
@@ -13,7 +13,7 @@ interactions:
       user-agent:
       - Default
     method: GET
-    uri: https://bitbucket.org/api/2.0/user/permissions/workspaces?q=workspace.uuid%3D%22%7Bd7c73e87-90ab-450f-bb5f-39e6a5870456%7D%22+AND+permission%3D%22owner%22+AND+user.uuid%3D%22%7B9a01f37b-b1b2-40c5-8c5e-1a39f4b5e645%7D%22&oauth_consumer_key=arubajamaicaohiwan&oauth_token=testss3hxhcfqf1h6g&oauth_signature_method=HMAC-SHA1&oauth_timestamp=1617375478&oauth_nonce=8b0fd629f5e64e5b8f766823188eef76&oauth_version=1.0&oauth_signature=8Glsiw6nKT4h3FPXQeSDj8hQU%2Bo%3D
+    uri: https://bitbucket.org/api/2.0/user/permissions/workspaces?oauth_consumer_key=arubajamaicaohiwan&oauth_signature_method=HMAC-SHA1&oauth_token=testss3hxhcfqf1h6g&oauth_version=1.0&q=workspace.uuid%3D%22%7Bd7c73e87-90ab-450f-bb5f-39e6a5870456%7D%22+AND+permission%3D%22owner%22+AND+user.uuid%3D%22%7B9a01f37b-b1b2-40c5-8c5e-1a39f4b5e645%7D%22
   response:
     content: '{"pagelen": 50, "values": [], "page": 1, "size": 0}'
     headers:


### PR DESCRIPTION
<!-- Describe your PR here. -->

<img width="1204" alt="Screenshot 2024-07-19 at 11 43 38 AM" src="https://github.com/user-attachments/assets/fe39ed4c-1b02-4685-add4-19ae1f275dfb">

The `uuid` does not support filtering the bitbucket api. Here we filter manually after we retrieve the result to check if the user is an admin. 

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.