### PR TITLE
bundle analysis: compare base commit with pre commit merge SHA

### DIFF
--- a/shared/bundle_analysis/comparison.py
+++ b/shared/bundle_analysis/comparison.py
@@ -15,7 +15,7 @@ from shared.bundle_analysis.storage import BundleAnalysisReportLoader
 from shared.django_apps.core.models import Repository
 from shared.django_apps.reports.models import CommitReport
 
-log = logging.getLogger("__name__")
+log = logging.getLogger(__name__)
 
 
 class MissingBaseReportError(Exception):

--- a/shared/bundle_analysis/comparison.py
+++ b/shared/bundle_analysis/comparison.py
@@ -193,7 +193,10 @@ class BundleAnalysisComparison:
             self.base_report_key = compare_sha_external_id
 
     def _check_compare_sha(self, repository: Repository) -> Optional[str]:
-        # Doing custom base compare SHA comparisons
+        """
+        When doing comparisons first check if there is a compare_sha set in the head report,
+        if there is use that commitid to load the base commit report to compare the head to.
+        """
         try:
             head_report_compare_sha = self.head_report.metadata().get(
                 MetadataKey.COMPARE_SHA

--- a/shared/bundle_analysis/comparison.py
+++ b/shared/bundle_analysis/comparison.py
@@ -188,6 +188,11 @@ class BundleAnalysisComparison:
         self.base_report_key = base_report_key
         self.head_report_key = head_report_key
 
+        compare_sha_external_id = self._check_compare_sha(repository)
+        if compare_sha_external_id:
+            self.base_report_key = compare_sha_external_id
+
+    def _check_compare_sha(self, repository: Repository) -> Optional[str]:
         # Doing custom base compare SHA comparisons
         try:
             head_report_compare_sha = self.head_report.metadata().get(
@@ -200,7 +205,7 @@ class BundleAnalysisComparison:
                     report_type=CommitReport.ReportType.BUNDLE_ANALYSIS,
                 ).first()
                 if base_report:
-                    self.base_report_key = base_report.external_id
+                    return base_report.external_id
                 else:
                     log.warning(
                         f"Bundle Analysis compare SHA not found in reports for {head_report_compare_sha}"

--- a/shared/bundle_analysis/comparison.py
+++ b/shared/bundle_analysis/comparison.py
@@ -193,9 +193,6 @@ class BundleAnalysisComparison:
             head_report_compare_sha = self.head_report.metadata().get(
                 MetadataKey.COMPARE_SHA
             )
-            print(
-                "[SHARED] doing custom comp? SHA:", head_report_compare_sha, repository
-            )
             if head_report_compare_sha and repository:
                 base_report = CommitReport.objects.filter(
                     commit__commitid=head_report_compare_sha,

--- a/shared/bundle_analysis/models.py
+++ b/shared/bundle_analysis/models.py
@@ -277,3 +277,4 @@ class Module(Base):
 
 class MetadataKey(Enum):
     SCHEMA_VERSION = "schema_version"
+    COMPARE_SHA = "compare_sha"

--- a/shared/bundle_analysis/report.py
+++ b/shared/bundle_analysis/report.py
@@ -239,12 +239,14 @@ class BundleAnalysisReport:
 
             # Save custom base commit SHA for doing comparisons if available
             if compare_sha:
-                session.add(
-                    Metadata(
-                        key="compare_sha",
-                        value=compare_sha,
-                    )
+                sql = text("""
+                    INSERT OR REPLACE INTO metadata (key, value)
+                    VALUES (:key, :value)
+                """)
+                session.execute(
+                    sql, {"key": "compare_sha", "value": json.dumps(compare_sha)}
                 )
+                session.commit()
 
             session.commit()
             return session_id, bundle_name


### PR DESCRIPTION
When doing comparisons first check if there is a compare_sha set in the head report, if there is use that commitid to load the base commit report to compare the head to.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.