### PR TITLE
Add logging for GH API client lib

### DIFF
--- a/shared/torngit/github.py
+++ b/shared/torngit/github.py
@@ -820,6 +820,7 @@ class Github(TorngitBaseAdapter):
                         rl_limit=res.headers.get("X-RateLimit-Limit"),
                         rl_reset_time=res.headers.get("X-RateLimit-Reset"),
                         retry_after=res.headers.get("Retry-After"),
+                        refreshable=callable(self._on_token_refresh),
                         **log_dict,
                     ),
                 )


### PR DESCRIPTION
Add a logging extra info to determine if a token being used is probably from integration and therefore can't be refreshed

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.