### PR TITLE
Bundle Analysis: Add Astro plugin to routing info

### DIFF
--- a/shared/bundle_analysis/comparison.py
+++ b/shared/bundle_analysis/comparison.py
@@ -413,7 +413,12 @@ class BundleAnalysisComparison:
         bundle_names = base_bundle_reports.keys() | head_bundle_reports.keys()
         comparison_mapping = {
             name: BundleRoutesComparison(
-                base_bundle_reports.get(name), head_bundle_reports.get(name)
+                base_bundle_reports.get(
+                    name, BundleRouteReport(self.base_report.db_path, {})
+                ),
+                head_bundle_reports.get(
+                    name, BundleRouteReport(self.head_report.db_path, {})
+                ),
             ).size_changes()
             for name in bundle_names
         }

--- a/tests/unit/bundle_analysis/test_bundle_utils.py
+++ b/tests/unit/bundle_analysis/test_bundle_utils.py
@@ -247,6 +247,61 @@ def test_bundle_asset_route_sveltekit_get_from_filename():
         assert result == expected, f"Failed for invalid case: {filename}"
 
 
+def test_bundle_asset_route_asset_route_astro_get_from_filename():
+    """
+    Test the get_from_filename method for the Astro plugin.
+    """
+    plugin = AssetRoutePluginName.ASTRO
+
+    # Valid cases
+    valid_cases = [
+        ("./src/pages/index.astro", "/"),  # Root
+        (
+            "src/pages/index.ts?__client-route",
+            "/",
+        ),  # With parameter after extension
+        ("src/pages/about.md", "/about"),  # Base case
+        ("src/pages/concerts/new-york.mdx", "/concerts/new-york"),  # Multiple
+        ("src/pages/concerts/index.ts", "/concerts"),  # Dynamic segments
+        (
+            "src/pages/[concerts].html",
+            "/[concerts]",
+        ),  # HTML
+        (
+            "src/pages/[city]/[..concerts]/[band].astro",
+            "/[city]/[..concerts]/[band]",
+        ),  # Dot dot expansion
+        # Ignoring underscore prefix
+        ("src/pages/_city/index.ts", None),
+        ("src/pages/city/_bank/index.ts", None),
+        ("src/pages/city/bank/_index.ts", None),
+        ("src/pages/city/bank/_post.ts", None),
+    ]
+
+    # Invalid cases
+    invalid_cases = [
+        ("hello.js", None),  # Contain at lease 3 parts
+        ("app/bout/hello.js", None),  # Prefix is not present
+        ("gap/routest/hello.js", None),  # Prefix is not present
+        ("src/pages/.hiddenfile", None),  # Hidden file (no valid name)
+        ("src/pages/invalidfile.", None),  # Ends with a dot
+        ("src/pages/invalidfile", None),  # No dot (not a file)
+        ("src/pages/badextension.py", None),  # Not valid extension
+    ]
+
+    # Test valid cases
+    for filename, expected in valid_cases:
+        asset_route = AssetRoute(plugin=plugin)
+        result = asset_route.get_from_filename(filename=filename)
+        assert result == expected, f"Failed for valid case: {filename}"
+
+    # Test invalid cases
+    for filename, expected in invalid_cases:
+        asset_route = AssetRoute(plugin=plugin)
+        result = asset_route.get_from_filename(filename=filename)
+        assert result == expected, f"Failed for invalid case: {filename}"
+
+
 def test_bundle_asset_route_exception_handling():
     """
     Test that get_from_filename correctly handles exceptions and logs them.


### PR DESCRIPTION
- Add Astro plugin to the list of supported plugins that can have info about asset routes.
- Also fix an issue with comparisons where base and head may not have the same bundles.

https://github.com/codecov/engineering-team/issues/3057

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.