### PR TITLE
feat: add percentage change for bundles

### DIFF
--- a/shared/bundle_analysis/comparison.py
+++ b/shared/bundle_analysis/comparison.py
@@ -44,6 +44,7 @@ class BundleChange:
     bundle_name: str
     change_type: ChangeType
     size_delta: int
+    percentage_delta: float  # [-100, 100] range
 
 
 @dataclass(frozen=True)
@@ -249,6 +250,7 @@ class BundleAnalysisComparison:
                     bundle_name=bundle_name,
                     change_type=BundleChange.ChangeType.ADDED,
                     size_delta=head_bundle_report.total_size(),
+                    percentage_delta=100,
                 )
             else:
                 base_bundle_report = base_bundle_reports[bundle_name]
@@ -256,10 +258,14 @@ class BundleAnalysisComparison:
                 size_delta = (
                     head_bundle_report.total_size() - base_bundle_report.total_size()
                 )
+                percentage_delta = round(
+                    (size_delta / base_bundle_report.total_size()) * 100, 2
+                )
                 yield BundleChange(
                     bundle_name=bundle_name,
                     change_type=BundleChange.ChangeType.CHANGED,
                     size_delta=size_delta,
+                    percentage_delta=percentage_delta,
                 )
 
         for bundle_name, base_bundle_report in base_bundle_reports.items():
@@ -267,6 +273,7 @@ class BundleAnalysisComparison:
                 bundle_name=bundle_name,
                 change_type=BundleChange.ChangeType.REMOVED,
                 size_delta=-base_bundle_report.total_size(),
+                percentage_delta=-100.0,
             )
 
     @property
@@ -284,6 +291,8 @@ class BundleAnalysisComparison:
         base_size = sum(
             report.total_size() for report in self.base_report.bundle_reports()
         )
+        if base_size == 0:
+            return 100.0
         return round((self.total_size_delta / base_size) * 100, 2)
 
     def bundle_comparison(self, bundle_name: str) -> BundleComparison:

--- a/shared/bundle_analysis/comparison.py
+++ b/shared/bundle_analysis/comparison.py
@@ -44,7 +44,7 @@ class BundleChange:
     bundle_name: str
     change_type: ChangeType
     size_delta: int
-    percentage_delta: float  # [-100, 100] range
+    percentage_delta: float
 
 
 @dataclass(frozen=True)

--- a/tests/unit/bundle_analysis/test_bundle_comparison.py
+++ b/tests/unit/bundle_analysis/test_bundle_comparison.py
@@ -72,16 +72,19 @@ def test_bundle_analysis_comparison():
                 bundle_name="sample",
                 change_type=BundleChange.ChangeType.CHANGED,
                 size_delta=1100,
+                percentage_delta=0.73,
             ),
             BundleChange(
                 bundle_name="new",
                 change_type=BundleChange.ChangeType.ADDED,
                 size_delta=0,
+                percentage_delta=100,
             ),
             BundleChange(
                 bundle_name="old",
                 change_type=BundleChange.ChangeType.REMOVED,
                 size_delta=0,
+                percentage_delta=-100,
             ),
         ]
     )


### PR DESCRIPTION
The design for https://github.com/codecov/engineering-team/issues/1491 includes warnings in the bundle table for individual bundles.

In order to do that we need a percentage change on the bundle level. The calculation of percentage follows the same idea as the `Comparison`: the percentage is taken using the base bundle size as the 100%

<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.