### PR TITLE
reduce prefech limit

### DIFF
--- a/shared/celery_config.py
+++ b/shared/celery_config.py
@@ -164,7 +164,7 @@ class BaseCeleryConfig(object):
 
     # http://celery.readthedocs.org/en/latest/userguide/optimizing.html#prefetch-limits
     worker_prefetch_multiplier = int(
-        get_config("setup", "tasks", "celery", "prefetch", default=4)
+        get_config("setup", "tasks", "celery", "prefetch", default=1)
     )
     # !!! NEVER 0 !!! 0 == infinate
 


### PR DESCRIPTION
see docs: https://docs.celeryq.dev/en/stable/userguide/optimizing.html#prefetch-limits

We want to reudce the number of tasks that are prefetched by workers, following celery docs suggestion:

> If you have many tasks with a long duration you want the multiplier value to be one: meaning it’ll only reserve one task per worker process at a time.

Most of our tasks are long running, and we have experienced a considerable number of tasks
being "in a limbo". So reducing the number of prefetched tasks might help with that too.
