### PR TITLE
[Bundle Analysis] Cache config service get_or_create

### DIFF
--- a/shared/django_apps/bundle_analysis/service/bundle_analysis.py
+++ b/shared/django_apps/bundle_analysis/service/bundle_analysis.py
@@ -9,7 +9,7 @@ class BundleAnalysisCacheConfigService:
         )
 
     @staticmethod
-    def create_cache_option(repo_id, name, is_caching=True) -> None:
+    def create_if_not_exists(repo_id, name, is_caching=True) -> None:
         CacheConfig.objects.get_or_create(
             repo_id=repo_id, bundle_name=name, defaults={"is_caching": is_caching}
         )

--- a/shared/django_apps/bundle_analysis/service/bundle_analysis.py
+++ b/shared/django_apps/bundle_analysis/service/bundle_analysis.py
@@ -7,3 +7,9 @@ class BundleAnalysisCacheConfigService:
         CacheConfig.objects.update_or_create(
             repo_id=repo_id, bundle_name=name, defaults={"is_caching": is_caching}
         )
+
+    @staticmethod
+    def create_cache_option(repo_id, name, is_caching=True) -> None:
+        CacheConfig.objects.get_or_create(
+            repo_id=repo_id, bundle_name=name, defaults={"is_caching": is_caching}
+        )

--- a/shared/django_apps/bundle_analysis/tests/service/test_bundle_config.py
+++ b/shared/django_apps/bundle_analysis/tests/service/test_bundle_config.py
@@ -65,3 +65,39 @@ class BundleAnalysisCacheConfigServiceTest(TestCase):
 
         query_results = CacheConfig.objects.all()
         assert len(query_results) == 4
+
+    def test_bundle_config_get_or_create(self):
+        # Create 1 -- default as is_caching=True
+        BundleAnalysisCacheConfigService.create_cache_option(repo_id=1, name="bundleA")
+        query_results = CacheConfig.objects.all()
+        assert len(query_results) == 1
+        assert query_results[0].repo_id == 1
+        assert query_results[0].bundle_name == "bundleA"
+        assert query_results[0].is_caching == True
+
+        # Create 2 -- already exist don't change is_caching value
+        BundleAnalysisCacheConfigService.create_cache_option(
+            repo_id=1, name="bundleA", is_caching=False
+        )
+        query_results = CacheConfig.objects.all()
+        assert len(query_results) == 1
+        assert query_results[0].repo_id == 1
+        assert query_results[0].bundle_name == "bundleA"
+        assert query_results[0].is_caching == True
+
+        # Create 3 -- new bundle
+        BundleAnalysisCacheConfigService.create_cache_option(
+            repo_id=1, name="bundleB", is_caching=False
+        )
+        query_results = CacheConfig.objects.all()
+        assert len(query_results) == 2
+        query_results = CacheConfig.objects.filter(bundle_name="bundleA").all()
+        assert len(query_results) == 1
+        assert query_results[0].repo_id == 1
+        assert query_results[0].bundle_name == "bundleA"
+        assert query_results[0].is_caching == True
+        query_results = CacheConfig.objects.filter(bundle_name="bundleB").all()
+        assert len(query_results) == 1
+        assert query_results[0].repo_id == 1
+        assert query_results[0].bundle_name == "bundleB"
+        assert query_results[0].is_caching == False

--- a/shared/django_apps/bundle_analysis/tests/service/test_bundle_config.py
+++ b/shared/django_apps/bundle_analysis/tests/service/test_bundle_config.py
@@ -68,7 +68,7 @@ class BundleAnalysisCacheConfigServiceTest(TestCase):
 
     def test_bundle_config_get_or_create(self):
         # Create 1 -- default as is_caching=True
-        BundleAnalysisCacheConfigService.create_cache_option(repo_id=1, name="bundleA")
+        BundleAnalysisCacheConfigService.create_if_not_exists(repo_id=1, name="bundleA")
         query_results = CacheConfig.objects.all()
         assert len(query_results) == 1
         assert query_results[0].repo_id == 1
@@ -76,7 +76,7 @@ class BundleAnalysisCacheConfigServiceTest(TestCase):
         assert query_results[0].is_caching == True
 
         # Create 2 -- already exist don't change is_caching value
-        BundleAnalysisCacheConfigService.create_cache_option(
+        BundleAnalysisCacheConfigService.create_if_not_exists(
             repo_id=1, name="bundleA", is_caching=False
         )
         query_results = CacheConfig.objects.all()
@@ -86,7 +86,7 @@ class BundleAnalysisCacheConfigServiceTest(TestCase):
         assert query_results[0].is_caching == True
 
         # Create 3 -- new bundle
-        BundleAnalysisCacheConfigService.create_cache_option(
+        BundleAnalysisCacheConfigService.create_if_not_exists(
             repo_id=1, name="bundleB", is_caching=False
         )
         query_results = CacheConfig.objects.all()


### PR DESCRIPTION
Add get_or_create, will have to use this instead of update_or_create in the BA processor. Currently we will always overwrite what the caching bool to true when doing a new commit into default branch. When switching to this the intention is that if the bundle cache data already exists we will not overwrite it to true.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.