### PR TITLE
feat: do storage service caching in shared

### DIFF
--- a/tests/unit/storage/test_init.py
+++ b/tests/unit/storage/test_init.py
@@ -140,3 +140,23 @@ class TestStorageInitialization(object):
         res = get_appropriate_storage_service(repoid=123)
         assert isinstance(res, MinioStorageService)
         assert res.minio_config == minio_config
+
+    def test_get_appropriate_storage_service_new_minio_cached(
+        self, mock_configuration, mocker
+    ):
+        mock_configuration.params["services"] = {
+            "chosen_storage": "minio",
+            "gcp": gcp_config,
+            "aws": aws_config,
+            "minio": minio_config,
+        }
+
+        mocker.patch.object(USE_NEW_MINIO, "check_value", return_value=False)
+
+        res = get_appropriate_storage_service(repoid=123)
+
+        assert isinstance(res, MinioStorageService)
+        assert res.minio_config == minio_config
+
+        second_res = get_appropriate_storage_service(repoid=123)
+        assert res is second_res


### PR DESCRIPTION
we currently do storage service caching in the worker with the reason that the initialization cost is non-trivial. i'm moving this caching to the shared layer, mostly because of the new minio rollout but also because it generally feels like a good idea (since it's been a good idea to do it in the worker).

There will be a change in the worker that will remove its layer of caching.

Maybe eventually, we will find that the complication of doing this caching is not worth it performance wise.