### PR TITLE
Cache Test Rollups Support PR

### DIFF
--- a/shared/celery_config.py
+++ b/shared/celery_config.py
@@ -50,6 +50,10 @@ cache_test_rollups_task_name = (
     f"app.tasks.{TaskConfigGroup.test_results.value}.CacheTestRollupsTask"
 )
 
+cache_test_rollups_redis_task_name = (
+    f"app.tasks.{TaskConfigGroup.test_results.value}.CacheTestRollupsRedisTask"
+)
+
 process_flakes_task_name = f"app.tasks.{TaskConfigGroup.flakes.value}.ProcessFlakesTask"
 
 manual_upload_completion_trigger_task_name = (

--- a/shared/celery_config.py
+++ b/shared/celery_config.py
@@ -45,6 +45,11 @@ test_results_finisher_task_name = (
 sync_test_results_task_name = (
     f"app.tasks.{TaskConfigGroup.test_results.value}.SyncTestResultsTask"
 )
+
+cache_test_rollups_task_name = (
+    f"app.tasks.{TaskConfigGroup.test_results.value}.CacheTestRollupsTask"
+)
+
 process_flakes_task_name = f"app.tasks.{TaskConfigGroup.flakes.value}.ProcessFlakesTask"
 
 manual_upload_completion_trigger_task_name = (

--- a/shared/django_apps/reports/tests/factories.py
+++ b/shared/django_apps/reports/tests/factories.py
@@ -13,6 +13,7 @@ from shared.django_apps.reports.models import (
     ReportResults,
     Test,
     TestInstance,
+    TestFlagBridge,
 )
 
 
@@ -175,3 +176,11 @@ class DailyTestRollupFactory(DjangoModelFactory):
     avg_duration_seconds = 0.0
     latest_run = dt.datetime.now()
     commits_where_fail: list[str] = []
+
+
+class TestFlagBridgeFactory(DjangoModelFactory):
+    class Meta:
+        model = TestFlagBridge
+
+    test = factory.SubFactory(TestFactory)
+    flag = factory.SubFactory(RepositoryFlagFactory)

--- a/shared/storage/minio.py
+++ b/shared/storage/minio.py
@@ -20,6 +20,8 @@ from minio.error import MinioException, S3Error
 from shared.storage.base import CHUNK_SIZE, BaseStorageService
 from shared.storage.exceptions import BucketAlreadyExistsError, FileNotInStorageError
 
+from typing import overload, BinaryIO
+
 log = logging.getLogger(__name__)
 
 
@@ -195,7 +197,13 @@ class MinioStorageService(BaseStorageService):
         except MinioException:
             raise
 
-    def read_file(self, bucket_name, path, file_obj=None):
+    @overload
+    def read_file(self, bucket_name: str, path: str) -> bytes: ...
+
+    @overload
+    def read_file(self, bucket_name: str, path: str, file_obj: BinaryIO) -> None: ...
+
+    def read_file(self, bucket_name, path, file_obj=None) -> bytes | None:
         try:
             res = self.minio_client.get_object(bucket_name, path)
             if file_obj is None:


### PR DESCRIPTION
- add task names for `cache_test_rollups_task` and `cache_test_rollups_redis_task`
- add function overloads for `StorageService.read_file`

this is to support the PRs in API and worker for caching test rollup aggregation results