### PR TITLE
Switch to `orjson` for Report de/serialization

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(
         "mmh3",
         "oauth2",
         "oauthlib",
+        "orjson",
         "prometheus-client",
         "protobuf>=4.21.6",
         "pyjwt",

--- a/tests/integration/test_report.py
+++ b/tests/integration/test_report.py
@@ -440,7 +440,7 @@ def test_to_database():
             "diff": None,
             "N": 0,
         },
-        '{"files": {"file.py": [0, [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], null, null]}, "sessions": {}}',
+        '{"files":{"file.py":[0,[0,0,0,0,0,0,0,0,0,0,0,0,0],null,null]},"sessions":{}}',
     )
     res = Report(
         files={"file.py": [0, ReportTotals()]},

--- a/tests/unit/test_report.py
+++ b/tests/unit/test_report.py
@@ -653,7 +653,7 @@ def test_to_database(mocker):
             "diff": None,
             "N": 0,
         },
-        '{"files": {"file.py": [0, [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], null, null]}, "sessions": {}}',
+        '{"files":{"file.py":[0,[0,0,0,0,0,0,0,0,0,0,0,0,0],null,null]},"sessions":{}}',
     )
 
 


### PR DESCRIPTION
This is the same as https://github.com/codecov/worker/pull/772, and for the same reasons: `orjson` is advertised as being 3x faster for deserialization, and up to 10x faster for serialization.