### PR TITLE
Change Copilot Copy

### DIFF
--- a/shared/torngit/github.py
+++ b/shared/torngit/github.py
@@ -629,9 +629,9 @@ class Github(TorngitBaseAdapter):
                 )
                 body["actions"] = [
                     {
-                        "name": "Open Sentry Agent",
+                        "name": "Generate Tests",
                         "type": "copilot-chat",
-                        "prompt": f"@{bot_name} generate tests for PR",
+                        "prompt": f"@{bot_name} generate tests for this PR.",
                     }
                 ]
         except Exception:


### PR DESCRIPTION
This PR Changes the copy for the copilot button to more clearly indicate the function of the button itself (i.e., to generate tests). 

Also  makes the sentry message in chat a complete sentence.