### PR TITLE
fix: cant use flags in validator?

### DIFF
--- a/shared/validation/validator.py
+++ b/shared/validation/validator.py
@@ -51,11 +51,8 @@ class CodecovYamlValidator(Validator):
         coerced_value: BundleThreshold = BundleSizeThresholdSchemaField().validate(
             value
         )
-        # This change is not forwards compatible, so we need this step in the rollout
-        from shared.rollouts.features import BUNDLE_THRESHOLD_FLAG
-
-        if BUNDLE_THRESHOLD_FLAG.check_value(identifier=1, default=False):
-            return coerced_value
+        # This change is not forwards compatible, so we need to return a number for now
+        # https://github.com/codecov/engineering-team/issues/2087 to clean up later
         return coerced_value.threshold
 
     def _validate_comma_separated_strings(self, constraint, field, value):

--- a/tests/unit/validation/test_validation.py
+++ b/tests/unit/validation/test_validation.py
@@ -838,7 +838,8 @@ class TestUserYamlValidation(BaseTestCase):
                 {
                     "comment": {
                         "require_bundle_changes": True,
-                        "bundle_change_threshold": ("absolute", 1200),
+                        # "bundle_change_threshold": ("absolute", 1200),
+                        "bundle_change_threshold": 1200,
                     }
                 },
                 id="bundle_changes_with_threshold",
@@ -853,7 +854,8 @@ class TestUserYamlValidation(BaseTestCase):
                 {
                     "comment": {
                         "require_bundle_changes": "bundle_increase",
-                        "bundle_change_threshold": ("absolute", 1000000),
+                        # "bundle_change_threshold": ("absolute", 1000000),
+                        "bundle_change_threshold": 1000000,
                     }
                 },
                 id="bundle_increase_required_with_threshold",
@@ -868,7 +870,8 @@ class TestUserYamlValidation(BaseTestCase):
                 {
                     "comment": {
                         "require_bundle_changes": "bundle_increase",
-                        "bundle_change_threshold": ("percentage", 10.0),
+                        # "bundle_change_threshold": ("percentage", 10.0),
+                        "bundle_change_threshold": 10.0,
                     }
                 },
                 id="bundle_increase_required_with_percentage_threshold",
@@ -893,7 +896,8 @@ class TestUserYamlValidation(BaseTestCase):
                 {
                     "bundle_analysis": {
                         "status": False,
-                        "bundle_change_threshold": ("percentage", 10.0),
+                        # "bundle_change_threshold": ("percentage", 10.0),
+                        "bundle_change_threshold": 10.0,
                     }
                 },
                 id="status_off_percentage_threshold",
@@ -908,7 +912,8 @@ class TestUserYamlValidation(BaseTestCase):
                 {
                     "bundle_analysis": {
                         "status": True,
-                        "bundle_change_threshold": ("absolute", 10000),
+                        # "bundle_change_threshold": ("absolute", 10000),
+                        "bundle_change_threshold": 10000,
                     }
                 },
                 id="status_on_absolute_threshold",

--- a/tests/unit/validation/test_validation.py
+++ b/tests/unit/validation/test_validation.py
@@ -838,6 +838,7 @@ class TestUserYamlValidation(BaseTestCase):
                 {
                     "comment": {
                         "require_bundle_changes": True,
+                        # https://github.com/codecov/engineering-team/issues/2087
                         # "bundle_change_threshold": ("absolute", 1200),
                         "bundle_change_threshold": 1200,
                     }
@@ -854,6 +855,7 @@ class TestUserYamlValidation(BaseTestCase):
                 {
                     "comment": {
                         "require_bundle_changes": "bundle_increase",
+                        # https://github.com/codecov/engineering-team/issues/2087
                         # "bundle_change_threshold": ("absolute", 1000000),
                         "bundle_change_threshold": 1000000,
                     }
@@ -870,6 +872,7 @@ class TestUserYamlValidation(BaseTestCase):
                 {
                     "comment": {
                         "require_bundle_changes": "bundle_increase",
+                        # https://github.com/codecov/engineering-team/issues/2087
                         # "bundle_change_threshold": ("percentage", 10.0),
                         "bundle_change_threshold": 10.0,
                     }
@@ -896,6 +899,7 @@ class TestUserYamlValidation(BaseTestCase):
                 {
                     "bundle_analysis": {
                         "status": False,
+                        # https://github.com/codecov/engineering-team/issues/2087
                         # "bundle_change_threshold": ("percentage", 10.0),
                         "bundle_change_threshold": 10.0,
                     }
@@ -912,6 +916,7 @@ class TestUserYamlValidation(BaseTestCase):
                 {
                     "bundle_analysis": {
                         "status": True,
+                        # https://github.com/codecov/engineering-team/issues/2087
                         # "bundle_change_threshold": ("absolute", 10000),
                         "bundle_change_threshold": 10000,
                     }


### PR DESCRIPTION
context: https://github.com/codecov/engineering-team/issues/2223

it seems that we get a validation error when trying to coerce the bundle_analysis threshold.
I can only assume it's the use of DJango database from an async context, so removing that.
