### PR TITLE
remove pickle usage in redis-backed cache helper

### DIFF
--- a/tests/unit/helpers/test_cache.py
+++ b/tests/unit/helpers/test_cache.py
@@ -1,3 +1,5 @@
+import unittest
+
 import pytest
 from redis.exceptions import TimeoutError
 
@@ -67,28 +69,30 @@ class FakeRedisWithIssues(object):
         raise TimeoutError()
 
 
-class TestRedisBackend(object):
+class TestRedisBackend(unittest.TestCase):
     def test_simple_redis_call(self):
         redis_backend = RedisBackend(FakeRedis())
         assert redis_backend.get("normal_key") == NO_VALUE
-        redis_backend.set("normal_key", 120, {"value_1": set("ascdefgh"), 1: [1, 3]})
+        value_1 = list(set("ascdefgh"))
+        redis_backend.set("normal_key", 120, {"value_1": value_1, "1": [1, 3]})
         assert redis_backend.get("normal_key") == {
-            "value_1": set("ascdefgh"),
-            1: [1, 3],
+            "value_1": value_1,
+            "1": [1, 3],
         }
-
-    def test_simple_redis_call_invalid_pickle_version(self):
-        redis_instance = FakeRedis()
-        # PICKLE HERE WILL BE SET TO VERSION 9 (\x09 in the second byte of the value)
-        # IF THIS STOPS FAILING WITH ValueError, CHANGE THE SECOND BYTE TO SOMETHING HIGHER
-        redis_instance.setex("key", 120, b"\x80\x09X\x05\x00\x00\x00valueq\x00.")
-        redis_backend = RedisBackend(redis_instance)
-        assert redis_backend.get("key") == NO_VALUE
 
     def test_simple_redis_call_exception(self):
         redis_backend = RedisBackend(FakeRedisWithIssues())
         assert redis_backend.get("normal_key") == NO_VALUE
-        redis_backend.set("normal_key", 120, {"value_1": set("ascdefgh"), 1: [1, 3]})
+        redis_backend.set(
+            "normal_key", 120, {"value_1": list(set("ascdefgh")), "1": [1, 3]}
+        )
+        assert redis_backend.get("normal_key") == NO_VALUE
+
+    def test_simple_redis_call_not_json_serializable(self):
+        redis_backend = RedisBackend(FakeRedis())
+
+        unserializable = set("abcdefg")
+        redis_backend.set("normal_key", 120, unserializable)
         assert redis_backend.get("normal_key") == NO_VALUE
 
 

--- a/tests/unit/helpers/test_cache.py
+++ b/tests/unit/helpers/test_cache.py
@@ -95,6 +95,13 @@ class TestRedisBackend(unittest.TestCase):
         redis_backend.set("normal_key", 120, unserializable)
         assert redis_backend.get("normal_key") == NO_VALUE
 
+    def test_simple_redis_call_dict_with_int_keys(self):
+        redis_backend = RedisBackend(FakeRedis())
+
+        d = {"abcde": {1: [1, 2, 3], 2: [4, 5, 6]}}
+        redis_backend.set("normal_key", 120, d)
+        assert redis_backend.get("normal_key") == NO_VALUE
+
 
 class TestCache(object):
     def test_simple_caching_no_backend_no_params(self, mocker):


### PR DESCRIPTION
fixes https://github.com/codecov/internal-issues/issues/961

if the value being cached is not JSON-serializable, it will simply give up on caching it rather than raise an exception. an error will be logged to GCP so we should be able to see that occurring in GCP Logs Explorer. but from local testing i couldn't find any issues

BEWARE: technically Python allows dicts with non-`str` keys to be serialized into JSON because it coerces all keys to `str`:
```python
>>> json.loads(json.dumps( {1: 'abcde'} ))
{'1': 'abcde'}
```
this cache change will log an error and skip caching to err on the safe side