### PR TITLE
clean up LIST_REPOS_PAGE_SIZE experiment

### DIFF
--- a/shared/bundle_analysis/report.py
+++ b/shared/bundle_analysis/report.py
@@ -7,9 +7,9 @@ from typing import Any, Dict, Iterator, List, Optional, Set, Tuple
 
 from sqlalchemy import text
 from sqlalchemy.exc import OperationalError
+from sqlalchemy.orm import Session as DbSession
 from sqlalchemy.orm.query import Query
 from sqlalchemy.sql import func
-from sqlalchemy.orm import Session as DbSession
 
 from shared.bundle_analysis.db_migrations import BundleAnalysisMigration
 from shared.bundle_analysis.models import (

--- a/shared/rollouts/features.py
+++ b/shared/rollouts/features.py
@@ -1,5 +1,3 @@
 from . import Feature
 
-LIST_REPOS_PAGE_SIZE = Feature("list_repos_page_size")
-
 BUNDLE_THRESHOLD_FLAG = Feature("bundle_threshold_flag")

--- a/shared/torngit/github.py
+++ b/shared/torngit/github.py
@@ -18,7 +18,6 @@ from shared.github import (
     mark_installation_as_rate_limited,
 )
 from shared.metrics import Counter, metrics
-from shared.rollouts.features import LIST_REPOS_PAGE_SIZE
 from shared.torngit.base import TokenType, TorngitBaseAdapter
 from shared.torngit.cache import get_redis_connection, torngit_cache
 from shared.torngit.enums import Endpoints
@@ -1261,9 +1260,7 @@ class Github(TorngitBaseAdapter):
         async with self.get_client() as client:
             max_index = len(repo_node_ids)
             curr_index = 0
-            page_size = await LIST_REPOS_PAGE_SIZE.check_value_async(
-                identifier=self.data["owner"].get("ownerid"), default=100
-            )
+            page_size = 50
             while curr_index < max_index:
                 chunk = repo_node_ids[curr_index : curr_index + page_size]
                 curr_index += page_size
@@ -1318,9 +1315,7 @@ class Github(TorngitBaseAdapter):
         """
         data = []
         page = 0
-        page_size = await LIST_REPOS_PAGE_SIZE.check_value_async(
-            identifier=self.data["owner"].get("ownerid"), default=100
-        )
+        page_size = 50
         async with self.get_client() as client:
             while True:
                 page += 1
@@ -1352,9 +1347,7 @@ class Github(TorngitBaseAdapter):
         """
         token = self.get_token_by_type_if_none(token, TokenType.read)
         page = 0
-        page_size = await LIST_REPOS_PAGE_SIZE.check_value_async(
-            identifier=self.data["owner"].get("ownerid"), default=100
-        )
+        page_size = 50
         data = []
         async with self.get_client() as client:
             while True:
@@ -1378,9 +1371,7 @@ class Github(TorngitBaseAdapter):
         rolling out in the worker.
         """
         token = self.get_token_by_type_if_none(token, TokenType.read)
-        page_size = await LIST_REPOS_PAGE_SIZE.check_value_async(
-            identifier=self.data["owner"].get("ownerid"), default=100
-        )
+        page_size = 50
         async with self.get_client() as client:
             page = 0
             while True:


### PR DESCRIPTION
rolled this out so 100% of users are receiving the new value of 50. cleaning up the code now

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.