### PR TITLE
Update YAML validator to drop reserved key for internal use only

### DIFF
--- a/shared/yaml/validation.py
+++ b/shared/yaml/validation.py
@@ -61,6 +61,11 @@ def pre_process_yaml(inputted_yaml_dict):
             val = inputted_yaml_dict["codecov"]["notify"].pop("require_ci_to_pass")
             inputted_yaml_dict["codecov"]["require_ci_to_pass"] = val
 
+    # Remove the reserved `to_string` key word in the base level of the json.
+    # This key is used to store the full YAML string preserving the original comments.
+    if "to_string" in inputted_yaml_dict:
+        inputted_yaml_dict.pop("to_string")
+
 
 def _calculate_error_location_and_message_from_error_dict(error_dict):
     current_value, location_so_far = error_dict, []

--- a/shared/yaml/validation.py
+++ b/shared/yaml/validation.py
@@ -1,5 +1,6 @@
 import binascii
 import logging
+from typing import Dict, List
 
 from shared.encryption.yaml_secret import yaml_secret_encryptor
 from shared.validation.cli_schema import schema as cli_schema
@@ -8,6 +9,10 @@ from shared.validation.user_schema import schema as user_schema
 from shared.validation.validator import CodecovYamlValidator
 
 log = logging.getLogger(__name__)
+
+YAML_TOP_LEVEL_RESERVED_KEYS: List[str] = [
+    "to_string"  # Used to store the full YAML string preserving the original comments
+]
 
 # *** Reminder: when changes are made to YAML validation, you will need to update the version of shared in both
 # worker (to apply the changes) AND codecov-api (so the validate route reflects the changes) ***
@@ -38,6 +43,16 @@ def validate_yaml(inputted_yaml_dict, show_secrets_for=None):
     return do_actual_validation(inputted_yaml_dict, show_secrets_for)
 
 
+def remove_reserved_keys(inputted_yaml_dict: Dict[str, any]) -> None:
+    """
+    This step removes reserved keywords in the base level of the json.
+    If any YAML is trying to be processed and validated those reserved keys will be ignored
+    """
+    for key in YAML_TOP_LEVEL_RESERVED_KEYS:
+        if key in inputted_yaml_dict:
+            inputted_yaml_dict.pop(key)
+
+
 def pre_process_yaml(inputted_yaml_dict):
     """
     Changes the inputted_yaml_dict in-place with compatibility changes that need to be done
@@ -61,10 +76,7 @@ def pre_process_yaml(inputted_yaml_dict):
             val = inputted_yaml_dict["codecov"]["notify"].pop("require_ci_to_pass")
             inputted_yaml_dict["codecov"]["require_ci_to_pass"] = val
 
-    # Remove the reserved `to_string` key word in the base level of the json.
-    # This key is used to store the full YAML string preserving the original comments.
-    if "to_string" in inputted_yaml_dict:
-        inputted_yaml_dict.pop("to_string")
+    remove_reserved_keys(inputted_yaml_dict)
 
 
 def _calculate_error_location_and_message_from_error_dict(error_dict):

--- a/tests/unit/validation/test_validation.py
+++ b/tests/unit/validation/test_validation.py
@@ -1444,3 +1444,10 @@ def test_slack_app_validation_boolean():
     user_input = {"slack_app": True}
     result = validate_yaml(user_input)
     assert result == user_input
+
+
+def test_to_string_validation():
+    user_input = {"to_string": {"abc": 123}}
+    expected_result = {}
+    result = validate_yaml(user_input)
+    assert result == expected_result


### PR DESCRIPTION
This change disallows the `to_string` key to be present during the validation of codecov YAML, if whenever the key is in the YAML string then it will fail with validation error. We need this reserved key in order to keep a copy of the owner YAML's full string content allowing to display original formatting and comments.
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.