### PR TITLE
Add conditional based on upload type

### DIFF
--- a/shared/reports/types.py
+++ b/shared/reports/types.py
@@ -1,4 +1,5 @@
 import logging
+from enum import Enum
 from dataclasses import asdict, dataclass
 from decimal import Decimal
 from typing import Any, Dict, List, Optional, Sequence, Tuple, TypedDict, Union
@@ -252,3 +253,8 @@ class ReportFileSummary(object):
             None,
             self.diff_totals,
         )
+
+class UploadType(Enum):
+    COVERAGE = "coverage"
+    TEST_RESULTS = "test_results"
+    BUNDLE_ANALYSIS = "bundle_analysis"

--- a/shared/reports/types.py
+++ b/shared/reports/types.py
@@ -1,7 +1,7 @@
 import logging
-from enum import Enum
 from dataclasses import asdict, dataclass
 from decimal import Decimal
+from enum import Enum
 from typing import Any, Dict, List, Optional, Sequence, Tuple, TypedDict, Union
 
 log = logging.getLogger(__name__)
@@ -253,6 +253,7 @@ class ReportFileSummary(object):
             None,
             self.diff_totals,
         )
+
 
 class UploadType(Enum):
     COVERAGE = "coverage"

--- a/shared/torngit/base.py
+++ b/shared/torngit/base.py
@@ -81,7 +81,7 @@ class TorngitBaseAdapter(object):
             "repo": {},
             "fallback_installations": None,
             "installation": None,
-            "additional_data": {}
+            "additional_data": {},
         }
         self.verify_ssl = verify_ssl
         self.data.update(kwargs)

--- a/shared/torngit/base.py
+++ b/shared/torngit/base.py
@@ -81,6 +81,7 @@ class TorngitBaseAdapter(object):
             "repo": {},
             "fallback_installations": None,
             "installation": None,
+            "additional_data": {}
         }
         self.verify_ssl = verify_ssl
         self.data.update(kwargs)

--- a/shared/torngit/github.py
+++ b/shared/torngit/github.py
@@ -35,7 +35,7 @@ from shared.torngit.exceptions import (
 from shared.torngit.response_types import ProviderPull
 from shared.torngit.status import Status
 from shared.typings.oauth_token_types import OauthConsumerToken
-from shared.typings.torngit import GithubInstallationInfo
+from shared.typings.torngit import GithubInstallationInfo, UploadType
 from shared.utils.urls import url_concat
 
 log = logging.getLogger(__name__)
@@ -611,26 +611,27 @@ class Github(TorngitBaseAdapter):
         self, body: dict, issueid: int | None = None
     ) -> dict:
         body = dict(body=body)
-        try:
-            ownerid = self.data["owner"].get("ownerid")
-            if (
-                issueid is not None
-                and await INCLUDE_GITHUB_COMMENT_ACTIONS_BY_OWNER.check_value_async(
-                    identifier=ownerid, default=False
-                )
-            ):
-                bot_name = get_config(
-                    "github", "comment_action_bot_name", default="sentry"
-                )
-                body["actions"] = [
-                    {
-                        "name": "Generate Unit Tests",
-                        "type": "copilot-chat",
-                        "prompt": f"@{bot_name} generate tests for this PR.",
-                    }
-                ]
-        except Exception:
-            pass
+        if self.data.get("additional_data", {}).get("upload_type") != UploadType.BUNDLE_ANALYSIS:
+            try:
+                ownerid = self.data["owner"].get("ownerid")
+                if (
+                    issueid is not None
+                    and await INCLUDE_GITHUB_COMMENT_ACTIONS_BY_OWNER.check_value_async(
+                        identifier=ownerid, default=False
+                    )
+                ):
+                    bot_name = get_config(
+                        "github", "comment_action_bot_name", default="sentry"
+                    )
+                    body["actions"] = [
+                        {
+                            "name": "Generate Unit Tests",
+                            "type": "copilot-chat",
+                            "prompt": f"@{bot_name} generate tests for this PR.",
+                        }
+                    ]
+            except Exception:
+                pass
 
         return body
 

--- a/shared/torngit/github.py
+++ b/shared/torngit/github.py
@@ -611,7 +611,10 @@ class Github(TorngitBaseAdapter):
         self, body: dict, issueid: int | None = None
     ) -> dict:
         body = dict(body=body)
-        if self.data.get("additional_data", {}).get("upload_type") != UploadType.BUNDLE_ANALYSIS:
+        if (
+            self.data.get("additional_data", {}).get("upload_type")
+            != UploadType.BUNDLE_ANALYSIS
+        ):
             try:
                 ownerid = self.data["owner"].get("ownerid")
                 if (

--- a/shared/typings/torngit.py
+++ b/shared/typings/torngit.py
@@ -1,5 +1,10 @@
+from enum import Enum
 from typing import Dict, List, Optional, TypedDict, Union
 
+class UploadType(Enum):
+    COVERAGE = "coverage"
+    TEST_RESULTS = "test_results"
+    BUNDLE_ANALYSIS = "bundle_analysis"
 
 class OwnerInfo(TypedDict):
     service_id: str
@@ -25,9 +30,13 @@ class GithubInstallationInfo(TypedDict):
     app_id: Optional[int]
     pem_path: Optional[str]
 
+class AdditionalData(TypedDict):
+    upload_type: Optional[UploadType]
+
 
 class TorngitInstanceData(TypedDict):
     owner: Union[OwnerInfo, Dict]
     repo: Union[RepoInfo, Dict]
     fallback_installations: List[Optional[GithubInstallationInfo]] | None
     installation: Optional[GithubInstallationInfo]
+    additional_data: Optional[AdditionalData]

--- a/shared/typings/torngit.py
+++ b/shared/typings/torngit.py
@@ -1,4 +1,5 @@
-from typing import Dict, List, Optional, TypedDict, Union, NotRequired
+from typing import Dict, List, NotRequired, Optional, TypedDict, Union
+
 from shared.reports.types import UploadType
 
 
@@ -25,6 +26,7 @@ class GithubInstallationInfo(TypedDict):
     # All other apps need app_id and pem_path
     app_id: Optional[int]
     pem_path: Optional[str]
+
 
 class AdditionalData(TypedDict):
     upload_type: NotRequired[UploadType]

--- a/shared/typings/torngit.py
+++ b/shared/typings/torngit.py
@@ -1,10 +1,6 @@
-from enum import Enum
-from typing import Dict, List, Optional, TypedDict, Union
+from typing import Dict, List, Optional, TypedDict, Union, NotRequired
+from shared.reports.types import UploadType
 
-class UploadType(Enum):
-    COVERAGE = "coverage"
-    TEST_RESULTS = "test_results"
-    BUNDLE_ANALYSIS = "bundle_analysis"
 
 class OwnerInfo(TypedDict):
     service_id: str
@@ -31,7 +27,7 @@ class GithubInstallationInfo(TypedDict):
     pem_path: Optional[str]
 
 class AdditionalData(TypedDict):
-    upload_type: Optional[UploadType]
+    upload_type: NotRequired[UploadType]
 
 
 class TorngitInstanceData(TypedDict):


### PR DESCRIPTION
The copilot AI button appears in every PR comment but should not appear in the BA PR comment. This solution adds a way to specify the upload type and manipulate the data being sent to GH.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.