### PR TITLE
chore: adding more causes for InvalidInstallationError

### DIFF
--- a/tests/integration/test_bots.py
+++ b/tests/integration/test_bots.py
@@ -9,6 +9,7 @@ from shared.django_apps.codecov_auth.models import (
     GithubAppInstallation,
 )
 from shared.django_apps.core.tests.factories import RepositoryFactory
+from shared.github import InvalidInstallationError
 
 fake_private_key = """-----BEGIN RSA PRIVATE KEY-----
 MIICXAIBAAKBgQDCFqq2ygFh9UQU/6PoDJ6L9e4ovLPCHtlBt7vzDwyfwr3XGxln
@@ -71,6 +72,6 @@ class TestRepositoryServiceIntegration(object):
         )
         app.save()
         assert list(repo.author.github_app_installations.all()) == [app]
-        with pytest.raises(requests.exceptions.HTTPError):
+        with pytest.raises(InvalidInstallationError):
             info = get_github_app_info_for_owner(repo.author)
             get_repo_appropriate_bot_token(repo, info[0])

--- a/tests/unit/test_github.py
+++ b/tests/unit/test_github.py
@@ -243,7 +243,7 @@ class TestGithubSpecificLogic(object):
         mocker.patch("shared.github.get_pem", return_value=fake_private_key)
         with pytest.raises(InvalidInstallationError) as exp:
             get_github_integration_token(service, integration_id)
-        assert exp.value.error_cause == "permission_error"
+        assert exp.value.error_cause == "installation_suspended"
         mocked_post.assert_called_with(
             "https://api.github.com/app/installations/1/access_tokens",
             headers={


### PR DESCRIPTION
We are still being hit by many invalid installation errors.
The `permission_error` real cause is still not unclear. At first the suspicion
was suspended apps, but that is not the whole story (from empirical data).

I suspected rate limit errors, and we discovered an unconfigured cache at some point.
That has been remedied but the errors are still going strong.

These changes attempt to further breakdown the responses we get to help with debugging.
Mostly it will verify if the issue is indeed with rate limit or not.
