### PR TITLE
Update with value instead of keys for plan data dict

### DIFF
--- a/shared/plan/constants.py
+++ b/shared/plan/constants.py
@@ -100,10 +100,11 @@ class PlanData:
             "tier_name": self.tier_name,
             "monthly_uploads_limit": self.monthly_uploads_limit,
             "trial_days": self.trial_days,
-            "is_free_plan": self.tier_name == TierName.BASIC,
-            "is_pro_plan": self.tier_name == TierName.PRO,
-            "is_team_plan": self.tier_name == TierName.TEAM,
-            "is_enterprise_plan": self.tier_name == TierName.ENTERPRISE,
+            "is_free_plan": self.tier_name == TierName.BASIC.value,
+            "is_pro_plan": self.tier_name == TierName.PRO.value,
+            "is_team_plan": self.tier_name == TierName.TEAM.value,
+            "is_enterprise_plan": self.tier_name == TierName.ENTERPRISE.value,
+            "is_trial_plan": self.value == PlanName.TRIAL_PLAN_NAME.value,
             "is_sentry_plan": self.value in SENTRY_PAID_USER_PLAN_REPRESENTATIONS,
         }
 


### PR DESCRIPTION
<!-- Describe your PR here. -->
tier name maps to values.


<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.