### PR TITLE
fix: Logs that have duplicate entries in GH webhook code

### DIFF
--- a/shared/django_apps/core/managers.py
+++ b/shared/django_apps/core/managers.py
@@ -311,8 +311,6 @@ class RepositoryQuerySet(QuerySet):
                 extra=dict(
                     defaults=defaults,
                     author=owner.ownerid,
-                    name=name,
-                    service_id=service_id,
                     created=created,
                 ),
             )
@@ -328,8 +326,6 @@ class RepositoryQuerySet(QuerySet):
                 extra=dict(
                     defaults=defaults,
                     author=owner.ownerid,
-                    name=name,
-                    service_id=service_id,
                     created=created,
                 ),
             )

--- a/shared/django_apps/core/managers.py
+++ b/shared/django_apps/core/managers.py
@@ -311,7 +311,6 @@ class RepositoryQuerySet(QuerySet):
                 extra=dict(
                     defaults=defaults,
                     author=owner.ownerid,
-                    created=created,
                 ),
             )
 
@@ -326,7 +325,6 @@ class RepositoryQuerySet(QuerySet):
                 extra=dict(
                     defaults=defaults,
                     author=owner.ownerid,
-                    created=created,
                 ),
             )
 


### PR DESCRIPTION
This PR removes duplicate log entries that were causing test failures in API

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.