### PR TITLE
feat: Map helper functions to available plans

### DIFF
--- a/shared/plan/constants.py
+++ b/shared/plan/constants.py
@@ -90,6 +90,23 @@ class PlanData:
     monthly_uploads_limit: Optional[MonthlyUploadLimits]
     trial_days: Optional[TrialDaysAmount]
 
+    def convert_to_DTO(self) -> dict:
+        return {
+            "marketing_name": self.marketing_name,
+            "value": self.value,
+            "billing_rate": self.billing_rate,
+            "base_unit_price": self.base_unit_price,
+            "benefits": self.benefits,
+            "tier_name": self.tier_name,
+            "monthly_uploads_limit": self.monthly_uploads_limit,
+            "trial_days": self.trial_days,
+            "is_free_plan": self.tier_name == TierName.BASIC,
+            "is_pro_plan": self.tier_name == TierName.PRO,
+            "is_team_plan": self.tier_name == TierName.TEAM,
+            "is_enterprise_plan": self.tier_name == TierName.ENTERPRISE,
+            "is_sentry_plan": self.value in SENTRY_PAID_USER_PLAN_REPRESENTATIONS,
+        }
+
 
 NON_PR_AUTHOR_PAID_USER_PLAN_REPRESENTATIONS = {
     PlanName.CODECOV_PRO_MONTHLY_LEGACY.value: PlanData(

--- a/shared/plan/service.py
+++ b/shared/plan/service.py
@@ -173,7 +173,7 @@ class PlanService:
         ):
             available_plans += TEAM_PLAN_REPRESENTATIONS.values()
 
-        return available_plans
+        return [plan.convert_to_DTO() for plan in available_plans]
 
     def _start_trial_helper(
         self,

--- a/tests/unit/plan/test_plan.py
+++ b/tests/unit/plan/test_plan.py
@@ -349,6 +349,7 @@ class AvailablePlansBeforeTrial(TestCase):
         expected_result.append(BASIC_PLAN)
         expected_result += PR_AUTHOR_PAID_USER_PLAN_REPRESENTATIONS.values()
         expected_result += TEAM_PLAN_REPRESENTATIONS.values()
+        expected_result = [result.convert_to_DTO() for result in expected_result]
 
         assert plan_service.available_plans(owner=self.owner) == expected_result
 
@@ -365,6 +366,7 @@ class AvailablePlansBeforeTrial(TestCase):
         expected_result.append(FREE_PLAN)
         expected_result += PR_AUTHOR_PAID_USER_PLAN_REPRESENTATIONS.values()
         expected_result += TEAM_PLAN_REPRESENTATIONS.values()
+        expected_result = [result.convert_to_DTO() for result in expected_result]
 
         assert plan_service.available_plans(owner=self.owner) == expected_result
 
@@ -380,6 +382,7 @@ class AvailablePlansBeforeTrial(TestCase):
         expected_result.append(BASIC_PLAN)
         expected_result += PR_AUTHOR_PAID_USER_PLAN_REPRESENTATIONS.values()
         expected_result += TEAM_PLAN_REPRESENTATIONS.values()
+        expected_result = [result.convert_to_DTO() for result in expected_result]
 
         assert plan_service.available_plans(owner=self.owner) == expected_result
 
@@ -393,6 +396,7 @@ class AvailablePlansBeforeTrial(TestCase):
         expected_result.append(BASIC_PLAN)
         expected_result += PR_AUTHOR_PAID_USER_PLAN_REPRESENTATIONS.values()
         expected_result += TEAM_PLAN_REPRESENTATIONS.values()
+        expected_result = [result.convert_to_DTO() for result in expected_result]
 
         assert plan_service.available_plans(owner=self.owner) == expected_result
 
@@ -411,6 +415,7 @@ class AvailablePlansBeforeTrial(TestCase):
         expected_result += PR_AUTHOR_PAID_USER_PLAN_REPRESENTATIONS.values()
         expected_result += SENTRY_PAID_USER_PLAN_REPRESENTATIONS.values()
         expected_result += TEAM_PLAN_REPRESENTATIONS.values()
+        expected_result = [result.convert_to_DTO() for result in expected_result]
 
         assert plan_service.available_plans(owner=self.owner) == expected_result
 
@@ -429,6 +434,7 @@ class AvailablePlansBeforeTrial(TestCase):
         expected_result += PR_AUTHOR_PAID_USER_PLAN_REPRESENTATIONS.values()
         expected_result += SENTRY_PAID_USER_PLAN_REPRESENTATIONS.values()
         expected_result += TEAM_PLAN_REPRESENTATIONS.values()
+        expected_result = [result.convert_to_DTO() for result in expected_result]
 
         assert plan_service.available_plans(owner=self.owner) == expected_result
 
@@ -445,6 +451,7 @@ class AvailablePlansBeforeTrial(TestCase):
         expected_result += PR_AUTHOR_PAID_USER_PLAN_REPRESENTATIONS.values()
         expected_result += SENTRY_PAID_USER_PLAN_REPRESENTATIONS.values()
         expected_result += TEAM_PLAN_REPRESENTATIONS.values()
+        expected_result = [result.convert_to_DTO() for result in expected_result]
 
         assert plan_service.available_plans(owner=self.owner) == expected_result
 
@@ -481,6 +488,7 @@ class AvailablePlansExpiredTrialLessThanTenUsers(TestCase):
         expected_result.append(BASIC_PLAN)
         expected_result += PR_AUTHOR_PAID_USER_PLAN_REPRESENTATIONS.values()
         expected_result += TEAM_PLAN_REPRESENTATIONS.values()
+        expected_result = [result.convert_to_DTO() for result in expected_result]
 
         assert plan_service.available_plans(owner=self.owner) == expected_result
 
@@ -496,6 +504,7 @@ class AvailablePlansExpiredTrialLessThanTenUsers(TestCase):
         expected_result.append(BASIC_PLAN)
         expected_result += PR_AUTHOR_PAID_USER_PLAN_REPRESENTATIONS.values()
         expected_result += TEAM_PLAN_REPRESENTATIONS.values()
+        expected_result = [result.convert_to_DTO() for result in expected_result]
 
         assert plan_service.available_plans(owner=self.owner) == expected_result
 
@@ -509,6 +518,7 @@ class AvailablePlansExpiredTrialLessThanTenUsers(TestCase):
         expected_result.append(BASIC_PLAN)
         expected_result += PR_AUTHOR_PAID_USER_PLAN_REPRESENTATIONS.values()
         expected_result += TEAM_PLAN_REPRESENTATIONS.values()
+        expected_result = [result.convert_to_DTO() for result in expected_result]
 
         assert plan_service.available_plans(owner=self.owner) == expected_result
 
@@ -527,6 +537,7 @@ class AvailablePlansExpiredTrialLessThanTenUsers(TestCase):
         expected_result += PR_AUTHOR_PAID_USER_PLAN_REPRESENTATIONS.values()
         expected_result += SENTRY_PAID_USER_PLAN_REPRESENTATIONS.values()
         expected_result += TEAM_PLAN_REPRESENTATIONS.values()
+        expected_result = [result.convert_to_DTO() for result in expected_result]
 
         assert plan_service.available_plans(owner=self.owner) == expected_result
 
@@ -545,6 +556,7 @@ class AvailablePlansExpiredTrialLessThanTenUsers(TestCase):
         expected_result += PR_AUTHOR_PAID_USER_PLAN_REPRESENTATIONS.values()
         expected_result += SENTRY_PAID_USER_PLAN_REPRESENTATIONS.values()
         expected_result += TEAM_PLAN_REPRESENTATIONS.values()
+        expected_result = [result.convert_to_DTO() for result in expected_result]
 
         assert plan_service.available_plans(owner=self.owner) == expected_result
 
@@ -563,6 +575,7 @@ class AvailablePlansExpiredTrialLessThanTenUsers(TestCase):
         expected_result += PR_AUTHOR_PAID_USER_PLAN_REPRESENTATIONS.values()
         expected_result += SENTRY_PAID_USER_PLAN_REPRESENTATIONS.values()
         expected_result += TEAM_PLAN_REPRESENTATIONS.values()
+        expected_result = [result.convert_to_DTO() for result in expected_result]
 
         assert plan_service.available_plans(owner=self.owner) == expected_result
 
@@ -594,6 +607,7 @@ class AvailablePlansExpiredTrialMoreThanTenActivatedUsers(TestCase):
         expected_result = []
         expected_result.append(BASIC_PLAN)
         expected_result += PR_AUTHOR_PAID_USER_PLAN_REPRESENTATIONS.values()
+        expected_result = [result.convert_to_DTO() for result in expected_result]
 
         assert plan_service.available_plans(owner=self.owner) == expected_result
 
@@ -611,6 +625,7 @@ class AvailablePlansExpiredTrialMoreThanTenActivatedUsers(TestCase):
         expected_result.append(BASIC_PLAN)
         expected_result += PR_AUTHOR_PAID_USER_PLAN_REPRESENTATIONS.values()
         expected_result += SENTRY_PAID_USER_PLAN_REPRESENTATIONS.values()
+        expected_result = [result.convert_to_DTO() for result in expected_result]
 
         assert plan_service.available_plans(owner=self.owner) == expected_result
 
@@ -628,6 +643,7 @@ class AvailablePlansExpiredTrialMoreThanTenActivatedUsers(TestCase):
         expected_result.append(BASIC_PLAN)
         expected_result += PR_AUTHOR_PAID_USER_PLAN_REPRESENTATIONS.values()
         expected_result += SENTRY_PAID_USER_PLAN_REPRESENTATIONS.values()
+        expected_result = [result.convert_to_DTO() for result in expected_result]
 
         assert plan_service.available_plans(owner=self.owner) == expected_result
 
@@ -643,6 +659,9 @@ class AvailablePlansExpiredTrialMoreThanTenSeatsLessThanTenActivatedUsers(TestCa
         self.expected_result.append(BASIC_PLAN)
         self.expected_result += PR_AUTHOR_PAID_USER_PLAN_REPRESENTATIONS.values()
         self.expected_result += TEAM_PLAN_REPRESENTATIONS.values()
+        self.expected_result = [
+            result.convert_to_DTO() for result in self.expected_result
+        ]
 
     def test_currently_team_plan(self):
         self.current_org = OwnerFactory(
@@ -700,6 +719,10 @@ class AvailablePlansExpiredTrialMoreThanTenSeatsLessThanTenActivatedUsers(TestCa
         self.expected_result.append(BASIC_PLAN)
         self.expected_result += PR_AUTHOR_PAID_USER_PLAN_REPRESENTATIONS.values()
         self.expected_result += TEAM_PLAN_REPRESENTATIONS.values()
+        self.expected_result = [
+            result.convert_to_DTO() for result in self.expected_result
+        ]
+
         assert (
             self.plan_service.available_plans(owner=self.owner) == self.expected_result
         )
@@ -734,6 +757,7 @@ class AvailablePlansOngoingTrial(TestCase):
         expected_result.append(BASIC_PLAN)
         expected_result += PR_AUTHOR_PAID_USER_PLAN_REPRESENTATIONS.values()
         expected_result += TEAM_PLAN_REPRESENTATIONS.values()
+        expected_result = [result.convert_to_DTO() for result in expected_result]
 
         # Can do Team plan when plan_activated_users is null
         assert self.plan_service.available_plans(owner=self.owner) == expected_result
@@ -751,6 +775,7 @@ class AvailablePlansOngoingTrial(TestCase):
         expected_result = []
         expected_result.append(BASIC_PLAN)
         expected_result += PR_AUTHOR_PAID_USER_PLAN_REPRESENTATIONS.values()
+        expected_result = [result.convert_to_DTO() for result in expected_result]
 
         # Can not do Team plan when at 11 activated users
         assert self.plan_service.available_plans(owner=self.owner) == expected_result
@@ -765,6 +790,7 @@ class AvailablePlansOngoingTrial(TestCase):
         expected_result += PR_AUTHOR_PAID_USER_PLAN_REPRESENTATIONS.values()
         expected_result += SENTRY_PAID_USER_PLAN_REPRESENTATIONS.values()
         expected_result += TEAM_PLAN_REPRESENTATIONS.values()
+        expected_result = [result.convert_to_DTO() for result in expected_result]
 
         # Can do Team plan when plan_activated_users is null
         assert self.plan_service.available_plans(owner=self.owner) == expected_result
@@ -783,6 +809,7 @@ class AvailablePlansOngoingTrial(TestCase):
         expected_result.append(BASIC_PLAN)
         expected_result += PR_AUTHOR_PAID_USER_PLAN_REPRESENTATIONS.values()
         expected_result += SENTRY_PAID_USER_PLAN_REPRESENTATIONS.values()
+        expected_result = [result.convert_to_DTO() for result in expected_result]
 
         # Can not do Team plan when at 11 activated users
         assert self.plan_service.available_plans(owner=self.owner) == expected_result


### PR DESCRIPTION
<!-- Describe your PR here. -->
Needed for available plans data type.



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.