### PR TITLE
Add batch insert fn for measurements

### DIFF
--- a/shared/upload/utils.py
+++ b/shared/upload/utils.py
@@ -1,6 +1,7 @@
 from datetime import timedelta
 from enum import Enum
 
+from django.db import transaction
 from django.db.models import Q
 from django.utils import timezone
 
@@ -33,6 +34,18 @@ def query_monthly_coverage_measurements(plan_service: PlanService) -> int:
         )
     monthly_limit = plan_service.monthly_uploads_limit
     return queryset[:monthly_limit].count()
+
+
+def bulk_insert_coverage_measurements(
+    measurements: list[UserMeasurement],
+) -> list[UserMeasurement]:
+    """
+    This function takes measurements as input and bulk_creates them into the DB.
+    The atomic transaction ensures either all transactions are inserted or none
+    if there's an error
+    """
+    with transaction.atomic():
+        return UserMeasurement.objects.bulk_create(measurements)
 
 
 def insert_coverage_measurement(


### PR DESCRIPTION
Create batch insert fn for user measurements

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.