### PR TITLE
Fix Account User activation

### DIFF
--- a/tests/unit/django_apps/codecov_auth/test_codecov_auth_models.py
+++ b/tests/unit/django_apps/codecov_auth/test_codecov_auth_models.py
@@ -1035,11 +1035,19 @@ class TestAccountModel(TransactionTestCase):
         student_user: User = UserFactory()
         student_owner.user = student_user
         student_user.save()
+        student_owner.save()
 
+        # User1 also has multiple owners. Should be counted as 1 user
         owner1: Owner = OwnerFactory(service="github", student=False)
+        owner1_gitlab: Owner = OwnerFactory(service="gitlab", student=False)
+        owner1_bitbucket: Owner = OwnerFactory(service="bitbucket", student=False)
         user1: User = UserFactory()
         owner1.user = user1
+        owner1_gitlab.user = user1
+        owner1_bitbucket.user = user1
         owner1.save()
+        owner1_gitlab.save()
+        owner1_bitbucket.save()
 
         owner2: Owner = OwnerFactory(service="bitbucket", student=False)
         user2: User = UserFactory()


### PR DESCRIPTION
There is a bug where the number of activated users count is higher than expected because it is counting _all_ the owners for all users associated with an account. Since a user may have multiple owners, it is counting them all separately. This should now count only the number of users.


### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.