### PR TITLE
2876 remove copilot btn from ba pr comment

### DIFF
--- a/shared/torngit/github.py
+++ b/shared/torngit/github.py
@@ -1616,9 +1616,9 @@ class Github(TorngitBaseAdapter):
             res = await self.api(client, "post", url, body=body, token=token)
             return res
 
-    async def edit_comment(self, issueid, commentid, body, token=None):
+    async def edit_comment(self, issueid, commentid, body, token=None, allow_copilot_button = True):
         token = self.get_token_by_type_if_none(token, TokenType.comment)
-        body = await self.build_comment_request_body(body, issueid)
+        body = await self.build_comment_request_body(body, issueid, allow_copilot_button)
         # https://developer.github.com/v3/issues/comments/#edit-a-comment
         try:
             async with self.get_client() as client:

--- a/shared/torngit/github.py
+++ b/shared/torngit/github.py
@@ -608,29 +608,30 @@ class Github(TorngitBaseAdapter):
         return GITHUB_API_ENDPOINTS[url_name]["url_template"]
 
     async def build_comment_request_body(
-        self, body: dict, issueid: int | None = None
+        self, body: dict, issueid: int | None = None, allow_copilot_button: bool = True
     ) -> dict:
         body = dict(body=body)
-        try:
-            ownerid = self.data["owner"].get("ownerid")
-            if (
-                issueid is not None
-                and await INCLUDE_GITHUB_COMMENT_ACTIONS_BY_OWNER.check_value_async(
-                    identifier=ownerid, default=False
-                )
-            ):
-                bot_name = get_config(
-                    "github", "comment_action_bot_name", default="sentry"
-                )
-                body["actions"] = [
-                    {
-                        "name": "Generate Unit Tests",
-                        "type": "copilot-chat",
-                        "prompt": f"@{bot_name} generate tests for this PR.",
-                    }
-                ]
-        except Exception:
-            pass
+        if allow_copilot_button:
+            try:
+                ownerid = self.data["owner"].get("ownerid")
+                if (
+                    issueid is not None
+                    and await INCLUDE_GITHUB_COMMENT_ACTIONS_BY_OWNER.check_value_async(
+                        identifier=ownerid, default=False
+                    )
+                ):
+                    bot_name = get_config(
+                        "github", "comment_action_bot_name", default="sentry"
+                    )
+                    body["actions"] = [
+                        {
+                            "name": "Generate Unit Tests",
+                            "type": "copilot-chat",
+                            "prompt": f"@{bot_name} generate tests for this PR.",
+                        }
+                    ]
+            except Exception:
+                pass
 
         return body
 
@@ -1604,9 +1605,9 @@ class Github(TorngitBaseAdapter):
 
     # Comments
     # --------
-    async def post_comment(self, issueid, body, token=None):
+    async def post_comment(self, issueid, body, token=None, allow_copilot_button=True):
         token = self.get_token_by_type_if_none(token, TokenType.comment)
-        body = await self.build_comment_request_body(body, issueid)
+        body = await self.build_comment_request_body(body, issueid, allow_copilot_button)
         # https://developer.github.com/v3/issues/comments/#create-a-comment
         async with self.get_client() as client:
             url = self.count_and_get_url_template(url_name="post_comment").substitute(

--- a/shared/torngit/github.py
+++ b/shared/torngit/github.py
@@ -1607,7 +1607,9 @@ class Github(TorngitBaseAdapter):
     # --------
     async def post_comment(self, issueid, body, token=None, allow_copilot_button=True):
         token = self.get_token_by_type_if_none(token, TokenType.comment)
-        body = await self.build_comment_request_body(body, issueid, allow_copilot_button)
+        body = await self.build_comment_request_body(
+            body, issueid, allow_copilot_button
+        )
         # https://developer.github.com/v3/issues/comments/#create-a-comment
         async with self.get_client() as client:
             url = self.count_and_get_url_template(url_name="post_comment").substitute(
@@ -1616,9 +1618,13 @@ class Github(TorngitBaseAdapter):
             res = await self.api(client, "post", url, body=body, token=token)
             return res
 
-    async def edit_comment(self, issueid, commentid, body, token=None, allow_copilot_button = True):
+    async def edit_comment(
+        self, issueid, commentid, body, token=None, allow_copilot_button=True
+    ):
         token = self.get_token_by_type_if_none(token, TokenType.comment)
-        body = await self.build_comment_request_body(body, issueid, allow_copilot_button)
+        body = await self.build_comment_request_body(
+            body, issueid, allow_copilot_button
+        )
         # https://developer.github.com/v3/issues/comments/#edit-a-comment
         try:
             async with self.get_client() as client:


### PR DESCRIPTION
BA doesn't need this copilot button to appear in them, so I'm adding a variable to enable/disable that button

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.