### PR TITLE
fix: configure cache for installation tokens

### DIFF
--- a/shared/bots/github_apps.py
+++ b/shared/bots/github_apps.py
@@ -13,8 +13,8 @@ from shared.django_apps.codecov_auth.models import (
 )
 from shared.django_apps.core.models import Repository
 from shared.github import get_github_integration_token, is_installation_rate_limited
+from shared.helpers.redis import get_redis_connection
 from shared.orms.owner_helper import DjangoSQLAlchemyOwnerWrapper
-from shared.torngit.cache import get_redis_connection
 from shared.typings.oauth_token_types import Token
 from shared.typings.torngit import GithubInstallationInfo
 

--- a/shared/bots/helpers.py
+++ b/shared/bots/helpers.py
@@ -5,15 +5,20 @@ from shared.bots.exceptions import RepositoryWithoutValidBotError
 from shared.config import get_config
 from shared.github import InvalidInstallationError
 from shared.github import get_github_integration_token as _get_github_integration_token
-from shared.helpers.cache import OurOwnCache
+from shared.helpers.cache import OurOwnCache, RedisBackend
+from shared.helpers.redis import get_redis_connection
 from shared.torngit.base import TokenType
 from shared.typings.oauth_token_types import Token
 
 cache = OurOwnCache()
+cache.configure(RedisBackend(get_redis_connection()), app="shared.installation_tokens")
+
 log = logging.getLogger(__name__)
 
 
-@cache.cache_function(ttl=480)
+# The integration tokens are valid for 1h
+# We use 30min of that
+@cache.cache_function(ttl=1800)
 def get_github_integration_token(
     service: str,
     installation_id: int = None,

--- a/shared/django_apps/legacy_migrations/management/commands/migrate.py
+++ b/shared/django_apps/legacy_migrations/management/commands/migrate.py
@@ -7,7 +7,7 @@ from django.db import transaction as django_transaction
 from django.db.utils import ProgrammingError
 
 from shared.django_apps.utils.config import RUN_ENV
-from shared.torngit.cache import get_redis_connection
+from shared.helpers.redis import get_redis_connection
 
 log = logging.getLogger(__name__)
 

--- a/shared/helpers/redis.py
+++ b/shared/helpers/redis.py
@@ -1,0 +1,21 @@
+from redis import Redis
+
+from shared.config import get_config
+
+
+def get_redis_url() -> str:
+    url = get_config("services", "redis_url")
+    if url is not None:
+        return url
+    hostname = "redis"
+    port = 6379
+    return f"redis://{hostname}:{port}"
+
+
+def get_redis_connection() -> Redis:
+    url = get_redis_url()
+    return _get_redis_instance_from_url(url)
+
+
+def _get_redis_instance_from_url(url):
+    return Redis.from_url(url)

--- a/shared/torngit/cache/__init__.py
+++ b/shared/torngit/cache/__init__.py
@@ -5,25 +5,7 @@ from typing_extensions import Literal
 
 from shared.config import get_config
 from shared.helpers.cache import OurOwnCache, RedisBackend
-
-
-def get_redis_url() -> str:
-    url = get_config("services", "redis_url")
-    if url is not None:
-        return url
-    hostname = "redis"
-    port = 6379
-    return f"redis://{hostname}:{port}"
-
-
-def get_redis_connection() -> Redis:
-    url = get_redis_url()
-    return _get_redis_instance_from_url(url)
-
-
-def _get_redis_instance_from_url(url):
-    return Redis.from_url(url)
-
+from shared.helpers.redis import get_redis_url
 
 CachedEndpoint = Union[Literal["check"], Literal["compare"], Literal["status"]]
 

--- a/shared/torngit/github.py
+++ b/shared/torngit/github.py
@@ -17,10 +17,11 @@ from shared.github import (
     get_github_jwt_token,
     mark_installation_as_rate_limited,
 )
+from shared.helpers.redis import get_redis_connection
 from shared.metrics import Counter, metrics
 from shared.rollouts.features import LIST_REPOS_PAGE_SIZE
 from shared.torngit.base import TokenType, TorngitBaseAdapter
-from shared.torngit.cache import get_redis_connection, torngit_cache
+from shared.torngit.cache import torngit_cache
 from shared.torngit.enums import Endpoints
 from shared.torngit.exceptions import (
     TorngitClientError,

--- a/tests/unit/helpers/test_redis.py
+++ b/tests/unit/helpers/test_redis.py
@@ -1,0 +1,12 @@
+from shared.helpers.redis import get_redis_url
+
+
+def test_get_redis_default():
+    assert get_redis_url() == "redis://redis:6379"
+
+
+def test_get_redis_from_url(mock_configuration):
+    mock_configuration.set_params(
+        {"services": {"redis_url": "https://my-redis-instance:6378"}}
+    )
+    assert get_redis_url() == "https://my-redis-instance:6378"

--- a/tests/unit/rate_limits/test_rate_limit.py
+++ b/tests/unit/rate_limits/test_rate_limit.py
@@ -9,12 +9,12 @@ from shared.django_apps.codecov_auth.models import (
 )
 from shared.django_apps.codecov_auth.tests.factories import OwnerFactory
 from shared.django_apps.core.tests.factories import RepositoryFactory
+from shared.helpers.redis import get_redis_connection
 from shared.rate_limits import (
     determine_entity_redis_key,
     determine_if_entity_is_rate_limited,
     set_entity_to_rate_limited,
 )
-from shared.torngit.cache import get_redis_connection
 
 
 @pytest.fixture

--- a/tests/unit/torngit/test_cache.py
+++ b/tests/unit/torngit/test_cache.py
@@ -1,16 +1,5 @@
 from shared.helpers.cache import NullBackend, RedisBackend
-from shared.torngit.cache import get_redis_url, torngit_cache
-
-
-def test_get_redis_default():
-    assert get_redis_url() == "redis://redis:6379"
-
-
-def test_get_redis_from_url(mock_configuration):
-    mock_configuration.set_params(
-        {"services": {"redis_url": "https://my-redis-instance:6378"}}
-    )
-    assert get_redis_url() == "https://my-redis-instance:6378"
+from shared.torngit.cache import torngit_cache
 
 
 class TestTorngitCacheConfig(object):


### PR DESCRIPTION
The function that gets installation tokens is cached so we don't ask for them so often.
However the cache was not being initialized.

SO the increase in requests is probably being interpreted by GitHub as rate limit violation and now we are getting 403s left and right :E

These changes configure the cache (I had to move some redis funcitons) and extends the timeout to 30minutes. THe [docs](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-an-installation-access-token-for-a-github-app) say they expire after 1h, so this should be safe to do.
