### PR TITLE
chore: rename bundle_analysis.bundle_analysis_threshold

### DIFF
--- a/shared/validation/user_schema.py
+++ b/shared/validation/user_schema.py
@@ -214,7 +214,7 @@ bundle_analysis_comment_config = {
     "bundle_change_threshold": {
         "coerce": "bundle_analysis_threshold",
         "meta": {
-            "description": "Threshold for 'require_bundle_changes'. Notifications will only be triggered if the change is larger than the threshold. Can also be configured using bundle_analysis.bundle_change_threshold"
+            "description": "Threshold for 'require_bundle_changes'. Notifications will only be triggered if the change is larger than the threshold."
         },
     },
 }
@@ -430,10 +430,10 @@ schema = {
     "bundle_analysis": {
         "type": "dict",
         "schema": {
-            "bundle_change_threshold": {
+            "warning_threshold": {
                 "coerce": "bundle_analysis_threshold",
                 "meta": {
-                    "description": "Notifications will only be triggered if the change is larger than the threshold."
+                    "description": "If the change is bigger then the threshold notification includes a warning or fails. See `bundle_analysis.status` for details."
                 },
             },
             "status": {
@@ -443,12 +443,15 @@ schema = {
                     "options": {
                         True: {
                             "type": bool,
-                            "description": "Enable status. Status can fail.",
+                            "description": "Enable status. Status will fail if changes exceed `bundle_analysis.warning_threshold`",
                         },
-                        False: {"type": bool, "description": "Disable status."},
+                        False: {
+                            "type": bool,
+                            "description": "Disable status. No status will be sent.",
+                        },
                         "informational": {
                             "type": str,
-                            "description": "Enable status. Status will always be success.",
+                            "description": "Enable status. Status will always pass, but include a warning if changes exceed `bundle_analysis.warning_threshold`",
                             "default": True,
                         },
                     },

--- a/tests/unit/validation/test_validation.py
+++ b/tests/unit/validation/test_validation.py
@@ -893,15 +893,15 @@ class TestUserYamlValidation(BaseTestCase):
                 {
                     "bundle_analysis": {
                         "status": False,
-                        "bundle_change_threshold": "10%",
+                        "warning_threshold": "10%",
                     }
                 },
                 {
                     "bundle_analysis": {
                         "status": False,
                         # https://github.com/codecov/engineering-team/issues/2087
-                        # "bundle_change_threshold": ("percentage", 10.0),
-                        "bundle_change_threshold": 10.0,
+                        # "warning_threshold": ("percentage", 10.0),
+                        "warning_threshold": 10.0,
                     }
                 },
                 id="status_off_percentage_threshold",
@@ -910,15 +910,15 @@ class TestUserYamlValidation(BaseTestCase):
                 {
                     "bundle_analysis": {
                         "status": True,
-                        "bundle_change_threshold": "10kb",
+                        "warning_threshold": "10kb",
                     }
                 },
                 {
                     "bundle_analysis": {
                         "status": True,
                         # https://github.com/codecov/engineering-team/issues/2087
-                        # "bundle_change_threshold": ("absolute", 10000),
-                        "bundle_change_threshold": 10000,
+                        # "warning_threshold": ("absolute", 10000),
+                        "warning_threshold": 10000,
                     }
                 },
                 id="status_on_absolute_threshold",


### PR DESCRIPTION
There were 2 configs with the same name: `comment.bundle_analysis_threshold`
and `bundle_analysis.bundle_analysis_threshold`. They are similar but will be kept
separate. One is the threshold to create a comment, the other to emit warnings or fail
a status.

To help differentiate them we are renaming one. Because `comment.bundle_analysis_threshold` is already used it's easier to rename the other one.
