### PR TITLE
Remove unused `append_to_file` and `update_archive`

### DIFF
--- a/shared/api_archive/archive.py
+++ b/shared/api_archive/archive.py
@@ -141,13 +141,6 @@ class ArchiveService(object):
         self.write_file(path, stringified_data)
         return path
 
-    def update_archive(self, path, data):
-        """
-        Grabs path from storage, adds data to path object
-        writes back to path, overwriting the original contents
-        """
-        self.storage.append_to_file(self.root, path, data)
-
     @sentry_sdk.trace
     def write_file(self, path, data, reduced_redundancy=False, gzipped=False):
         """

--- a/shared/storage/aws.py
+++ b/shared/storage/aws.py
@@ -86,30 +86,6 @@ class AWSStorageService(BaseStorageService):
         )
         return True
 
-    def append_to_file(self, bucket_name, path, data):
-        """
-            Appends more content to the file `path`
-
-        Args:
-            bucket_name (str): The name of the bucket for the file lives
-            path (str): The desired path of the file
-            data (str): The data to be appended to the file
-
-        Raises:
-            NotImplementedError: If the current instance did not implement this method
-        """
-        try:
-            file_contents = "\n".join(
-                (self.read_file(bucket_name, path).decode(), data)
-            )
-        except ClientError as e:
-            if e.response["Error"]["Code"] == "NoSuchKey":
-                file_contents = data
-            else:
-                raise
-
-        return self.write_file(bucket_name=bucket_name, path=path, data=file_contents)
-
     def read_file(self, bucket_name, path, file_obj=None):
         """Reads the content of a file
 

--- a/shared/storage/base.py
+++ b/shared/storage/base.py
@@ -46,21 +46,6 @@ class BaseStorageService(object):
         """
         raise NotImplementedError()
 
-    def append_to_file(self, bucket_name, path, data):
-        """
-            Appends more content to the file `path`
-            (What happens if the file doesn't exist?)
-
-        Args:
-            bucket_name (str): The name of the bucket for the file lives
-            path (str): The desired path of the file
-            data (str): The data to be appended to the file
-
-        Raises:
-            NotImplementedError: If the current instance did not implement this method
-        """
-        raise NotImplementedError()
-
     def read_file(self, bucket_name, path, file_obj=None):
         """Reads the content of a file
 

--- a/shared/storage/fallback.py
+++ b/shared/storage/fallback.py
@@ -44,20 +44,6 @@ class StorageWithFallbackService(BaseStorageService):
             is_already_gzipped=is_already_gzipped,
         )
 
-    def append_to_file(self, bucket_name, path, data):
-        """
-            Appends more content to the file `path`
-
-        Args:
-            bucket_name (str): The name of the bucket for the file lives
-            path (str): The desired path of the file
-            data (str): The data to be appended to the file
-
-        Raises:
-            NotImplementedError: If the current instance did not implement this method
-        """
-        return self.main_service.append_to_file(bucket_name, path, data)
-
     def read_file(self, bucket_name, path, file_obj=None):
         """Reads the content of a file
 

--- a/shared/storage/gcp.py
+++ b/shared/storage/gcp.py
@@ -84,30 +84,6 @@ class GCPStorageService(BaseStorageService):
             blob.upload_from_file(data)
             return True
 
-    def append_to_file(self, bucket_name, path, data):
-        """
-            Appends more content to the file `path`
-            (What happens if the file doesn't exist?)
-
-            Note that this method assumes some non-bytes and instead decodable structure
-                at the file
-
-        Args:
-            bucket_name (str): The name of the bucket for the file lives
-            path (str): The desired path of the file
-            data (str): The data to be appended to the file
-
-        Raises:
-            NotImplementedError: If the current instance did not implement this method
-        """
-        try:
-            file_contents = "\n".join(
-                (self.read_file(bucket_name, path).decode(), data)
-            )
-        except FileNotInStorageError:
-            file_contents = data
-        return self.write_file(bucket_name, path, file_contents)
-
     def read_file(self, bucket_name, path, file_obj=None, *, retry=0):
         """Reads the content of a file
 

--- a/shared/storage/memory.py
+++ b/shared/storage/memory.py
@@ -69,27 +69,6 @@ class MemoryStorageService(BaseStorageService):
             self.storage[bucket_name][path] = data.read()
         return True
 
-    def append_to_file(self, bucket_name, path, data):
-        """
-            Appends more content to the file `path`
-            (What happens if the file doesn't exist?)
-
-        Args:
-            bucket_name (str): The name of the bucket for the file lives
-            path (str): The desired path of the file
-            data (str): The data to be appended to the file
-
-        Raises:
-            NotImplementedError: If the current instance did not implement this method
-        """
-        if isinstance(data, str):
-            data = data.encode()
-        if path not in self.storage[bucket_name]:
-            return self.write_file(bucket_name, path, data)
-        else:
-            new_content = b"\n".join([self.storage[bucket_name].get(path, b""), data])
-            return self.write_file(bucket_name, path, new_content)
-
     def read_file(self, bucket_name, path, file_obj=None):
         """Reads the content of a file
 

--- a/shared/storage/minio.py
+++ b/shared/storage/minio.py
@@ -195,21 +195,6 @@ class MinioStorageService(BaseStorageService):
         except MinioException:
             raise
 
-    """
-        Retrieves object from path, appends data, writes back to path.
-    """
-
-    def append_to_file(self, bucket_name, path, data):
-        try:
-            file_contents = "\n".join(
-                (self.read_file(bucket_name, path).decode(), data)
-            )
-        except FileNotInStorageError:
-            file_contents = data
-        except MinioException:
-            raise
-        return self.write_file(bucket_name, path, file_contents)
-
     def read_file(self, bucket_name, path, file_obj=None):
         try:
             res = self.minio_client.get_object(bucket_name, path)

--- a/tests/unit/storage/test_aws.py
+++ b/tests/unit/storage/test_aws.py
@@ -81,19 +81,6 @@ class TestAWSStorageService(BaseTestCase):
         reading_result = storage.read_file(bucket_name=bucket_name, path=path)
         assert reading_result.decode() == data
 
-    def test_write_then_append_then_read_file(self, codecov_vcr):
-        storage = AWSStorageService(aws_config)
-        path = "test_write_then_append_then_read_file/result"
-        data = "lorem ipsum dolor test_write_then_read_file á"
-        second_data = "mom, look at me, appending data"
-        bucket_name = "felipearchivetest"
-        writing_result = storage.write_file(bucket_name, path, data)
-        assert writing_result
-        second_writing_result = storage.append_to_file(bucket_name, path, second_data)
-        assert second_writing_result
-        reading_result = storage.read_file(bucket_name, path)
-        assert reading_result.decode() == "\n".join([data, second_data])
-
     def test_delete_file(self, codecov_vcr):
         storage = AWSStorageService(aws_config)
         path = "test_delete_file/result2"

--- a/tests/unit/storage/test_fallback.py
+++ b/tests/unit/storage/test_fallback.py
@@ -90,29 +90,6 @@ class TestFallbackStorageService(BaseTestCase):
         reading_result = storage.read_file(bucket_name, path)
         assert reading_result.decode() == data
 
-    def test_write_then_append_then_read_file(self, codecov_vcr, storage_service):
-        storage = storage_service
-        path = "test_write_then_append_then_read_file/result"
-        data = "lorem ipsum dolor test_write_then_read_file á"
-        second_data = "mom, look at me, appending data"
-        bucket_name = "testingarchive20190210001"
-        writing_result = storage.write_file(bucket_name, path, data)
-        second_writing_result = storage.append_to_file(bucket_name, path, second_data)
-        assert writing_result
-        assert second_writing_result
-        reading_result = storage.read_file(bucket_name, path)
-        assert reading_result.decode() == "\n".join([data, second_data])
-
-    def test_append_to_non_existing_file(self, request, codecov_vcr, storage_service):
-        storage = storage_service
-        path = f"{request.node.name}/result.txt"
-        second_data = "mom, look at me, appending data"
-        bucket_name = "testingarchive20190210001"
-        second_writing_result = storage.append_to_file(bucket_name, path, second_data)
-        assert second_writing_result
-        reading_result = storage.read_file(bucket_name, path)
-        assert reading_result.decode() == second_data
-
     def test_read_file_does_not_exist(self, request, codecov_vcr, storage_service):
         storage = storage_service
         path = f"{request.node.name}/does_not_exist.txt"

--- a/tests/unit/storage/test_gcp.py
+++ b/tests/unit/storage/test_gcp.py
@@ -116,29 +116,6 @@ class TestGCPStorateService(BaseTestCase):
             reading_result.decode() == "lorem ipsum dolor test_write_then_read_file á"
         )
 
-    def test_write_then_append_then_read_file(self, codecov_vcr):
-        storage = GCPStorageService(gcp_config)
-        path = "test_write_then_append_then_read_file/result"
-        data = "lorem ipsum dolor test_write_then_read_file á"
-        second_data = "mom, look at me, appending data"
-        bucket_name = "testingarchive02"
-        writing_result = storage.write_file(bucket_name, path, data)
-        second_writing_result = storage.append_to_file(bucket_name, path, second_data)
-        assert writing_result
-        assert second_writing_result
-        reading_result = storage.read_file(bucket_name, path)
-        assert reading_result.decode() == "\n".join([data, second_data])
-
-    def test_append_to_non_existing_file(self, request, codecov_vcr):
-        storage = GCPStorageService(gcp_config)
-        path = f"{request.node.name}/result.txt"
-        second_data = "mom, look at me, appending data"
-        bucket_name = "testingarchive02"
-        second_writing_result = storage.append_to_file(bucket_name, path, second_data)
-        assert second_writing_result
-        reading_result = storage.read_file(bucket_name, path)
-        assert reading_result.decode() == second_data
-
     def test_read_file_does_not_exist(self, request, codecov_vcr):
         storage = GCPStorageService(gcp_config)
         path = f"{request.node.name}/does_not_exist.txt"

--- a/tests/unit/storage/test_memory.py
+++ b/tests/unit/storage/test_memory.py
@@ -57,29 +57,6 @@ class TestMemoryStorageService(BaseTestCase):
         with open(local_path, "rb") as f:
             assert f.read().decode() == data
 
-    def test_write_then_append_then_read_file(self, codecov_vcr):
-        storage = MemoryStorageService(minio_config)
-        path = "test_write_then_append_then_read_file/result"
-        data = "lorem ipsum dolor test_write_then_read_file á"
-        second_data = "mom, look at me, appending data"
-        bucket_name = "thiagoarchivetest"
-        writing_result = storage.write_file(bucket_name, path, data)
-        second_writing_result = storage.append_to_file(bucket_name, path, second_data)
-        assert writing_result
-        assert second_writing_result
-        reading_result = storage.read_file(bucket_name, path)
-        assert reading_result.decode() == "\n".join([data, second_data])
-
-    def test_append_to_non_existing_file(self, request, codecov_vcr):
-        storage = MemoryStorageService(minio_config)
-        path = f"{request.node.name}/result.txt"
-        second_data = "mom, look at me, appending data"
-        bucket_name = "thiagoarchivetest"
-        second_writing_result = storage.append_to_file(bucket_name, path, second_data)
-        assert second_writing_result
-        reading_result = storage.read_file(bucket_name, path)
-        assert reading_result.decode() == second_data
-
     def test_read_file_does_not_exist(self, request, codecov_vcr):
         storage = MemoryStorageService(minio_config)
         path = f"{request.node.name}/does_not_exist.txt"

--- a/tests/unit/storage/test_minio.py
+++ b/tests/unit/storage/test_minio.py
@@ -60,29 +60,6 @@ class TestMinioStorageService(BaseTestCase):
         with open(local_path, "rb") as f:
             assert f.read().decode() == data
 
-    def test_write_then_append_then_read_file(self, codecov_vcr):
-        storage = MinioStorageService(minio_config)
-        path = "test_write_then_append_then_read_file/result"
-        data = "lorem ipsum dolor test_write_then_read_file á"
-        second_data = "mom, look at me, appending data"
-        bucket_name = "archivetest"
-        writing_result = storage.write_file(bucket_name, path, data)
-        second_writing_result = storage.append_to_file(bucket_name, path, second_data)
-        assert writing_result
-        assert second_writing_result
-        reading_result = storage.read_file(bucket_name, path)
-        assert reading_result.decode() == "\n".join([data, second_data])
-
-    def test_append_to_non_existing_file(self, request, codecov_vcr):
-        storage = MinioStorageService(minio_config)
-        path = f"{request.node.name}/result.txt"
-        second_data = "mom, look at me, appending data"
-        bucket_name = "archivetest"
-        second_writing_result = storage.append_to_file(bucket_name, path, second_data)
-        assert second_writing_result
-        reading_result = storage.read_file(bucket_name, path)
-        assert reading_result.decode() == second_data
-
     def test_read_file_does_not_exist(self, request, codecov_vcr):
         storage = MinioStorageService(minio_config)
         path = f"{request.node.name}/does_not_exist.txt"


### PR DESCRIPTION
The `update_archive` function was the only user of `append_to_file`, but itself is not used anywhere.

Thus the `append_to_file` function can be removed. It was problematic in itself, as it did not guarantee atomic updates.