### PR TITLE
Do not expose `BundleAnalysisReport.db_session`

### DIFF
--- a/shared/bundle_analysis/report.py
+++ b/shared/bundle_analysis/report.py
@@ -299,7 +299,9 @@ class BundleAnalysisReport:
                     )
         return ret
 
-    def associate_previous_assets(self, prev_bundle_analysis_report: Any) -> None:
+    def associate_previous_assets(
+        self, prev_bundle_analysis_report: "BundleAnalysisReport"
+    ) -> None:
         """
         Only associate past asset if it is Javascript or Typescript types
         and belonging to the same bundle name
@@ -307,8 +309,9 @@ class BundleAnalysisReport:
         Rule 1. Previous and current asset have the same hashed name
         Rule 2. Previous and current asset shared the same set of module names
         """
+        prev_bundle_reports = list(prev_bundle_analysis_report.bundle_reports())
         for curr_bundle_report in self.bundle_reports():
-            for prev_bundle_report in prev_bundle_analysis_report.bundle_reports():
+            for prev_bundle_report in prev_bundle_reports:
                 if curr_bundle_report.name == prev_bundle_report.name:
                     associated_assets_found = set()
 

--- a/shared/bundle_analysis/report.py
+++ b/shared/bundle_analysis/report.py
@@ -9,6 +9,7 @@ from sqlalchemy import text
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm.query import Query
 from sqlalchemy.sql import func
+from sqlalchemy.orm import Session as DbSession
 
 from shared.bundle_analysis.db_migrations import BundleAnalysisMigration
 from shared.bundle_analysis.models import (
@@ -189,44 +190,42 @@ class BundleAnalysisReport:
         self.db_path = db_path
         if self.db_path is None:
             _, self.db_path = tempfile.mkstemp(prefix="bundle_analysis_")
-        self.db_session = get_db_session(self.db_path, auto_close=False)
-        self._setup()
+        with get_db_session(self.db_path) as db_session:
+            self._setup(db_session)
 
-    def _setup(self):
+    def _setup(self, db_session: DbSession):
         """
         Creates the schema for a new bundle report database.
         """
         try:
             schema_version = (
-                self.db_session.query(Metadata)
+                db_session.query(Metadata)
                 .filter_by(key=MetadataKey.SCHEMA_VERSION.value)
                 .first()
-            )
-            self._migrate(schema_version.value)
+            ).value
+            if schema_version < SCHEMA_VERSION:
+                log.info(
+                    f"Migrating Bundle Analysis DB schema from {schema_version} to {SCHEMA_VERSION}"
+                )
+                BundleAnalysisMigration(
+                    db_session, schema_version, SCHEMA_VERSION
+                ).migrate()
         except OperationalError:
             # schema does not exist
-            con = sqlite3.connect(self.db_path)
-            con.executescript(SCHEMA)
+            try:
+                con = sqlite3.connect(self.db_path)
+                con.executescript(SCHEMA)
+                con.commit()
+            finally:
+                con.close()
             schema_version = Metadata(
                 key=MetadataKey.SCHEMA_VERSION.value,
                 value=SCHEMA_VERSION,
             )
-            self.db_session.add(schema_version)
-            self.db_session.commit()
-
-    def _migrate(self, from_version: int, to_version: int = SCHEMA_VERSION):
-        """
-        Migrate the database from `schema_version` to `models.SCHEMA_VERSION`
-        such that the resulting schema is identical to `models.SCHEMA`
-        """
-        if from_version < to_version:
-            log.info(
-                f"Migrating Bundle Analysis DB schema from {from_version} to {to_version}"
-            )
-            BundleAnalysisMigration(self.db_session, from_version, to_version).migrate()
+            db_session.add(schema_version)
+            db_session.commit()
 
     def cleanup(self):
-        self.db_session.close()
         os.unlink(self.db_path)
 
     def ingest(self, path: str) -> int:
@@ -234,10 +233,11 @@ class BundleAnalysisReport:
         Ingest the bundle stats JSON at the given file path.
         Returns session ID of ingested data.
         """
-        parser = Parser(path, self.db_session).get_proper_parser()
-        session_id = parser.parse(path)
-        self.db_session.commit()
-        return session_id
+        with get_db_session(self.db_path) as session:
+            parser = Parser(path, session).get_proper_parser()
+            session_id = parser.parse(path)
+            session.commit()
+            return session_id
 
     def _associate_bundle_report_assets_by_name(
         self, curr_bundle_report: BundleReport, prev_bundle_report: BundleReport
@@ -309,12 +309,12 @@ class BundleAnalysisReport:
         Rule 1. Previous and current asset have the same hashed name
         Rule 2. Previous and current asset shared the same set of module names
         """
+        associated_assets_found = set()
+
         prev_bundle_reports = list(prev_bundle_analysis_report.bundle_reports())
         for curr_bundle_report in self.bundle_reports():
             for prev_bundle_report in prev_bundle_reports:
                 if curr_bundle_report.name == prev_bundle_report.name:
-                    associated_assets_found = set()
-
                     # Rule 1 check
                     associated_assets_found |= (
                         self._associate_bundle_report_assets_by_name(
@@ -329,14 +329,15 @@ class BundleAnalysisReport:
                         )
                     )
 
-                    # Update the Assets table for the bundle
-                    # TODO: Use SQLalchemy ORM to update instead of raw SQL
-                    # https://github.com/codecov/engineering-team/issues/1846
-                    for pair in associated_assets_found:
-                        prev_uuid, curr_uuid = pair
-                        stmt = f"UPDATE assets SET uuid='{prev_uuid}' WHERE uuid='{curr_uuid}'"
-                        self.db_session.execute(text(stmt))
-                    self.db_session.commit()
+        with get_db_session(self.db_path) as session:
+            # Update the Assets table for the bundle
+            # TODO: Use SQLalchemy ORM to update instead of raw SQL
+            # https://github.com/codecov/engineering-team/issues/1846
+            for pair in associated_assets_found:
+                prev_uuid, curr_uuid = pair
+                stmt = f"UPDATE assets SET uuid='{prev_uuid}' WHERE uuid='{curr_uuid}'"
+                session.execute(text(stmt))
+            session.commit()
 
     def metadata(self) -> Dict[MetadataKey, Any]:
         with get_db_session(self.db_path) as session:

--- a/tests/unit/bundle_analysis/test_bundle_analysis.py
+++ b/tests/unit/bundle_analysis/test_bundle_analysis.py
@@ -313,7 +313,9 @@ def test_bundle_report_info():
         assert bundle_report_info["bundler_name"] == "rollup"
         assert bundle_report_info["bundler_version"] == "3.29.4"
         assert bundle_report_info["built_at"] == 1701451048604
-        assert bundle_report_info["plugin_name"] == "codecov-vite-bundle-analysis-plugin"
+        assert (
+            bundle_report_info["plugin_name"] == "codecov-vite-bundle-analysis-plugin"
+        )
         assert bundle_report_info["plugin_version"] == "1.0.0"
         assert bundle_report_info["duration"] == 331
     finally:
@@ -359,7 +361,8 @@ def test_bundle_name_not_valid():
         with pytest.raises(Exception) as excinfo:
             report.ingest(sample_bundle_stats_path_3)
             assert (
-                excinfo.bundle_analysis_plugin_name == "codecov-vite-bundle-analysis-plugin"
+                excinfo.bundle_analysis_plugin_name
+                == "codecov-vite-bundle-analysis-plugin"
             )
     finally:
         report.cleanup()

--- a/tests/unit/bundle_analysis/test_bundle_analysis.py
+++ b/tests/unit/bundle_analysis/test_bundle_analysis.py
@@ -188,26 +188,26 @@ def test_bundle_report_asset_filtering():
 
 def test_save_load_bundle_report():
     try:
-        report = BundleAnalysisReport()
-        report.ingest(sample_bundle_stats_path)
+        created_report = BundleAnalysisReport()
+        created_report.ingest(sample_bundle_stats_path)
 
         loader = BundleAnalysisReportLoader(
             storage_service=MemoryStorageService({}),
             repo_key="testing",
         )
         test_key = "8d1099f1-ba73-472f-957f-6908eced3f42"
-        loader.save(report, test_key)
+        loader.save(created_report, test_key)
 
-        db_path = report.db_path
         report = loader.load(test_key)
 
-        initial_data = open(db_path, "rb").read()
+        initial_data = open(created_report.db_path, "rb").read()
         loaded_data = open(report.db_path, "rb").read()
 
-        assert db_path != report.db_path
+        assert created_report.db_path != report.db_path
         assert len(initial_data) > 0
         assert initial_data == loaded_data
     finally:
+        created_report.cleanup()
         report.cleanup()
 
 
@@ -249,76 +249,91 @@ def test_reupload_bundle_report():
 
 
 def test_bundle_report_no_assets():
-    report_path = (
-        Path(__file__).parent.parent.parent
-        / "samples"
-        / "sample_bundle_stats_no_assets.json"
-    )
-    report = BundleAnalysisReport()
-    report.ingest(report_path)
-    bundle_report = report.bundle_report("b5")
-    asset_reports = list(bundle_report.asset_reports())
+    try:
+        report_path = (
+            Path(__file__).parent.parent.parent
+            / "samples"
+            / "sample_bundle_stats_no_assets.json"
+        )
+        report = BundleAnalysisReport()
+        report.ingest(report_path)
+        bundle_report = report.bundle_report("b5")
+        asset_reports = list(bundle_report.asset_reports())
 
-    assert asset_reports == []
-    assert bundle_report.total_size() == 0
+        assert asset_reports == []
+        assert bundle_report.total_size() == 0
+    finally:
+        report.cleanup()
 
 
 def test_bundle_report_no_chunks():
-    report_path = (
-        Path(__file__).parent.parent.parent
-        / "samples"
-        / "sample_bundle_stats_no_chunks.json"
-    )
-    report = BundleAnalysisReport()
-    report.ingest(report_path)
-    bundle_report = report.bundle_report("sample")
-    asset_reports = list(bundle_report.asset_reports())
+    try:
+        report_path = (
+            Path(__file__).parent.parent.parent
+            / "samples"
+            / "sample_bundle_stats_no_chunks.json"
+        )
+        report = BundleAnalysisReport()
+        report.ingest(report_path)
+        bundle_report = report.bundle_report("sample")
+        asset_reports = list(bundle_report.asset_reports())
 
-    assert len(asset_reports) == 2
-    assert bundle_report.total_size() == 144731
+        assert len(asset_reports) == 2
+        assert bundle_report.total_size() == 144731
+    finally:
+        report.cleanup()
 
 
 def test_bundle_report_no_modules():
-    report_path = (
-        Path(__file__).parent.parent.parent
-        / "samples"
-        / "sample_bundle_stats_no_modules.json"
-    )
-    report = BundleAnalysisReport()
-    report.ingest(report_path)
-    bundle_report = report.bundle_report("sample")
-    asset_reports = list(bundle_report.asset_reports())
+    try:
+        report_path = (
+            Path(__file__).parent.parent.parent
+            / "samples"
+            / "sample_bundle_stats_no_modules.json"
+        )
+        report = BundleAnalysisReport()
+        report.ingest(report_path)
+        bundle_report = report.bundle_report("sample")
+        asset_reports = list(bundle_report.asset_reports())
 
-    assert len(asset_reports) == 2
-    assert bundle_report.total_size() == 144731
+        assert len(asset_reports) == 2
+        assert bundle_report.total_size() == 144731
+    finally:
+        report.cleanup()
 
 
 def test_bundle_report_info():
-    report = BundleAnalysisReport()
-    report.ingest(sample_bundle_stats_path)
-    bundle_report = report.bundle_report("sample")
-    bundle_report_info = bundle_report.info()
+    try:
+        report = BundleAnalysisReport()
+        report.ingest(sample_bundle_stats_path)
+        bundle_report = report.bundle_report("sample")
+        bundle_report_info = bundle_report.info()
 
-    assert bundle_report_info["version"] == "2"
-    assert bundle_report_info["bundler_name"] == "rollup"
-    assert bundle_report_info["bundler_version"] == "3.29.4"
-    assert bundle_report_info["built_at"] == 1701451048604
-    assert bundle_report_info["plugin_name"] == "codecov-vite-bundle-analysis-plugin"
-    assert bundle_report_info["plugin_version"] == "1.0.0"
-    assert bundle_report_info["duration"] == 331
+        assert bundle_report_info["version"] == "2"
+        assert bundle_report_info["bundler_name"] == "rollup"
+        assert bundle_report_info["bundler_version"] == "3.29.4"
+        assert bundle_report_info["built_at"] == 1701451048604
+        assert bundle_report_info["plugin_name"] == "codecov-vite-bundle-analysis-plugin"
+        assert bundle_report_info["plugin_version"] == "1.0.0"
+        assert bundle_report_info["duration"] == 331
+    finally:
+        report.cleanup()
 
 
 def test_bundle_report_size_integer():
-    report_path = (
-        Path(__file__).parent.parent.parent
-        / "samples"
-        / "sample_bundle_stats_decimal_size.json"
-    )
-    report = BundleAnalysisReport()
-    report.ingest(report_path)
-    bundle_report = report.bundle_report("sample")
+    try:
+        report_path = (
+            Path(__file__).parent.parent.parent
+            / "samples"
+            / "sample_bundle_stats_decimal_size.json"
+        )
+        report = BundleAnalysisReport()
+        report.ingest(report_path)
+        bundle_report = report.bundle_report("sample")
 
-    assert bundle_report.total_size() == 150572
+        assert bundle_report.total_size() == 150572
+    finally:
+        report.cleanup()
 
 
 def test_bundle_parser_error():
@@ -326,22 +341,28 @@ def test_bundle_parser_error():
         "shared.bundle_analysis.parsers.ParserV1._parse_assets_event",
         side_effect=Exception("MockError"),
     ):
-        report = BundleAnalysisReport()
-        with pytest.raises(Exception) as excinfo:
-            report.ingest(sample_bundle_stats_path)
-            assert (
-                excinfo.bundle_analysis_plugin_name
-                == "codecov-vite-bundle-analysis-plugin"
-            )
+        try:
+            report = BundleAnalysisReport()
+            with pytest.raises(Exception) as excinfo:
+                report.ingest(sample_bundle_stats_path)
+                assert (
+                    excinfo.bundle_analysis_plugin_name
+                    == "codecov-vite-bundle-analysis-plugin"
+                )
+        finally:
+            report.cleanup()
 
 
 def test_bundle_name_not_valid():
-    report = BundleAnalysisReport()
-    with pytest.raises(Exception) as excinfo:
-        report.ingest(sample_bundle_stats_path_3)
-        assert (
-            excinfo.bundle_analysis_plugin_name == "codecov-vite-bundle-analysis-plugin"
-        )
+    try:
+        report = BundleAnalysisReport()
+        with pytest.raises(Exception) as excinfo:
+            report.ingest(sample_bundle_stats_path_3)
+            assert (
+                excinfo.bundle_analysis_plugin_name == "codecov-vite-bundle-analysis-plugin"
+            )
+    finally:
+        report.cleanup()
 
 
 def test_bundle_file_save_rate_limit_error():
@@ -350,18 +371,21 @@ def test_bundle_file_save_rate_limit_error():
         side_effect=Exception("TooManyRequests"),
     ):
         with pytest.raises(Exception) as excinfo:
-            report = BundleAnalysisReport()
-            report.ingest(sample_bundle_stats_path)
+            try:
+                report = BundleAnalysisReport()
+                report.ingest(sample_bundle_stats_path)
 
-            loader = BundleAnalysisReportLoader(
-                storage_service=MemoryStorageService({}),
-                repo_key="testing",
-            )
-            test_key = "8d1099f1-ba73-472f-957f-6908eced3f42"
-            loader.save(report, test_key)
+                loader = BundleAnalysisReportLoader(
+                    storage_service=MemoryStorageService({}),
+                    repo_key="testing",
+                )
+                test_key = "8d1099f1-ba73-472f-957f-6908eced3f42"
+                loader.save(report, test_key)
 
-            assert str(excinfo) == "TooManyRequests"
-            assert isinstance(excinfo, PutRequestRateLimitError)
+                assert str(excinfo) == "TooManyRequests"
+                assert isinstance(excinfo, PutRequestRateLimitError)
+            finally:
+                report.cleanup()
 
 
 def test_bundle_file_save_unknown_error():
@@ -370,18 +394,21 @@ def test_bundle_file_save_unknown_error():
         side_effect=Exception("UnknownError"),
     ):
         with pytest.raises(Exception) as excinfo:
-            report = BundleAnalysisReport()
-            report.ingest(sample_bundle_stats_path)
+            try:
+                report = BundleAnalysisReport()
+                report.ingest(sample_bundle_stats_path)
 
-            loader = BundleAnalysisReportLoader(
-                storage_service=MemoryStorageService({}),
-                repo_key="testing",
-            )
-            test_key = "8d1099f1-ba73-472f-957f-6908eced3f42"
-            loader.save(report, test_key)
+                loader = BundleAnalysisReportLoader(
+                    storage_service=MemoryStorageService({}),
+                    repo_key="testing",
+                )
+                test_key = "8d1099f1-ba73-472f-957f-6908eced3f42"
+                loader.save(report, test_key)
 
-            assert str(excinfo) == "UnknownError"
-            assert type(excinfo) is Exception
+                assert str(excinfo) == "UnknownError"
+                assert type(excinfo) is Exception
+            finally:
+                report.cleanup()
 
 
 def test_create_bundle_report_v1():

--- a/tests/unit/bundle_analysis/test_bundle_analysis.py
+++ b/tests/unit/bundle_analysis/test_bundle_analysis.py
@@ -15,6 +15,7 @@ from shared.bundle_analysis.models import (
     MetadataKey,
     Module,
     Session,
+    get_db_session,
 )
 from shared.storage.exceptions import PutRequestRateLimitError
 from shared.storage.memory import MemoryStorageService
@@ -541,39 +542,37 @@ def test_bundle_is_cached():
 def test_bundle_deletion():
     try:
         bundle_analysis_report = BundleAnalysisReport()
-        db_session = bundle_analysis_report.db_session
+        with get_db_session(bundle_analysis_report.db_path) as db_session:
+            session_id = bundle_analysis_report.ingest(sample_bundle_stats_path)
+            assert session_id == 1
 
-        session_id = bundle_analysis_report.ingest(sample_bundle_stats_path)
-        assert session_id == 1
+            session_id = bundle_analysis_report.ingest(sample_bundle_stats_path_5)
+            assert session_id == 2
 
-        session_id = bundle_analysis_report.ingest(sample_bundle_stats_path_5)
-        assert session_id == 2
+            assert _table_rows_count(db_session) == (2, 2, 10, 6, 62)
 
-        assert _table_rows_count(db_session) == (2, 2, 10, 6, 62)
+            # Delete non-existent bundle
+            bundle_analysis_report.delete_bundle_by_name("fake")
+            assert _table_rows_count(db_session) == (2, 2, 10, 6, 62)
 
-        # Delete non-existent bundle
-        bundle_analysis_report.delete_bundle_by_name("fake")
-        assert _table_rows_count(db_session) == (2, 2, 10, 6, 62)
+            # Delete bundle 'sample'
+            bundle_analysis_report.delete_bundle_by_name("sample")
+            assert _table_rows_count(db_session) == (1, 1, 5, 3, 31)
+            res = list(db_session.query(Bundle).all())
+            assert len(res) == 1
+            assert res[0].name == "sample2"
 
-        # Delete bundle 'sample'
-        bundle_analysis_report.delete_bundle_by_name("sample")
-        assert _table_rows_count(db_session) == (1, 1, 5, 3, 31)
-        res = list(db_session.query(Bundle).all())
-        assert len(res) == 1
-        assert res[0].name == "sample2"
+            # Delete bundle 'sample' again
+            bundle_analysis_report.delete_bundle_by_name("sample")
+            assert _table_rows_count(db_session) == (1, 1, 5, 3, 31)
+            res = list(db_session.query(Bundle).all())
+            assert len(res) == 1
+            assert res[0].name == "sample2"
 
-        # Delete bundle 'sample' again
-        bundle_analysis_report.delete_bundle_by_name("sample")
-        assert _table_rows_count(db_session) == (1, 1, 5, 3, 31)
-        res = list(db_session.query(Bundle).all())
-        assert len(res) == 1
-        assert res[0].name == "sample2"
-
-        # Delete bundle 'sample2'
-        bundle_analysis_report.delete_bundle_by_name("sample2")
-        assert _table_rows_count(db_session) == (0, 0, 0, 0, 0)
-        res = list(db_session.query(Bundle).all())
-        assert len(res) == 0
-
+            # Delete bundle 'sample2'
+            bundle_analysis_report.delete_bundle_by_name("sample2")
+            assert _table_rows_count(db_session) == (0, 0, 0, 0, 0)
+            res = list(db_session.query(Bundle).all())
+            assert len(res) == 0
     finally:
         bundle_analysis_report.cleanup()

--- a/tests/unit/bundle_analysis/test_bundle_comparison.py
+++ b/tests/unit/bundle_analysis/test_bundle_comparison.py
@@ -12,7 +12,7 @@ from shared.bundle_analysis import (
     MissingBundleError,
     MissingHeadReportError,
 )
-from shared.bundle_analysis.models import Bundle
+from shared.bundle_analysis.models import Bundle, get_db_session
 from shared.storage.memory import MemoryStorageService
 
 here = Path(__file__)
@@ -47,15 +47,17 @@ def test_bundle_analysis_comparison():
         base_report.ingest(base_report_bundle_stats_path)
 
         old_bundle = Bundle(name="old")
-        base_report.db_session.add(old_bundle)
-        base_report.db_session.commit()
+        with get_db_session(base_report.db_path) as db_session:
+            db_session.add(old_bundle)
+            db_session.commit()
 
         head_report = BundleAnalysisReport()
         head_report.ingest(head_report_bundle_stats_path)
 
         new_bundle = Bundle(name="new")
-        head_report.db_session.add(new_bundle)
-        head_report.db_session.commit()
+        with get_db_session(head_report.db_path) as db_session:
+            db_session.add(new_bundle)
+            db_session.commit()
 
         loader.save(base_report, "base-report")
         loader.save(head_report, "head-report")
@@ -146,15 +148,17 @@ def test_bundle_analysis_total_size_delta():
         base_report.ingest(base_report_bundle_stats_path)
 
         old_bundle = Bundle(name="old")
-        base_report.db_session.add(old_bundle)
-        base_report.db_session.commit()
+        with get_db_session(base_report.db_path) as db_session:
+            db_session.add(old_bundle)
+            db_session.commit()
 
         head_report = BundleAnalysisReport()
         head_report.ingest(head_report_bundle_stats_path)
 
         new_bundle = Bundle(name="new")
-        head_report.db_session.add(new_bundle)
-        head_report.db_session.commit()
+        with get_db_session(head_report.db_path) as db_session:
+            db_session.add(new_bundle)
+            db_session.commit()
 
         loader.save(base_report, "base-report")
         loader.save(head_report, "head-report")

--- a/tests/unit/bundle_analysis/test_bundle_comparison.py
+++ b/tests/unit/bundle_analysis/test_bundle_comparison.py
@@ -42,22 +42,26 @@ def test_bundle_analysis_comparison():
     with pytest.raises(MissingHeadReportError):
         comparison.head_report
 
-    base_report = BundleAnalysisReport()
-    base_report.ingest(base_report_bundle_stats_path)
+    try:
+        base_report = BundleAnalysisReport()
+        base_report.ingest(base_report_bundle_stats_path)
 
-    old_bundle = Bundle(name="old")
-    base_report.db_session.add(old_bundle)
-    base_report.db_session.commit()
+        old_bundle = Bundle(name="old")
+        base_report.db_session.add(old_bundle)
+        base_report.db_session.commit()
 
-    head_report = BundleAnalysisReport()
-    head_report.ingest(head_report_bundle_stats_path)
+        head_report = BundleAnalysisReport()
+        head_report.ingest(head_report_bundle_stats_path)
 
-    new_bundle = Bundle(name="new")
-    head_report.db_session.add(new_bundle)
-    head_report.db_session.commit()
+        new_bundle = Bundle(name="new")
+        head_report.db_session.add(new_bundle)
+        head_report.db_session.commit()
 
-    loader.save(base_report, "base-report")
-    loader.save(head_report, "head-report")
+        loader.save(base_report, "base-report")
+        loader.save(head_report, "head-report")
+    finally:
+        base_report.cleanup()
+        head_report.cleanup()
 
     bundle_changes = comparison.bundle_changes()
     assert set(bundle_changes) == set(
@@ -126,32 +130,37 @@ def test_bundle_analysis_comparison():
 
 
 def test_bundle_analysis_total_size_delta():
-    loader = BundleAnalysisReportLoader(
-        storage_service=MemoryStorageService({}),
-        repo_key="testing",
-    )
+    try:
+        loader = BundleAnalysisReportLoader(
+            storage_service=MemoryStorageService({}),
+            repo_key="testing",
+        )
 
-    comparison = BundleAnalysisComparison(
-        loader=loader,
-        base_report_key="base-report",
-        head_report_key="head-report",
-    )
+        comparison = BundleAnalysisComparison(
+            loader=loader,
+            base_report_key="base-report",
+            head_report_key="head-report",
+        )
 
-    base_report = BundleAnalysisReport()
-    base_report.ingest(base_report_bundle_stats_path)
+        base_report = BundleAnalysisReport()
+        base_report.ingest(base_report_bundle_stats_path)
 
-    old_bundle = Bundle(name="old")
-    base_report.db_session.add(old_bundle)
-    base_report.db_session.commit()
+        old_bundle = Bundle(name="old")
+        base_report.db_session.add(old_bundle)
+        base_report.db_session.commit()
 
-    head_report = BundleAnalysisReport()
-    head_report.ingest(head_report_bundle_stats_path)
+        head_report = BundleAnalysisReport()
+        head_report.ingest(head_report_bundle_stats_path)
 
-    new_bundle = Bundle(name="new")
-    head_report.db_session.add(new_bundle)
-    head_report.db_session.commit()
+        new_bundle = Bundle(name="new")
+        head_report.db_session.add(new_bundle)
+        head_report.db_session.commit()
 
-    loader.save(base_report, "base-report")
-    loader.save(head_report, "head-report")
+        loader.save(base_report, "base-report")
+        loader.save(head_report, "head-report")
 
-    assert comparison.total_size_delta == 1100
+        assert comparison.total_size_delta == 1100
+
+    finally:
+        base_report.cleanup()
+        head_report.cleanup()


### PR DESCRIPTION
This PR contains a couple of improvements:

- Removes `BundleAnalysisReport.db_session` completely, so it should not be possible to leak an open DB handle anymore.
- Within `BundleAnalysisReport.associate_previous_assets`: avoid an N+1 query by moving it out of the loop.
- Similarly, also moves the `set` out of the inner loop, which might reduce the total number of `UPDATE` calls.
- Updates a bunch of tests to properly `cleanup` the `BundleAnalysisReport` and its temporary file.

Related to https://github.com/codecov/internal-issues/issues/650, Although I’m unsure whether this completely fixes that problem.

---

Feel free to review with "ignore whitespace" as most of this is just indentation changes.