### PR TITLE
bundle analysis: fix noisy erros from old bundles

### DIFF
--- a/shared/bundle_analysis/migrations/v003_modify_gzip_size_nullable.py
+++ b/shared/bundle_analysis/migrations/v003_modify_gzip_size_nullable.py
@@ -8,6 +8,17 @@ def modify_gzip_size_nullable(db_session: Session):
     Because SQLite does not have a "alter column" command we need to
     rename the existing table, create the new table, and migrate all the data over
     """
+
+    # Fixes an issue where old bundle reports that were created before the inception of
+    # DB migrations would error because UUID column does not exist.
+    table_info = db_session.execute(text("""PRAGMA table_info(assets)"""))
+    if "uuid" not in [row._mapping["name"] for row in table_info]:
+        db_session.execute(
+            text("""
+            ALTER TABLE "assets" ADD COLUMN "uuid" text DEFAULT ''
+        """)
+        )
+
     stmts = [
         """
         PRAGMA foreign_keys=off;


### PR DESCRIPTION
Fixes these Sentry [errors](https://codecov.sentry.io/issues/?environment=roblox&environment=snowflake&environment=production&environment=dd&environment=enova&environment=epic&environment=mailchimp&groupStatsPeriod=24h&page=0&project=5514400&project=5215654&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D%20table%20bundle&referrer=issue-list&statsPeriod=14d&stream_index=0)

uuid column was added to assets column a long time ago before the advent of the migration mechanism, now for whatever reason these old bundles are requested they will error because its assumed uuid exists everywhere. This fix will allow the migration to not error when this happens.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.