### PR TITLE
fix: unpickleable exception

### DIFF
--- a/shared/github/__init__.py
+++ b/shared/github/__init__.py
@@ -44,7 +44,7 @@ InstallationErrorCause = Literal["installation_not_found"] | Literal["permission
 
 class InvalidInstallationError(Exception):
     def __init__(self, error_cause: InstallationErrorCause, *args: object) -> None:
-        super().__init__(*args)
+        super().__init__(error_cause, *args)
         self.error_cause = error_cause
 
 

--- a/tests/unit/github/test_github_installation_helpers.py
+++ b/tests/unit/github/test_github_installation_helpers.py
@@ -1,3 +1,4 @@
+import pickle
 from time import time
 from unittest.mock import patch
 
@@ -5,8 +6,15 @@ import pytest
 from freezegun import freeze_time
 
 # This import here avoids a circular import issue
-from shared.github import get_github_jwt_token, get_pem
+from shared.github import InvalidInstallationError, get_github_jwt_token, get_pem
 from shared.utils.test_utils import mock_config_helper
+
+
+def test_can_unpickle_invalid_installation_error():
+    exception = InvalidInstallationError("permission_error")
+    pickled = pickle.dumps(exception)
+    unpickled = pickle.loads(pickled)
+    assert str(unpickled) == str(exception)
 
 
 @patch("shared.github.load_pem_from_path")


### PR DESCRIPTION
It seems that `celery` unpickles exceptions for some reason.
I suppose it can't do that with `InvalidInstallationError` because I was not passing all args.
Indeed the full log error is
`UnpickleableExceptionWrapper('shared.github', 'InvalidInstallationError', (), 'InvalidInstallationError()')`

Where we see it trying to create the exception with a `()` (empty tuple) for args.
Passing all args should fix this, I hope.
