### PR TITLE
Create fn to extract values from rollout_universe

### DIFF
--- a/shared/rollouts/__init__.py
+++ b/shared/rollouts/__init__.py
@@ -162,6 +162,26 @@ class Feature:
     def check_value_async(self, identifier, default=False):
         return self.check_value(identifier, default)
 
+    def check_values(self):
+        # Will only run and refresh values from the database every ~5 minutes due to TTL cache
+        self._fetch_and_set_from_db()
+
+        # check if an override exists
+        identifier_override_field = rollout_universe_to_override_string(
+            self.feature_flag.rollout_universe
+        )
+
+        # Get values for override field
+        values = set()
+        for variant in self.ff_variants:
+            values.update(getattr(variant, identifier_override_field))
+
+        return values
+
+    @sync_to_async
+    def check_values_async(self):
+        return self.check_values()
+
     def check_value_no_fetch(self, identifier, default=False):
         """
         Same as `check_value()` except does not make any DB calls, and assumes the flag data has been passed into the class


### PR DESCRIPTION
We might want to extract the values a Feature Flag variant has in one go to prevent multiple fetches during runtime. This has a manual fetch to data entries to ensure latest values are updated

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.