### PR TITLE
chore: mark suspended apps so

### DIFF
--- a/shared/bots/github_apps.py
+++ b/shared/bots/github_apps.py
@@ -12,7 +12,11 @@ from shared.django_apps.codecov_auth.models import (
     Service,
 )
 from shared.django_apps.core.models import Repository
-from shared.github import get_github_integration_token, is_installation_rate_limited
+from shared.github import (
+    InvalidInstallationError,
+    get_github_integration_token,
+    is_installation_rate_limited,
+)
 from shared.helpers.redis import get_redis_connection
 from shared.orms.owner_helper import DjangoSQLAlchemyOwnerWrapper
 from shared.typings.oauth_token_types import Token
@@ -117,16 +121,29 @@ def get_github_app_token(
 ) -> TokenWithOwner:
     """Get an access_token from GitHub that we can use to authenticate as the installation
     See https://docs.github.com/en/enterprise-server@3.9/apps/creating-github-apps/authenticating-with-a-github-app/authenticating-as-a-github-app-installation#generating-an-installation-access-token
+
+    ⚠️ side effect: Marks installation as `suspended` if we fail to get the access_token due to "installation_suspended"
+
+    Raises:
+      InvalidInstallationError: if we can't get the installation's access_token
     """
-    github_token = get_github_integration_token(
-        service.value,
-        installation_info["installation_id"],
-        app_id=installation_info.get("app_id", None),
-        pem_path=installation_info.get("pem_path", None),
-    )
-    installation_token = Token(key=github_token)
-    # The token is not owned by an Owner object, so 2nd arg is None
-    return installation_token, None
+    try:
+        github_token = get_github_integration_token(
+            service.value,
+            installation_info["installation_id"],
+            app_id=installation_info.get("app_id", None),
+            pem_path=installation_info.get("pem_path", None),
+        )
+        installation_token = Token(key=github_token)
+        # The token is not owned by an Owner object, so 2nd arg is None
+        return installation_token, None
+    except InvalidInstallationError as err:
+        if err.error_cause == "installation_suspended":
+            # Mark the installation as suspended so we don't keep trying to get the token for it
+            GithubAppInstallation.objects.filter(id=installation_info["id"]).update(
+                is_suspended=True
+            )
+        raise err
 
 
 def get_specific_github_app_details(

--- a/tests/integration/test_bots.py
+++ b/tests/integration/test_bots.py
@@ -1,5 +1,4 @@
 import pytest
-import requests
 
 from shared.bots.exceptions import RepositoryWithoutValidBotError
 from shared.bots.github_apps import get_github_app_info_for_owner

--- a/tests/unit/bots/test_github_apps.py
+++ b/tests/unit/bots/test_github_apps.py
@@ -5,37 +5,53 @@ import pytest
 from shared.bots.exceptions import NoConfiguredAppsAvailable, RequestedGithubAppNotFound
 from shared.bots.github_apps import (
     get_github_app_info_for_owner,
+    get_github_app_token,
     get_specific_github_app_details,
 )
 from shared.django_apps.codecov_auth.models import (
     GITHUB_APP_INSTALLATION_DEFAULT_NAME,
     GithubAppInstallation,
+    Owner,
+    Service,
 )
 from shared.django_apps.codecov_auth.tests.factories import OwnerFactory
+from shared.github import InvalidInstallationError
 from shared.typings.torngit import GithubInstallationInfo
 
 
-class TestGetSpecificGithubAppDetails(object):
-    def _get_owner_with_apps(self):
-        owner = OwnerFactory(service="github")
-        app_1 = GithubAppInstallation(
-            owner=owner,
-            installation_id=1200,
-            app_id=12,
-        )
-        app_2 = GithubAppInstallation(
-            owner=owner,
-            installation_id=1500,
-            app_id=15,
-            pem_path="some_path",
-        )
-        GithubAppInstallation.objects.bulk_create([app_1, app_2])
-        assert list(owner.github_app_installations.all()) == [app_1, app_2]
-        return owner
+def _get_owner_with_apps() -> Owner:
+    owner = OwnerFactory(service="github")
+    app_1 = GithubAppInstallation(
+        owner=owner,
+        installation_id=1200,
+        app_id=12,
+    )
+    app_2 = GithubAppInstallation(
+        owner=owner,
+        installation_id=1500,
+        app_id=15,
+        pem_path="some_path",
+    )
+    GithubAppInstallation.objects.bulk_create([app_1, app_2])
+    assert list(owner.github_app_installations.all()) == [app_1, app_2]
+    return owner
 
+
+def _to_installation_info(
+    installation: GithubAppInstallation,
+) -> GithubInstallationInfo:
+    return GithubInstallationInfo(
+        id=installation.id,
+        installation_id=installation.installation_id,
+        pem_path=installation.pem_path,
+        app_id=installation.app_id,
+    )
+
+
+class TestGetSpecificGithubAppDetails(object):
     @pytest.mark.django_db(databases={"default"})
     def test_get_specific_github_app_details(self):
-        owner = self._get_owner_with_apps()
+        owner = _get_owner_with_apps()
         assert get_specific_github_app_details(
             owner, owner.github_app_installations.all()[0].id, "commit_id_for_logs"
         ) == GithubInstallationInfo(
@@ -55,7 +71,7 @@ class TestGetSpecificGithubAppDetails(object):
 
     @pytest.mark.django_db(databases={"default"})
     def test_get_specific_github_app_not_found(self):
-        owner = self._get_owner_with_apps()
+        owner = _get_owner_with_apps()
         with pytest.raises(RequestedGithubAppNotFound):
             get_specific_github_app_details(owner, 123456, "commit_id_for_logs")
 
@@ -114,3 +130,54 @@ class TestGetSpecificGithubAppDetails(object):
         assert exp.value.apps_count == 1
         assert exp.value.suspended_count == int(app.is_suspended)
         assert exp.value.rate_limited_count == int(is_rate_limited)
+
+
+class TestGettingGitHubAppTokenSideEffect(object):
+    @pytest.mark.django_db(databases={"default"})
+    def test_mark_installation_suspended_side_effect(self, mocker):
+        owner = _get_owner_with_apps()
+        installations: list[GithubAppInstallation] = (
+            owner.github_app_installations.all()
+        )
+        installation_info = _to_installation_info(installations[0])
+        mocker.patch(
+            "shared.bots.github_apps.get_github_integration_token",
+            side_effect=InvalidInstallationError("installation_suspended"),
+        )
+
+        assert all(
+            [installation.is_suspended == False for installation in installations]
+        )
+
+        with pytest.raises(InvalidInstallationError):
+            get_github_app_token(Service(owner.service), installation_info)
+
+        installations[0].refresh_from_db()
+        assert installations[0].is_suspended is True
+        installations[1].refresh_from_db()
+        assert installations[1].is_suspended is False
+
+    @pytest.mark.django_db(databases={"default"})
+    def test_mark_installation_suspended_side_effect_not_called(self, mocker):
+        owner = _get_owner_with_apps()
+        installations: list[GithubAppInstallation] = (
+            owner.github_app_installations.all()
+        )
+        installation_info = _to_installation_info(installations[0])
+        mocker.patch(
+            "shared.bots.github_apps.get_github_integration_token",
+            side_effect=InvalidInstallationError("permission_error"),
+        )
+
+        assert all(
+            [installation.is_suspended == False for installation in installations]
+        )
+
+        with pytest.raises(InvalidInstallationError):
+            get_github_app_token(Service(owner.service), installation_info)
+
+        installations[0].refresh_from_db()
+        installations[1].refresh_from_db()
+        assert all(
+            [installation.is_suspended == False for installation in installations]
+        )


### PR DESCRIPTION
In commit 6637dcc392d7adde051948cb9053201fd0e9cbda we added a further breakdown
of why `InvalidInstallationError` was raised when trying to get the access_token.
In particular the body of the response tells us if the installation is suspended,
which is quite convenient.

Scrolling through the events in Sentry for that issue - [example](https://codecov.sentry.io/issues/5619600100/events/d9d0c0f6e66a43dba92e4d0021b9f0fa/?project=4165036&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=previous-event&statsPeriod=7d&stream_index=10&utc=true) - there's quite a few "installation_suspended" entries.

We do have a mechanism to mark installations as suspended, so we don't try to get tokens for those, but it relies on webhooks, and these installations were probably suspended before that was put in place.

So these changes mark installations that are suspended as suspended after we get the error.

To unsuspend an installation is a manual task done by the user in the GitHub UI. It sends us a webhook and we mark the app as unsuspended.
