### PR TITLE
bundle analysis: add gzip size total for report

### DIFF
--- a/tests/unit/bundle_analysis/test_bundle_analysis.py
+++ b/tests/unit/bundle_analysis/test_bundle_analysis.py
@@ -750,3 +750,27 @@ def test_bundle_report_asset_type_javascript():
             case["expected_total_size"],
             case["expected_js_size"],
         )
+
+
+def test_bundle_report_total_gzip_size():
+    try:
+        report = BundleAnalysisReport()
+        session_id, bundle_name = report.ingest(sample_bundle_stats_path)
+        assert session_id == 1
+        assert bundle_name == "sample"
+
+        assert report.metadata() == {
+            MetadataKey.SCHEMA_VERSION: SCHEMA_VERSION,
+        }
+
+        bundle_reports = list(report.bundle_reports())
+        assert len(bundle_reports) == 1
+
+        bundle_report = report.bundle_report("invalid")
+        assert bundle_report is None
+        bundle_report = report.bundle_report("sample")
+
+        assert bundle_report.total_size() == 150572
+        assert bundle_report.total_gzip_size() == 150567
+    finally:
+        report.cleanup()


### PR DESCRIPTION
Add a function for BundleReport to fetch gzip size total

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.