### PR TITLE
chore: some type updates

### DIFF
--- a/shared/helpers/cache.py
+++ b/shared/helpers/cache.py
@@ -142,7 +142,7 @@ class LogMapping(dict):
         return self.get("args_indexes_to_log", [])
 
     @property
-    def kwargs_keys_to_log(self) -> List[Any]:
+    def kwargs_keys_to_log(self) -> List[str]:
         """List of args from the function to be logged (if present)"""
         return self.get("kwargs_keys_to_log", [])
 

--- a/shared/torngit/cache/__init__.py
+++ b/shared/torngit/cache/__init__.py
@@ -47,7 +47,7 @@ class TorngitCache(OurOwnCache):
     def is_enabled(self) -> bool:
         return self._enabled
 
-    def get_ttl(self, endpoint: CachedEndpoint) -> dict:
+    def get_ttl(self, endpoint: CachedEndpoint) -> int:
         return self.ttls.get(endpoint, 120)
 
 

--- a/shared/typings/oauth_token_types.py
+++ b/shared/typings/oauth_token_types.py
@@ -1,8 +1,9 @@
-from typing import Awaitable, Callable, Optional, TypedDict
+from typing import Awaitable, Callable, NotRequired, TypedDict
 
 
 class Token(TypedDict):
     key: str
+    refresh_token: NotRequired[str]
     # This information is used to identify the token owner in the logs, if present
     username: str | None
     # This represents the entity it belongs to. Entities can have the form of
@@ -13,9 +14,9 @@ class Token(TypedDict):
     entity_name: str | None
 
 
-class OauthConsumerToken(Token):
-    secret: Optional[str]
-    refresh_token: Optional[str]
+class OauthConsumerToken(TypedDict):
+    key: str  # client_id
+    secret: str
 
 
-OnRefreshCallback = Optional[Callable[[OauthConsumerToken], Awaitable[None]]]
+OnRefreshCallback = Callable[[Token], Awaitable[None]]

--- a/shared/typings/torngit.py
+++ b/shared/typings/torngit.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, NotRequired, Optional, TypedDict, Union
+from typing import Dict, List, NotRequired, Optional, TypedDict
 
 from shared.reports.types import UploadType
 
@@ -38,8 +38,8 @@ class AdditionalData(TypedDict):
 
 
 class TorngitInstanceData(TypedDict):
-    owner: Union[OwnerInfo, Dict]
-    repo: Union[RepoInfo, Dict]
-    fallback_installations: List[Optional[GithubInstallationInfo]] | None
-    installation: Optional[GithubInstallationInfo]
-    additional_data: Optional[AdditionalData]
+    owner: OwnerInfo | Dict
+    repo: RepoInfo | Dict
+    fallback_installations: List[GithubInstallationInfo | None] | None
+    installation: GithubInstallationInfo | None
+    additional_data: AdditionalData | None


### PR DESCRIPTION
Some relevant decisions:
* `timeout` passed to `TorngitBaseAdapter.__init__` is transformed into `httpx.Timeout` directly, (so that `self._timeout` can be directly an `httpx.Timeout` object instead a bunch of different options
* `verify_ssl` receives the default value of `True`. That shouldn't break anyone except BB server. (but no one is using it, so as I said it shouldn't break anyone)
* Better differentiation of aouth_consumer_token and token. They are actually different things.
