### PR TITLE
fix: sql migration failures should be an error, not info level

### DIFF
--- a/shared/django_apps/legacy_migrations/management/commands/migrate.py
+++ b/shared/django_apps/legacy_migrations/management/commands/migrate.py
@@ -142,7 +142,7 @@ class Command(MigrateCommand):
             super().handle(*args, **options)
             django_transaction.commit(database)
         except:
-            log.info("Codecov migrations failed.")
+            log.error("Codecov migrations failed.")
             raise
         else:
             log.info("Codecov migrations succeeded.")


### PR DESCRIPTION
We had a recent failure on upgrade of codecov due to a migration failure (reports_test_results_flag_bridge applying
unique constraints, but us having duplicates in that table.) 

If migrations fail, that should probably be reported as an error and not info level log message.
<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
