### PR TITLE
Bundle analysis: make gzip size nullable

### DIFF
--- a/shared/bundle_analysis/db_migrations.py
+++ b/shared/bundle_analysis/db_migrations.py
@@ -3,6 +3,9 @@ from sqlalchemy.orm import Session
 
 from shared.bundle_analysis.migrations.v001_add_gzip_size import add_gzip_size
 from shared.bundle_analysis.migrations.v002_bundle_is_cached import add_is_cached
+from shared.bundle_analysis.migrations.v003_modify_gzip_size_nullable import (
+    modify_gzip_size_nullable,
+)
 
 
 class BundleAnalysisMigration:
@@ -26,6 +29,7 @@ class BundleAnalysisMigration:
         self.migrations = {
             2: add_gzip_size,
             3: add_is_cached,
+            4: modify_gzip_size_nullable,
         }
 
     def update_schema_version(self, version):

--- a/shared/bundle_analysis/migrations/v003_modify_gzip_size_nullable.py
+++ b/shared/bundle_analysis/migrations/v003_modify_gzip_size_nullable.py
@@ -1,0 +1,42 @@
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+
+def modify_gzip_size_nullable(db_session: Session):
+    """
+    Modify gzip_size column of assets table to be a nullable value
+    Because SQLite does not have a "alter column" command we need to
+    rename the existing table, create the new table, and migrate all the data over
+    """
+
+    # Update column
+    stmt = """
+    PRAGMA foreign_keys=off;
+
+    BEGIN TRANSACTION;
+
+    ALTER TABLE assets RENAME TO assets_old;
+
+    create table assets (
+        id integer primary key,
+        session_id integer not null,
+        name text not null,
+        normalized_name text not null,
+        size integer not null,
+        gzip_size integer,
+        uuid text not null,
+        asset_type text not null,
+        foreign key (session_id) references sessions (id)
+    );
+
+    INSERT INTO assets (id, session_id, name, normalized_name, size, gzip_size, uuid, asset_type)
+    SELECT id, session_id, name, normalized_name, size, gzip_size, uuid, asset_type
+    FROM assets_old;
+
+    DROP TABLE assets_old;
+
+    COMMIT;
+
+    PRAGMA foreign_keys=on;
+    """
+    db_session.execute(text(stmt))

--- a/shared/bundle_analysis/migrations/v003_modify_gzip_size_nullable.py
+++ b/shared/bundle_analysis/migrations/v003_modify_gzip_size_nullable.py
@@ -8,35 +8,38 @@ def modify_gzip_size_nullable(db_session: Session):
     Because SQLite does not have a "alter column" command we need to
     rename the existing table, create the new table, and migrate all the data over
     """
+    stmts = [
+        """
+        PRAGMA foreign_keys=off;
+        """,
+        """
+        ALTER TABLE assets RENAME TO assets_old;
+        """,
+        """
+        CREATE TABLE assets (
+            id integer primary key,
+            session_id integer not null,
+            name text not null,
+            normalized_name text not null,
+            size integer not null,
+            gzip_size integer,
+            uuid text not null,
+            asset_type text not null,
+            foreign key (session_id) references sessions (id)
+        );
+        """,
+        """
+        INSERT INTO assets (id, session_id, name, normalized_name, size, gzip_size, uuid, asset_type)
+        SELECT id, session_id, name, normalized_name, size, gzip_size, uuid, asset_type
+        FROM assets_old;
+        """,
+        """
+        DROP TABLE assets_old;
+        """,
+        """
+        PRAGMA foreign_keys=on;
+        """,
+    ]
 
-    # Update column
-    stmt = """
-    PRAGMA foreign_keys=off;
-
-    BEGIN TRANSACTION;
-
-    ALTER TABLE assets RENAME TO assets_old;
-
-    create table assets (
-        id integer primary key,
-        session_id integer not null,
-        name text not null,
-        normalized_name text not null,
-        size integer not null,
-        gzip_size integer,
-        uuid text not null,
-        asset_type text not null,
-        foreign key (session_id) references sessions (id)
-    );
-
-    INSERT INTO assets (id, session_id, name, normalized_name, size, gzip_size, uuid, asset_type)
-    SELECT id, session_id, name, normalized_name, size, gzip_size, uuid, asset_type
-    FROM assets_old;
-
-    DROP TABLE assets_old;
-
-    COMMIT;
-
-    PRAGMA foreign_keys=on;
-    """
-    db_session.execute(text(stmt))
+    for stmt in stmts:
+        db_session.execute(text(stmt))

--- a/shared/bundle_analysis/models.py
+++ b/shared/bundle_analysis/models.py
@@ -223,7 +223,7 @@ class Asset(Base):
     name = Column(types.Text, nullable=False)
     normalized_name = Column(types.Text, nullable=False)
     size = Column(types.Integer, nullable=False)
-    gzip_size = Column(types.Integer, nullable=False)
+    gzip_size = Column(types.Integer)
     uuid = Column(types.Text, nullable=False)
     asset_type = Column(SQLAlchemyEnum(AssetType))
     session = relationship("Session", backref=backref("assets"))

--- a/shared/bundle_analysis/models.py
+++ b/shared/bundle_analysis/models.py
@@ -42,7 +42,7 @@ create table assets (
     name text not null,
     normalized_name text not null,
     size integer not null,
-    gzip_size integer not null default 0,
+    gzip_size integer,
     uuid text not null,
     asset_type text not null,
     foreign key (session_id) references sessions (id)
@@ -86,7 +86,7 @@ create table chunks_modules (
 );
 """
 
-SCHEMA_VERSION = 3
+SCHEMA_VERSION = 4
 
 Base = declarative_base()
 

--- a/shared/bundle_analysis/parsers/v2.py
+++ b/shared/bundle_analysis/parsers/v2.py
@@ -228,7 +228,7 @@ class ParserV2:
             self.asset.normalized_name = value
         elif prefix == "assets.item.size":
             self.asset.size = int(value)
-        elif prefix == "assets.item.gzipSize":
+        elif prefix == "assets.item.gzipSize" and value is not None:
             self.asset.gzip_size = int(value)
         elif (prefix, event) == ("assets.item", "end_map"):
             self.asset_list.append(


### PR DESCRIPTION
Make a SQLite migration to make it so that gzip size is nullable and when parsing `gzipSize` handles the case that the value can be null.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.