### PR TITLE
feat: percentage delta

### DIFF
--- a/shared/bundle_analysis/comparison.py
+++ b/shared/bundle_analysis/comparison.py
@@ -238,6 +238,19 @@ class BundleAnalysisComparison:
     def total_size_delta(self) -> int:
         return sum(bundle_change.size_delta for bundle_change in self.bundle_changes())
 
+    @property
+    def percentage_delta(self) -> float:
+        """Returns the size delta as a percentage of BASE report total size.
+        For example, base_bundle_reports have a total size of 1MB
+        and the total_size_delta is 100kB then percentage_delta is 10.0%
+
+        Percentage is returned as a float 0-100, rounded to 2 decimal places
+        """
+        base_size = sum(
+            report.total_size() for report in self.base_report.bundle_reports()
+        )
+        return round((self.total_size_delta / base_size) * 100, 2)
+
     def bundle_comparison(self, bundle_name: str) -> BundleComparison:
         """
         More detailed comparison (about asset changes) for a particular bundle that

--- a/tests/unit/bundle_analysis/test_bundle_comparison.py
+++ b/tests/unit/bundle_analysis/test_bundle_comparison.py
@@ -126,6 +126,7 @@ def test_bundle_analysis_comparison():
     total_size_delta = bundle_comparison.total_size_delta()
     assert total_size_delta == 1100
     assert total_size_delta == sum([change.size_delta for change in asset_changes])
+    assert comparison.percentage_delta == 0.73
 
     with pytest.raises(MissingBundleError):
         comparison.bundle_comparison("new")
@@ -164,6 +165,7 @@ def test_bundle_analysis_total_size_delta():
         loader.save(head_report, "head-report")
 
         assert comparison.total_size_delta == 1100
+        assert comparison.percentage_delta == 0.73
 
     finally:
         base_report.cleanup()


### PR DESCRIPTION
Adds `percentage_delta` for bundle analysis comparison.
This is because status configuration allows users to set a _percentage_ threshold for changes (to fail commit status and whatnot).

To make is easy to compare I'm adding the function that gives us the data, as specified in the function docstring
