### PR TITLE
add FieldTracker to Owner - no migration required!

### DIFF
--- a/shared/django_apps/codecov_auth/models.py
+++ b/shared/django_apps/codecov_auth/models.py
@@ -16,6 +16,7 @@ from django.db.models.manager import BaseManager
 from django.forms import ValidationError
 from django.utils import timezone
 from django_prometheus.models import ExportModelOperationsMixin
+from model_utils import FieldTracker
 
 from shared.config import get_config
 from shared.django_apps.codecov.models import BaseCodecovModel, BaseModel
@@ -381,7 +382,9 @@ class Owner(ExportModelOperationsMixin("codecov_auth.owner"), models.Model):
     )
 
     objects = OwnerManager()
-
+    tracker = FieldTracker(
+        fields=["username", "service", "upload_token_required_for_public_repos"]
+    )
     repository_set = RepositoryManager()
 
     def __str__(self):


### PR DESCRIPTION
<!-- Describe your PR here. -->
We have this on `Repository` model so we can do [this](https://github.com/codecov/codecov-api/blob/f48452449f88a23715104f3bc17027d7c094563b/core/signals.py#L27) in `api`.
I'd like to add the same thing for `Owner` to use in the same way in `api`.

ChatGPT says it's performant 👼 

https://github.com/codecov/engineering-team/issues/2299