### PR TITLE
chore: add ProviderPull type

### DIFF
--- a/shared/bots/__init__.py
+++ b/shared/bots/__init__.py
@@ -26,7 +26,7 @@ def get_adapter_auth_information(
     repository: Optional[Repository] | Any = None,
     *,
     ignore_installations: bool = False,
-    installation_name_to_use: str | None = GITHUB_APP_INSTALLATION_DEFAULT_NAME,
+    installation_name_to_use: str = GITHUB_APP_INSTALLATION_DEFAULT_NAME,
 ) -> AdapterAuthInformation:
     """
     Gets all the auth information needed to send requests to the provider.

--- a/shared/torngit/bitbucket.py
+++ b/shared/torngit/bitbucket.py
@@ -17,6 +17,7 @@ from shared.torngit.exceptions import (
     TorngitServer5xxCodeError,
     TorngitServerUnreachableError,
 )
+from shared.torngit.response_types import ProviderPull
 from shared.torngit.status import Status
 from shared.utils.urls import url_concat
 
@@ -452,7 +453,7 @@ class Bitbucket(TorngitBaseAdapter):
                         break
         return data
 
-    async def get_pull_request(self, pullid, token=None):
+    async def get_pull_request(self, pullid, token=None) -> ProviderPull | None:
         # https://confluence.atlassian.com/display/BITBUCKET/pullrequests+Resource#pullrequestsResource-GETaspecificpullrequest
         async with self.get_client() as client:
             try:
@@ -489,14 +490,14 @@ class Bitbucket(TorngitBaseAdapter):
                 ),
                 token=token,
             )
-        return dict(
+        return ProviderPull(
             author=dict(
                 id=str(res["author"]["uuid"][1:-1]) if res["author"] else None,
                 username=(
-                    res["author"].get("nickname") or res["author"].get("username")
-                )
-                if res["author"]
-                else None,
+                    (res["author"].get("nickname") or res["author"].get("username"))
+                    if res["author"]
+                    else None
+                ),
             ),
             base=dict(
                 branch=res["destination"]["branch"]["name"], commitid=base["hash"]
@@ -508,9 +509,11 @@ class Bitbucket(TorngitBaseAdapter):
             title=res["title"],
             id=str(pullid),
             number=str(pullid),
-            merge_commit_sha=res.get("merge_commit", dict()).get("hash")
-            if res["state"] == "MERGED"
-            else None,
+            merge_commit_sha=(
+                res.get("merge_commit", dict()).get("hash")
+                if res["state"] == "MERGED"
+                else None
+            ),
         )
 
     async def post_comment(self, issueid, body, token=None):

--- a/shared/torngit/github.py
+++ b/shared/torngit/github.py
@@ -37,6 +37,7 @@ from shared.torngit.exceptions import (
     TorngitServerUnreachableError,
     TorngitUnauthorizedError,
 )
+from shared.torngit.response_types import ProviderPull
 from shared.torngit.status import Status
 from shared.typings.oauth_token_types import OauthConsumerToken
 from shared.typings.torngit import GithubInstallationInfo
@@ -549,14 +550,15 @@ query Repos($owner: String!, $cursor: String, $first: Int!) {
 """,
     )
 
-    def get(self, query_name: str) -> Optional[str]:
+    def get(self, query_name: str) -> str | None:
         return self._queries.get(query_name, None)
 
-    def prepare(self, query_name: str, variables: dict) -> Optional[dict]:
+    def prepare(self, query_name: str, variables: dict) -> dict | None:
         # If Query was an object we could validate the variables
         query = self.get(query_name)
         if query is not None:
             return {"query": query, "variables": variables}
+        return None
 
 
 class Github(TorngitBaseAdapter):
@@ -1933,7 +1935,7 @@ class Github(TorngitBaseAdapter):
 
     # Pull Requests
     # -------------
-    def _pull(self, pull):
+    def _pull(self, pull) -> ProviderPull:
         return dict(
             author=dict(
                 id=str(pull["user"]["id"]) if pull["user"] else None,
@@ -1963,7 +1965,7 @@ class Github(TorngitBaseAdapter):
             merge_commit_sha=pull["merge_commit_sha"] if pull["merged"] else None,
         )
 
-    async def get_pull_request(self, pullid, token=None):
+    async def get_pull_request(self, pullid, token=None) -> ProviderPull | None:
         token = self.get_token_by_type_if_none(token, TokenType.pull)
         # https://developer.github.com/v3/pulls/#get-a-single-pull-request
         async with self.get_client() as client:

--- a/shared/torngit/gitlab.py
+++ b/shared/torngit/gitlab.py
@@ -21,6 +21,7 @@ from shared.torngit.exceptions import (
     TorngitServer5xxCodeError,
     TorngitServerUnreachableError,
 )
+from shared.torngit.response_types import ProviderPull
 from shared.torngit.status import Status
 from shared.typings.oauth_token_types import OauthConsumerToken, Token
 from shared.utils.urls import url_concat
@@ -854,7 +855,7 @@ class Gitlab(TorngitBaseAdapter):
             )
         return all_groups
 
-    async def get_pull_request(self, pullid, token=None):
+    async def get_pull_request(self, pullid, token=None) -> ProviderPull | None:
         # https://docs.gitlab.com/ce/api/merge_requests.html#get-single-mr
         url = self.count_and_get_url_template("get_pull_request").substitute(
             service_id=self.data["repo"]["service_id"], pullid=pullid
@@ -907,7 +908,7 @@ class Gitlab(TorngitBaseAdapter):
             if pull["state"] == "locked":
                 pull["state"] = "closed"
 
-            return dict(
+            return ProviderPull(
                 author=dict(
                     id=str(pull["author"]["id"]) if pull["author"] else None,
                     username=pull["author"]["username"] if pull["author"] else None,
@@ -924,6 +925,7 @@ class Gitlab(TorngitBaseAdapter):
                     pull["merge_commit_sha"] if pull["state"] == "merged" else None
                 ),
             )
+        return None
 
     async def get_pull_request_files(self, pullid, token=None):
         # https://docs.gitlab.com/ee/api/merge_requests.html#list-merge-request-diffs

--- a/shared/torngit/response_types.py
+++ b/shared/torngit/response_types.py
@@ -1,0 +1,24 @@
+from typing import Literal, NotRequired, TypedDict
+
+
+class ProviderAuthor(TypedDict):
+    id: str | None
+    username: str | None
+
+
+class ProviderCommit(TypedDict):
+    branch: str
+    commitid: str
+    slug: NotRequired[str]  # Only GitHub includes slug
+
+
+class ProviderPull(TypedDict):
+    author: ProviderAuthor
+    base: ProviderCommit
+    head: ProviderCommit
+    state: Literal["open", "closed", "merged"]
+    title: str
+    id: str
+    number: str
+    labels: NotRequired[list[str]]  # Only GitHub includes labels
+    merge_commit_sha: str | None

--- a/shared/typings/torngit.py
+++ b/shared/typings/torngit.py
@@ -22,12 +22,12 @@ class GithubInstallationInfo(TypedDict):
     installation_id: int
     # The default app (configured via yaml) doesn't need this info.
     # All other apps need app_id and pem_path
-    app_id: Optional[int] = None
-    pem_path: Optional[str] = None
+    app_id: Optional[int]
+    pem_path: Optional[str]
 
 
 class TorngitInstanceData(TypedDict):
     owner: Union[OwnerInfo, Dict]
     repo: Union[RepoInfo, Dict]
-    fallback_installations: List[Optional[GithubInstallationInfo]]
+    fallback_installations: List[Optional[GithubInstallationInfo]] | None
     installation: Optional[GithubInstallationInfo]


### PR DESCRIPTION
adds back the type hints that were removed when we reverted https://github.com/codecov/shared/commit/62ef7b37c2a2fd0e192939e3f776d99d7fcc045b

<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.