### PR TITLE
Update Sentry Bot Name

### DIFF
--- a/shared/torngit/github.py
+++ b/shared/torngit/github.py
@@ -623,7 +623,7 @@ class Github(TorngitBaseAdapter):
                 )
             ):
                 bot_name = get_config(
-                    "github", "comment_action_bot_name", default="sentry-ai"
+                    "github", "comment_action_bot_name", default="sentry"
                 )
                 body["actions"] = [
                     {


### PR DESCRIPTION
<!-- Describe your PR here. -->
There was a slight miscommunication on this. The bot's name is not `sentry-ai` in production, it is just `sentry`. This commit rectifies this error.
