### PR TITLE
[chore] Deprecate allow coverage offsets yaml field

### DIFF
--- a/shared/validation/user_schema.py
+++ b/shared/validation/user_schema.py
@@ -237,7 +237,7 @@ schema = {
             "max_report_age": {"type": ["string", "integer", "boolean"]},
             "disable_default_path_fixes": {"type": "boolean"},
             "require_ci_to_pass": {"type": "boolean"},
-            "allow_coverage_offsets": {"type": "boolean"}, # [DEPRECATED]
+            "allow_coverage_offsets": {"type": "boolean"},  # [DEPRECATED]
             "allow_pseudo_compare": {"type": "boolean"},
             "archive": {"type": "dict", "schema": {"uploads": {"type": "boolean"}}},
             "notify": {

--- a/shared/validation/user_schema.py
+++ b/shared/validation/user_schema.py
@@ -237,7 +237,7 @@ schema = {
             "max_report_age": {"type": ["string", "integer", "boolean"]},
             "disable_default_path_fixes": {"type": "boolean"},
             "require_ci_to_pass": {"type": "boolean"},
-            "allow_coverage_offsets": {"type": "boolean"},
+            "allow_coverage_offsets": {"type": "boolean"}, # [DEPRECATED]
             "allow_pseudo_compare": {"type": "boolean"},
             "archive": {"type": "dict", "schema": {"uploads": {"type": "boolean"}}},
             "notify": {


### PR DESCRIPTION
<!-- Describe your PR here. -->

Following up from https://github.com/codecov/codecov-api/pull/780/files#diff-f880df5913bd1613d329d68bfa71ad888ed8ac3e76069bc5ed72bf72e75c3272

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.