### PR TITLE
add UploadErrorCode enum for use in worker/api

### DIFF
--- a/shared/upload/constants.py
+++ b/shared/upload/constants.py
@@ -1,3 +1,5 @@
+from enum import StrEnum
+
 ci = {
     "travis": {
         "title": "Travis-CI",
@@ -220,3 +222,13 @@ global_upload_token_providers = [
     "bitbucket",
     "bitbucket_server",
 ]
+
+
+class UploadErrorCode(StrEnum):
+    FILE_NOT_IN_STORAGE = "file_not_in_storage"
+    REPORT_EXPIRED = "report_expired"
+    REPORT_EMPTY = "report_empty"
+
+    # We don't want these - try to add error cases when they arise
+    UNKNOWN_PROCESSING = "unknown_processing"
+    UNKNOWN_STORAGE = "unknown_storage"


### PR DESCRIPTION
part of https://github.com/codecov/engineering-team/issues/1520
related to https://github.com/codecov/worker/pull/703

API has a version of this enum, and worker just uses magic strings. it turns out this is important for displaying user-friendly error text in the UI so it is important to be consistent. this PR creates an enum that i'll make worker and API use