### PR TITLE
log `x-github-request-id` in torngit github

### DIFF
--- a/shared/torngit/github.py
+++ b/shared/torngit/github.py
@@ -850,6 +850,7 @@ class Github(TorngitBaseAdapter):
                         rl_limit=res.headers.get("X-RateLimit-Limit"),
                         rl_reset_time=res.headers.get("X-RateLimit-Reset"),
                         retry_after=res.headers.get("Retry-After"),
+                        gh_request_id=res.headers.get("x-github-request-id"),
                         **log_dict,
                     ),
                 )


### PR DESCRIPTION
we saw a strange request recently that returned a 200 but was unexpectedly missing all the rate limit headers and it took 5 seconds. seems like something might have been up with it, but we had no way to ask GH support to take a look

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.