### PR TITLE
chore: clear rollout

### DIFF
--- a/shared/validation/validator.py
+++ b/shared/validation/validator.py
@@ -13,7 +13,6 @@ from shared.validation.helpers import (
     PercentSchemaField,
     UserGivenBranchRegex,
 )
-from shared.validation.types import BundleThreshold
 
 
 class CodecovYamlValidator(Validator):
@@ -48,12 +47,7 @@ class CodecovYamlValidator(Validator):
         return ByteSizeSchemaField().validate(value)
 
     def _normalize_coerce_bundle_analysis_threshold(self, value):
-        coerced_value: BundleThreshold = BundleSizeThresholdSchemaField().validate(
-            value
-        )
-        # This change is not forwards compatible, so we need to return a number for now
-        # https://github.com/codecov/engineering-team/issues/2087 to clean up later
-        return coerced_value.threshold
+        return BundleSizeThresholdSchemaField().validate(value)
 
     def _validate_comma_separated_strings(self, constraint, field, value):
         """Test the oddity of a value.

--- a/tests/unit/validation/test_validation.py
+++ b/tests/unit/validation/test_validation.py
@@ -838,9 +838,7 @@ class TestUserYamlValidation(BaseTestCase):
                 {
                     "comment": {
                         "require_bundle_changes": True,
-                        # https://github.com/codecov/engineering-team/issues/2087
-                        # "bundle_change_threshold": ("absolute", 1200),
-                        "bundle_change_threshold": 1200,
+                        "bundle_change_threshold": ("absolute", 1200),
                     }
                 },
                 id="bundle_changes_with_threshold",
@@ -855,9 +853,7 @@ class TestUserYamlValidation(BaseTestCase):
                 {
                     "comment": {
                         "require_bundle_changes": "bundle_increase",
-                        # https://github.com/codecov/engineering-team/issues/2087
-                        # "bundle_change_threshold": ("absolute", 1000000),
-                        "bundle_change_threshold": 1000000,
+                        "bundle_change_threshold": ("absolute", 1000000),
                     }
                 },
                 id="bundle_increase_required_with_threshold",
@@ -872,9 +868,7 @@ class TestUserYamlValidation(BaseTestCase):
                 {
                     "comment": {
                         "require_bundle_changes": "bundle_increase",
-                        # https://github.com/codecov/engineering-team/issues/2087
-                        # "bundle_change_threshold": ("percentage", 10.0),
-                        "bundle_change_threshold": 10.0,
+                        "bundle_change_threshold": ("percentage", 10.0),
                     }
                 },
                 id="bundle_increase_required_with_percentage_threshold",
@@ -899,9 +893,7 @@ class TestUserYamlValidation(BaseTestCase):
                 {
                     "bundle_analysis": {
                         "status": False,
-                        # https://github.com/codecov/engineering-team/issues/2087
-                        # "warning_threshold": ("percentage", 10.0),
-                        "warning_threshold": 10.0,
+                        "warning_threshold": ("percentage", 10.0),
                     }
                 },
                 id="status_off_percentage_threshold",
@@ -916,9 +908,7 @@ class TestUserYamlValidation(BaseTestCase):
                 {
                     "bundle_analysis": {
                         "status": True,
-                        # https://github.com/codecov/engineering-team/issues/2087
-                        # "warning_threshold": ("absolute", 10000),
-                        "warning_threshold": 10000,
+                        "warning_threshold": ("absolute", 10000),
                     }
                 },
                 id="status_on_absolute_threshold",


### PR DESCRIPTION
With the release of the `new_notify` for bundle analysis we should be OK to clean the rollout.
Part of https://github.com/codecov/engineering-team/issues/2087

<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.