### PR TITLE
dev: Add Ruff print rules to shared (T20)

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -36,9 +36,9 @@ indent-width = 4
 target-version = "py312"
 
 [lint]
-# Currently only enabled for F (Pyflakes), I (isort), E,W (pycodestyle:Error/Warning), PLC/PLE/PLW (Pylint:Convention/Error/Warning) 
-# and PERF (Perflint) rules: https://docs.astral.sh/ruff/rules/
-select = ["F", "I", "E", "W", "PLC", "PLE", "PLW", "PERF"]
+# Currently only enabled for F (Pyflakes), I (isort), E,W (pycodestyle:Error/Warning), PLC/PLE/PLW (Pylint:Convention/Error/Warning),
+# PERF (Perflint), and T20 (Flake8-print) rules: https://docs.astral.sh/ruff/rules/
+select = ["F", "I", "E", "W", "PLC", "PLE", "PLW", "PERF", "T20"]
 ignore = ["F403", "F405", "E501", "E712"]
 
 # Allow fix for all enabled rules (when `--fix`) is provided.

--- a/shared/django_apps/reports/migrations/0019_auto_20240424_1824.py
+++ b/shared/django_apps/reports/migrations/0019_auto_20240424_1824.py
@@ -24,7 +24,7 @@ class Migration(migrations.Migration):
     ]
 
     def populate_test_instances(apps, schema_editor):
-        print("Not running due to performance")
+        print("Not running due to performance")  # noqa: T201
         return
         TestInstance = apps.get_model("reports", "TestInstance")
 

--- a/shared/license/__init__.py
+++ b/shared/license/__init__.py
@@ -100,4 +100,4 @@ def startup_license_logging():
 
         # printing the message in a single statement so the lines won't get split up
         # among all the other messages during startup
-        print(*statements_to_print, sep="\n")
+        print(*statements_to_print, sep="\n")  # noqa: T201

--- a/shared/storage/minio.py
+++ b/shared/storage/minio.py
@@ -246,7 +246,7 @@ class MinioStorageService(BaseStorageService):
             for del_err in self.minio_client.remove_objects(
                 bucket_name, [DeleteObject(path) for path in paths]
             ):
-                print("Deletion error: {}".format(del_err))
+                print("Deletion error: {}".format(del_err))  # noqa: T201
             return [True] * len(paths)
         except MinioException:
             raise

--- a/shared/storage/new_minio.py
+++ b/shared/storage/new_minio.py
@@ -310,7 +310,7 @@ class NewMinioStorageService(BaseStorageService):
             for del_err in self.minio_client.remove_objects(
                 bucket_name, [DeleteObject(url) for url in urls]
             ):
-                print("Deletion error: {}".format(del_err))
+                print("Deletion error: {}".format(del_err))  # noqa: T201
             return [True] * len(urls)
         except MinioException:
             raise

--- a/tests/integration/test_bitbucket.py
+++ b/tests/integration/test_bitbucket.py
@@ -525,7 +525,6 @@ class TestBitbucketTestCase(object):
             "commits": [{"commitid": "b92edba"}, {"commitid": "6ae5f17"}],
         }
         res = await valid_handler.get_compare(base, head)
-        print(res)
         assert sorted(list(res.keys())) == sorted(list(expected_result.keys()))
         assert res == expected_result
 
@@ -1043,7 +1042,6 @@ class TestBitbucketTestCase(object):
             }
         ]
         res = await valid_handler.list_repos()
-        print(res)
         assert sorted(res, key=lambda x: x["repo"]["service_id"]) == sorted(
             expected_result, key=lambda x: x["repo"]["service_id"]
         )
@@ -1089,7 +1087,6 @@ class TestBitbucketTestCase(object):
             },
         ]
         res = await valid_handler.list_teams()
-        print(res)
         assert res == expected_result
 
     @pytest.mark.asyncio

--- a/tests/integration/test_gitlab.py
+++ b/tests/integration/test_gitlab.py
@@ -316,7 +316,6 @@ class TestGitlabTestCase(object):
         res = await valid_handler.get_commit_diff(
             "c739768fcac68144a3a6d82305b9c4106934d31a"
         )
-        print(list(res.keys()))
         assert res == expected_result
 
     @pytest.mark.asyncio
@@ -364,7 +363,6 @@ class TestGitlabTestCase(object):
     @pytest.mark.asyncio
     async def test_get_branches(self, valid_handler, codecov_vcr):
         branches = sorted(await valid_handler.get_branches())
-        print(branches)
         assert list(map(lambda a: a[0], branches)) == ["main", "other-branch"]
 
     @pytest.mark.asyncio
@@ -374,7 +372,6 @@ class TestGitlabTestCase(object):
             "sha": "0fc784af11c401449e56b24a174bae7b9af86c98",
         }
         branch = await valid_handler.get_branch("main")
-        print(branch)
         assert branch == expected_result
 
     @pytest.mark.asyncio
@@ -507,7 +504,6 @@ class TestGitlabTestCase(object):
             ],
         }
         res = await valid_handler.get_compare(base, head)
-        print(res)
         assert sorted(list(res.keys())) == sorted(list(expected_result.keys()))
         for key in res:
             assert res[key] == expected_result[key]

--- a/tests/unit/reports/samples/test_filtered.py
+++ b/tests/unit/reports/samples/test_filtered.py
@@ -866,7 +866,6 @@ class TestFilteredReport(object):
         }
 
     def test_network(self, sample_report):
-        print(list(sample_report.filter(paths=[".*go"]).network))
         assert list(sample_report.filter(paths=[".*go"]).network) == [
             (
                 "file_1.go",

--- a/tests/unit/reports/test_carryforward.py
+++ b/tests/unit/reports/test_carryforward.py
@@ -1,5 +1,4 @@
 import dataclasses
-import pprint
 from json import loads
 
 import pytest
@@ -400,7 +399,6 @@ class TestCarryfowardFlag(object):
         assert res.files == ["file_1.go"]
         readable_report = self.convert_report_to_better_readable(res)
 
-        pprint.pprint(readable_report)
         expected_result = {
             "archive": {
                 "file_1.go": [
@@ -473,7 +471,6 @@ class TestCarryfowardFlag(object):
         assert res.files == ["file_1.go"]
         readable_report = self.convert_report_to_better_readable(res)
 
-        pprint.pprint(readable_report)
         expected_result = {
             "archive": {
                 "file_1.go": [

--- a/tests/unit/reports/test_changes.py
+++ b/tests/unit/reports/test_changes.py
@@ -83,7 +83,6 @@ def test_run_comparison_using_rust(sample_rust_report):
         }
     }
     k = run_comparison_using_rust(base_report, head_report, diff)
-    print(k)
     assert k == {
         "files": [
             {
@@ -154,7 +153,6 @@ def test_get_changes_using_rust(sample_rust_report):
         }
     }
     k = get_changes_using_rust(base_report, head_report, diff)
-    print(k)
     assert k == [
         Change(
             path="tests/__init__.py",
@@ -532,5 +530,4 @@ class TestRustifyDiff(object):
                 [((43, 7, 43, 7), [" ", " ", " ", "-", "+", " ", " ", " "])],
             ),
         }
-        print(rustify_diff(user_input))
         assert rustify_diff(user_input) == expected_result

--- a/tests/unit/reports/test_editable.py
+++ b/tests/unit/reports/test_editable.py
@@ -1887,8 +1887,6 @@ class TestEditableReport(object):
                 if line.datapoints:
                     for dp in line.datapoints:
                         assert dp.sessionid != 0 or 3 not in dp.label_ids
-        print(sample_with_labels_report)
-        print(sample_with_labels_report._files)
         res = self.convert_report_to_better_readable(sample_with_labels_report)
         expected_result = {
             "totals": {

--- a/tests/unit/reports/test_readonly.py
+++ b/tests/unit/reports/test_readonly.py
@@ -203,8 +203,6 @@ class TestReadOnly(object):
 
     def test_get_file_totals(self, sample_report, mocker):
         r = ReadOnlyReport.create_from_report(sample_report)
-        print(sample_report._files)
-        print(r)
         assert r.get_file_totals("location/file_1.py") == ReportTotals(
             files=0,
             lines=2,

--- a/tests/unit/reports/test_types.py
+++ b/tests/unit/reports/test_types.py
@@ -120,7 +120,6 @@ class TestNetworkFile(object):
             ),
             diff_totals=None,
         )
-        print(network_file.astuple())
         assert network_file.astuple() == (
             (0, 0, -2, 1, 0, -23.333330000000004, 0, 0, 0, 0, 0, 0, 0),
             None,

--- a/tests/unit/torngit/test_github_enterprise.py
+++ b/tests/unit/torngit/test_github_enterprise.py
@@ -140,14 +140,11 @@ class TestGithubEnterprise(object):
         await gl.make_http_call(client, method, url, **query_params)
         assert client.request.call_count == 1
         args, kwargs = client.request.call_args
-        print(args)
-        print(kwargs)
         assert kwargs.get("headers") is not None
         assert kwargs.get("headers").get("Host") == "ghe.com"
         assert len(args) == 2
         built_url = args[1]
         parsed_url = urlparse(built_url)
-        print(parsed_url)
         assert parsed_url.scheme == "https"
         assert parsed_url.netloc == mock_host
         assert parsed_url.path == "/random_url"

--- a/tests/unit/torngit/test_gitlab_enterprise.py
+++ b/tests/unit/torngit/test_gitlab_enterprise.py
@@ -11,7 +11,6 @@ class TestGitlabEnterprise(object):
         assert gle.redirect_uri == "https://codecov.io/login/gle"
 
         def custom_config(*args, **kwargs):
-            print(args)
             if args == ("gitlab_enterprise", "redirect_uri"):
                 return "https://custom_redirect.com"
             if args == ("setup", "codecov_url"):
@@ -26,7 +25,6 @@ class TestGitlabEnterprise(object):
         )
 
         def custom_config(*args, **kwargs):
-            print(args)
             if args == ("gitlab", "redirect_uri"):
                 return None
             if args == ("setup", "codecov_url"):

--- a/tests/unit/validation/test_helpers.py
+++ b/tests/unit/validation/test_helpers.py
@@ -261,7 +261,6 @@ class TestGlobToRegexTranslation(BaseTestCase):
             re.compile(translate_glob_to_regex("**/test*.ts")).match("src/src2/test.ts")
             is not None
         )
-        print(f'"a/*/*b*.ts" => {translate_glob_to_regex("a/*/*b*.ts")}')
         assert (
             re.compile(translate_glob_to_regex("a/*/*b*.ts")).match("a/folder/b.ts")
             is not None
@@ -285,7 +284,6 @@ class TestGlobToRegexTranslation(BaseTestCase):
             )
             is None
         )
-        print(f'"a/**/*b*.ts" => {translate_glob_to_regex("a/**/*b*.ts")}')
         assert (
             re.compile(translate_glob_to_regex("a/**/*b*.ts")).match("a/folder/b.ts")
             is not None

--- a/tests/unit/validation/test_install_validation.py
+++ b/tests/unit/validation/test_install_validation.py
@@ -338,7 +338,6 @@ def test_validate_sample_production_config(mocker):
     }
     mock_warning = mocker.patch.object(install_log, "warning")
     res = validate_install_configuration(user_input)
-    print(mock_warning.call_args)
     assert mock_warning.call_count == 0
     assert res["site"] == expected_result["site"]
     assert res == expected_result


### PR DESCRIPTION
This PR aims to add the ruff print rules to worker, and either removes or ignores each print statement (I just used my best judgement)

Ruff rules can be found here: https://docs.astral.sh/ruff/rules/#flake8-print-t20

Closes https://github.com/codecov/engineering-team/issues/3277


<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.