### PR TITLE
334 v2 adjust installation key

### DIFF
--- a/shared/bots/github_apps.py
+++ b/shared/bots/github_apps.py
@@ -143,7 +143,7 @@ def get_github_app_token(
         # The token is not owned by an Owner object, so 2nd arg is None
         return installation_token, None
     except InvalidInstallationError as err:
-        if err.error_cause == "installation_suspended":
+        if err.error_cause == "installation_suspended" and "id" in installation_info:
             # Mark the installation as suspended so we don't keep trying to get the token for it
             GithubAppInstallation.objects.filter(id=installation_info["id"]).update(
                 is_suspended=True

--- a/shared/bots/github_apps.py
+++ b/shared/bots/github_apps.py
@@ -145,9 +145,9 @@ def get_github_app_token(
     except InvalidInstallationError as err:
         if err.error_cause == "installation_suspended":
             # Mark the installation as suspended so we don't keep trying to get the token for it
-            GithubAppInstallation.objects.filter(
-                installation_id=installation_info["installation_id"]
-            ).update(is_suspended=True)
+            GithubAppInstallation.objects.filter(id=installation_info["id"]).update(
+                is_suspended=True
+            )
         raise err
 
 

--- a/shared/bots/github_apps.py
+++ b/shared/bots/github_apps.py
@@ -145,9 +145,9 @@ def get_github_app_token(
     except InvalidInstallationError as err:
         if err.error_cause == "installation_suspended":
             # Mark the installation as suspended so we don't keep trying to get the token for it
-            GithubAppInstallation.objects.filter(id=installation_info["id"]).update(
-                is_suspended=True
-            )
+            GithubAppInstallation.objects.filter(
+                installation_id=installation_info["installation_id"]
+            ).update(is_suspended=True)
         raise err
 
 


### PR DESCRIPTION
Seeing a couple of issues in Sentry about key error, https://codecov.sentry.io/issues/?groupStatsPeriod=auto&project=4165036&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D+KeyError&referrer=issue-list&statsPeriod=3h&stream_index=6. I tracked it down to this line, https://github.com/codecov/shared/blob/114034600da5b7a3f974a5201b5c51917617bc50/shared/bots/github_apps.py#L323-L324, being called, where the GithubInstallationInfo only returns the installation_id, so I'm using that key instead of the id. I verified this key being unique from GH's side, so we can safely filter by that key. The only drawback is that the installation_id isn't indexed, so the filtering logic might take a bit more time (but we can add an index in a followup PR)

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.