### PR TITLE
bundle analysis: save custom compare sha to metadata

### DIFF
--- a/shared/bundle_analysis/models.py
+++ b/shared/bundle_analysis/models.py
@@ -112,7 +112,6 @@ class LegacySessionManager:
 
     def __exit__(self, type, value, traceback):
         self.session.close()
-        return True
 
 
 def _use_modern_sqlalchemy_session_manager():

--- a/shared/bundle_analysis/parsers/v1.py
+++ b/shared/bundle_analysis/parsers/v1.py
@@ -91,7 +91,7 @@ class ParserV1:
         self.chunk_list = []
         self.module_list = []
 
-    def parse(self, path: str) -> int:
+    def parse(self, path: str) -> Tuple[int, str]:
         try:
             self.reset()
 
@@ -152,7 +152,7 @@ class ParserV1:
                 self._create_associations()
 
                 assert self.session.bundle is not None
-                return self.session.id
+                return self.session.id, self.session.bundle.name
         except Exception as e:
             # Inject the plugin name to the Exception object so we have visibilitity on which plugin
             # is causing the trouble.

--- a/shared/bundle_analysis/parsers/v2.py
+++ b/shared/bundle_analysis/parsers/v2.py
@@ -92,7 +92,7 @@ class ParserV2:
         self.chunk_list = []
         self.module_list = []
 
-    def parse(self, path: str) -> int:
+    def parse(self, path: str) -> Tuple[int, str]:
         try:
             self.reset()
 
@@ -153,7 +153,7 @@ class ParserV2:
                 self._create_associations()
 
                 assert self.session.bundle is not None
-                return self.session.id
+                return self.session.id, self.session.bundle.name
         except Exception as e:
             # Inject the plugin name to the Exception object so we have visibilitity on which plugin
             # is causing the trouble.

--- a/shared/bundle_analysis/parsers/v2.py
+++ b/shared/bundle_analysis/parsers/v2.py
@@ -110,20 +110,6 @@ class ParserV2:
                 for event in ijson.parse(f):
                     self._parse_event(event)
 
-                if self.asset_list:
-                    insert_asset = Asset.__table__.insert().values(self.asset_list)
-                    self.db_session.execute(insert_asset)
-
-                if self.chunk_list:
-                    insert_chunks = Chunk.__table__.insert().values(self.chunk_list)
-                    self.db_session.execute(insert_chunks)
-
-                if self.module_list:
-                    insert_modules = Module.__table__.insert().values(self.module_list)
-                    self.db_session.execute(insert_modules)
-
-                self.db_session.flush()
-
                 # Delete old session/asset/chunk/module with the same bundle name if applicable
                 old_session = (
                     self.db_session.query(Session)
@@ -143,6 +129,20 @@ class ParserV2:
                             self.db_session.flush()
                     self.db_session.delete(old_session)
                     self.db_session.flush()
+
+                if self.asset_list:
+                    insert_asset = Asset.__table__.insert().values(self.asset_list)
+                    self.db_session.execute(insert_asset)
+
+                if self.chunk_list:
+                    insert_chunks = Chunk.__table__.insert().values(self.chunk_list)
+                    self.db_session.execute(insert_chunks)
+
+                if self.module_list:
+                    insert_modules = Module.__table__.insert().values(self.module_list)
+                    self.db_session.execute(insert_modules)
+
+                self.db_session.flush()
 
                 # save top level bundle stats info
                 self.session.info = json.dumps(self.info)


### PR DESCRIPTION
Also have the ingester return the bundle name of the parsed bundle file, this is an optimization for worker to save BA measurements data.

Note: only merge this when the worker PR to match the new ingest function signature is ready to be merged.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.