### PR TITLE
create Feature db record in constructor, not just in check_value()

### DIFF
--- a/shared/rollouts/__init__.py
+++ b/shared/rollouts/__init__.py
@@ -112,6 +112,10 @@ class Feature:
         self.feature_flag = feature_flag
         self.ff_variants = ff_variants
 
+        # Force the feature to be created in the database when it is initialized
+        # and not just when `check_value()` is called.
+        self._fetch_and_set_from_db()
+
         # See if this environment has disabled feature flagging entirely.
         # These environments will always get default values.
         self.env_disable = os.getenv("CODECOV__FEATURE__DISABLE") is not None


### PR DESCRIPTION
the `Feature` record has to be created before you can set overrides, create variants, and set the identifier type. if we make sure that happens in the `Feature` constructor, then you will be able to configure your feature as soon as it's deployed and not have to wait for `check_value()` to be called (which you might not actually be ready to do)