### PR TITLE
Adjust comment request body fn

### DIFF
--- a/shared/torngit/github.py
+++ b/shared/torngit/github.py
@@ -21,7 +21,6 @@ from shared.metrics import Counter, metrics
 from shared.rate_limits import (
     set_entity_to_rate_limited,
 )
-from shared.rollouts.features import INCLUDE_GITHUB_COMMENT_ACTIONS_BY_OWNER
 from shared.torngit.base import TokenType, TorngitBaseAdapter
 from shared.torngit.cache import torngit_cache
 from shared.torngit.enums import Endpoints
@@ -612,17 +611,13 @@ class Github(TorngitBaseAdapter):
         GITHUB_API_ENDPOINTS[url_name]["counter"].inc()
         return GITHUB_API_ENDPOINTS[url_name]["url_template"]
 
-    async def build_comment_request_body(
-        self, body: dict
-    ) -> dict:
+    async def build_comment_request_body(self, body: dict) -> dict:
         """
         This function is to add the expected payload for the copilot test generation
         """
         body = dict(body=body)
         try:
-            bot_name = get_config(
-                "github", "comment_action_bot_name", default="sentry"
-            )
+            bot_name = get_config("github", "comment_action_bot_name", default="sentry")
             body["actions"] = [
                 {
                     "name": "Generate Tests with Sentry",

--- a/shared/torngit/github.py
+++ b/shared/torngit/github.py
@@ -613,27 +613,23 @@ class Github(TorngitBaseAdapter):
         return GITHUB_API_ENDPOINTS[url_name]["url_template"]
 
     async def build_comment_request_body(
-        self, body: dict, issueid: int | None = None
+        self, body: dict
     ) -> dict:
+        """
+        This function is to add the expected payload for the copilot test generation
+        """
         body = dict(body=body)
         try:
-            ownerid = self.data["owner"].get("ownerid")
-            if (
-                issueid is not None
-                and await INCLUDE_GITHUB_COMMENT_ACTIONS_BY_OWNER.check_value_async(
-                    identifier=ownerid, default=False
-                )
-            ):
-                bot_name = get_config(
-                    "github", "comment_action_bot_name", default="sentry"
-                )
-                body["actions"] = [
-                    {
-                        "name": "Generate Tests with Sentry",
-                        "type": "copilot-chat",
-                        "prompt": f"@{bot_name} generate tests for this PR.",
-                    }
-                ]
+            bot_name = get_config(
+                "github", "comment_action_bot_name", default="sentry"
+            )
+            body["actions"] = [
+                {
+                    "name": "Generate Tests with Sentry",
+                    "type": "copilot-chat",
+                    "prompt": f"@{bot_name} generate tests for this PR.",
+                }
+            ]
         except Exception:
             pass
 
@@ -1609,7 +1605,7 @@ class Github(TorngitBaseAdapter):
     # --------
     async def post_comment(self, issueid, body, token=None):
         token = self.get_token_by_type_if_none(token, TokenType.comment)
-        body = await self.build_comment_request_body(body, issueid)
+        body = await self.build_comment_request_body(body)
         # https://developer.github.com/v3/issues/comments/#create-a-comment
         async with self.get_client() as client:
             url = self.count_and_get_url_template(url_name="post_comment").substitute(
@@ -1620,7 +1616,7 @@ class Github(TorngitBaseAdapter):
 
     async def edit_comment(self, issueid, commentid, body, token=None):
         token = self.get_token_by_type_if_none(token, TokenType.comment)
-        body = await self.build_comment_request_body(body, issueid)
+        body = await self.build_comment_request_body(body)
         # https://developer.github.com/v3/issues/comments/#edit-a-comment
         try:
             async with self.get_client() as client:

--- a/tests/unit/torngit/test_github.py
+++ b/tests/unit/torngit/test_github.py
@@ -693,7 +693,16 @@ class TestUnitGithub(object):
         )
         mocked_response = respx_vcr.post(
             url="https://api.github.com/repos/ThiagoCodecov/example-python/issues/1/comments",
-            json={"body": "Hello world"},
+            json={
+                "body": "Hello world",
+                "actions": [
+                    {
+                        "name": "Generate Tests with Sentry",
+                        "type": "copilot-chat",
+                        "prompt": "@sentry generate tests for this PR.",
+                    }
+                ],
+            },
         ).mock(
             return_value=httpx.Response(
                 status_code=201,

--- a/tests/unit/torngit/test_github_enterprise.py
+++ b/tests/unit/torngit/test_github_enterprise.py
@@ -66,7 +66,16 @@ class TestGithubEnterprise(object):
         client.__aenter__.return_value.request.assert_called_with(
             "POST",
             "https://api.github.dev/repos/stevepeak/codecov-test/issues/pullid/comments",
-            json={"body": "body"},
+            json={
+                "body": "body",
+                "actions": [
+                    {
+                        "name": "Generate Tests with Sentry",
+                        "type": "copilot-chat",
+                        "prompt": "@sentry generate tests for this PR.",
+                    }
+                ],
+            },
             headers={
                 "Accept": "application/json",
                 "Authorization": "token fake_token",


### PR DESCRIPTION
The test comment generation is no longer going to be filtered to specific repositories, hence deleting that piece of the logic

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.