### PR TITLE
Remove usage of `ReportDetails`/`files_array`

### DIFF
--- a/shared/django_apps/core/tests/factories.py
+++ b/shared/django_apps/core/tests/factories.py
@@ -112,7 +112,6 @@ class CommitWithReportFactory(CommitFactory):
 
         from reports.tests.factories import (
             CommitReportFactory,
-            ReportDetailsFactory,
             ReportLevelTotalsFactory,
             UploadFactory,
             UploadFlagMembershipFactory,
@@ -120,29 +119,6 @@ class CommitWithReportFactory(CommitFactory):
         )
 
         commit_report = CommitReportFactory(commit=commit)
-        ReportDetailsFactory(
-            report=commit_report,
-            _files_array=[
-                {
-                    "filename": "tests/__init__.py",
-                    "file_index": 0,
-                    "file_totals": [0, 3, 2, 1, 0, "66.66667", 0, 0, 0, 0, 0, 0, 0],
-                    "diff_totals": None,
-                },
-                {
-                    "filename": "tests/test_sample.py",
-                    "file_index": 1,
-                    "file_totals": [0, 7, 7, 0, 0, "100", 0, 0, 0, 0, 0, 0, 0],
-                    "diff_totals": None,
-                },
-                {
-                    "filename": "awesome/__init__.py",
-                    "file_index": 2,
-                    "file_totals": [0, 10, 8, 2, 0, "80.00000", 0, 0, 0, 0, 0, 0, 0],
-                    "diff_totals": [0, 2, 1, 1, 0, "50.00000", 0, 0, 0, 0, 0, 0, 0],
-                },
-            ],
-        )
         ReportLevelTotalsFactory(
             report=commit_report,
             files=3,

--- a/tests/unit/django_apps/core/test_core_models.py
+++ b/tests/unit/django_apps/core/test_core_models.py
@@ -58,7 +58,6 @@ class CommitTests(TestCase):
         mock_read_file = MagicMock()
         mock_archive.return_value.read_file = mock_read_file
         commit._report = self.sample_report
-        commit._files_array_storage_path = None
         commit.save()
 
         fetched = Commit.objects.get(id=commit.id)


### PR DESCRIPTION
This primarily removes usage from other test fixtures.