### PR TITLE
Ensure that language validation works on all supported languages

### DIFF
--- a/shared/torngit/base.py
+++ b/shared/torngit/base.py
@@ -4,6 +4,7 @@ from typing import Dict, List, Optional, Tuple
 
 import httpx
 
+from shared.django_apps.core.models import Repository
 from shared.torngit.cache import torngit_cache
 from shared.torngit.enums import Endpoints
 from shared.torngit.response_types import ProviderPull
@@ -38,28 +39,7 @@ class TorngitBaseAdapter(object):
     _token: Token | None = None
     verify_ssl = None
 
-    valid_languages = (
-        "javascript",
-        "shell",
-        "python",
-        "ruby",
-        "perl",
-        "dart",
-        "java",
-        "c",
-        "clojure",
-        "d",
-        "fortran",
-        "go",
-        "groovy",
-        "kotlin",
-        "php",
-        "r",
-        "scala",
-        "swift",
-        "objective-c",
-        "xtend",
-    )
+    valid_languages = set(language.value for language in Repository.Languages)
 
     def __init__(
         self,


### PR DESCRIPTION
The database has a set of enum validation which is different from the in-code validation that we do when checking that the language is valid. This should ensure that the language set looks the same.

Resolves this issue: https://github.com/codecov/engineering-team/issues/2061

Might want to try this in worker/staging before merging because it uses a Django property.
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.