### PR TITLE
add PROCESSING_TIMEOUT upload error code

### DIFF
--- a/shared/upload/constants.py
+++ b/shared/upload/constants.py
@@ -228,6 +228,7 @@ class UploadErrorCode(StrEnum):
     FILE_NOT_IN_STORAGE = "file_not_in_storage"
     REPORT_EXPIRED = "report_expired"
     REPORT_EMPTY = "report_empty"
+    PROCESSING_TIMEOUT = "processing_timeout"
 
     # We don't want these - try to add error cases when they arise
     UNKNOWN_PROCESSING = "unknown_processing"


### PR DESCRIPTION
a significant number of "unknown errors" that we report to users are timing out during processing. this PR creates an error code for it, and we can later choose to display different text in gazebo for that error code

note: worker will _attempt_ to set this error code and save everything when it gets the "soft timeout" signal. but there is no guarantee it won't be forcibly killed before it can save everything. there will still be some unknown uploads from that

sibling PR in gazebo: https://github.com/codecov/gazebo/pull/3522