### PR TITLE
fix: use update_or_create instead of get_or_create depending on the webhook response

### DIFF
--- a/shared/django_apps/core/managers.py
+++ b/shared/django_apps/core/managers.py
@@ -306,7 +306,7 @@ class RepositoryQuerySet(QuerySet):
                 author=owner, service_id=service_id, defaults=defaults
             )
 
-            log.warning(
+            log.info(
                 "[GetOrCreateFromGitRepo] - Repo successfully updated or created",
                 extra=dict(
                     defaults=defaults,

--- a/shared/django_apps/core/managers.py
+++ b/shared/django_apps/core/managers.py
@@ -1,6 +1,7 @@
 import datetime
 
 from dateutil import parser
+from django.db import IntegrityError
 from django.db.models import (
     Avg,
     Count,
@@ -284,7 +285,7 @@ class RepositoryQuerySet(QuerySet):
     def get_or_create_from_git_repo(self, git_repo, owner):
         from shared.django_apps.codecov_auth.models import Owner
 
-        repo, created = self.get_or_create(
+        repo, created = self.update_or_create(
             author=owner,
             service_id=git_repo.get("service_id") or git_repo.get("id"),
             private=git_repo["private"],


### PR DESCRIPTION
This PR aims to fix these related sentry issues:

https://codecov.sentry.io/issues/5334155312
https://codecov.sentry.io/issues/5409774549
https://codecov.sentry.io/issues/5215132965
https://codecov.sentry.io/issues/5820085486
https://codecov.sentry.io/issues/5441235127

That seem to all be related to a unique_constraint error when trying to create this object when a similar one already exists. Thanks @adrian-codecov for talking me through this one

Unique constraint comes from here: https://github.com/codecov/shared/blob/b42ecbe84e6cf1e0d8cfdab6dc5beb12600e06b3/shared/django_apps/core/models.py#L157-L163

Related django documentation: https://docs.djangoproject.com/en/5.1/ref/models/querysets/#update-or-create


<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.