### PR TITLE
Fix deactivation of users on accounts

### DIFF
--- a/shared/django_apps/codecov_auth/models.py
+++ b/shared/django_apps/codecov_auth/models.py
@@ -228,6 +228,9 @@ class Account(BaseModel):
 
     def deactivate_owner_user_from_account(self, owner_user: "Owner") -> None:
         if owner_user.user is None:
+            log.warning(
+                "Attempting to deactivate an owner without associated user. Skipping deactivation."
+            )
             return
 
         organizations_in_account: list[Owner] = self.organizations.all()
@@ -600,7 +603,7 @@ class Owner(ExportModelOperationsMixin("codecov_auth.owner"), models.Model):
         self.save()
 
         if self.account and user.user:
-            self.account.deactivate_owner_user_from_account(self)
+            self.account.deactivate_owner_user_from_account(user)
 
     def add_admin(self, user):
         log.info(


### PR DESCRIPTION
Currently the deactivation code is attempting to remove the incorrect owner reference (the org) when it's supposed to remove the user. This fixes it to remove the correct owner.


### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.