### PR TITLE
Downgrade config log level

### DIFF
--- a/shared/validation/install.py
+++ b/shared/validation/install.py
@@ -403,7 +403,7 @@ def validate_install_configuration(inputted_dict):
     validator = CodecovYamlValidator(show_secret=True)
     is_valid = validator.validate(inputted_dict, config_schema)
     if not is_valid:
-        log.warning(
+        log.debug(
             "Configuration considered invalid, using dict as it is",
             extra=dict(errors=validator.errors),
         )


### PR DESCRIPTION
<!-- Describe your PR here. -->

Our config is forever and always invalid. Lets not spam logs about it.


<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.