### PR TITLE
Unpin django-models-utils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
         # API Deps
         "django-prometheus",
         "python-redis-lock",
-        "django-model-utils==4.3.1",
+        "django-model-utils>=4.3.1",
         "requests>=2.32.3",
         "sentry-sdk>=1.40.0",
     ],


### PR DESCRIPTION
This library was causing some `distutils` issues, so unpinning this so that we can install a more recent version if necessary.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.