### PR TITLE
log: add the relevant glob to a warning log about globs

### DIFF
--- a/shared/validation/helpers.py
+++ b/shared/validation/helpers.py
@@ -381,7 +381,10 @@ class PathPatternSchemaField(object):
 
     def validate_glob(self, value):
         if not value.endswith("$") and not value.endswith("*"):
-            log.warning("Old glob behavior would have interpreted this glob as prefix")
+            log.warning(
+                "Old glob behavior would have interpreted this glob as prefix",
+                extra=dict(glob=value),
+            )
         return translate_glob_to_regex(value)
 
     def validate_path_prefix(self, value):


### PR DESCRIPTION
as title

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.