### PR TITLE
account pretty_plan overrides org pretty_plan

### DIFF
--- a/shared/django_apps/codecov_auth/models.py
+++ b/shared/django_apps/codecov_auth/models.py
@@ -586,6 +586,8 @@ class Owner(ExportModelOperationsMixin("codecov_auth.owner"), models.Model):
 
     @property
     def pretty_plan(self):
+        if self.account:
+            return self.account.pretty_plan
         if self.plan in USER_PLAN_REPRESENTATIONS:
             plan_details = asdict(USER_PLAN_REPRESENTATIONS[self.plan])
 


### PR DESCRIPTION
<!-- Describe your PR here. -->
This is for displaying the correct plan to the user if they are in an Account.
