### PR TITLE
fix: Only throw TorngitServerUnreachableError when no retries left

### DIFF
--- a/shared/torngit/github.py
+++ b/shared/torngit/github.py
@@ -848,7 +848,7 @@ class Github(TorngitBaseAdapter):
                     ),
                 )
             except (httpx.TimeoutException, httpx.NetworkError):
-                if current_retry <= max_number_retries:
+                if current_retry < max_number_retries:
                     log.warning(
                         "GitHub was not able to be reached, retrying",
                         extra=dict(
@@ -856,6 +856,7 @@ class Github(TorngitBaseAdapter):
                             **log_dict,
                         ),
                     )
+                    continue
                 else:
                     raise TorngitServerUnreachableError(
                         "GitHub was not able to be reached."

--- a/shared/torngit/github.py
+++ b/shared/torngit/github.py
@@ -848,9 +848,18 @@ class Github(TorngitBaseAdapter):
                     ),
                 )
             except (httpx.TimeoutException, httpx.NetworkError):
-                raise TorngitServerUnreachableError(
-                    "GitHub was not able to be reached."
-                )
+                if current_retry <= max_number_retries:
+                    log.warning(
+                        "GitHub was not able to be reached, retrying",
+                        extra=dict(
+                            current_retry=current_retry,
+                            **log_dict,
+                        ),
+                    )
+                else:
+                    raise TorngitServerUnreachableError(
+                        "GitHub was not able to be reached."
+                    )
             # Github doesn't have any specific message for trying to use an expired token
             # on top of that they return 404 for certain endpoints (not 401).
             # So this is the little heuristics that we follow to decide on refreshing a token


### PR DESCRIPTION
## Description

This PR aims to allow our users making a github API request who face a timeout or network error to still retry their API request until the max amount of retries has been reached.

Previously we were throwing an error immediately in these cases.

Closes https://github.com/codecov/feedback/issues/542

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.