### PR TITLE
Bundle Analysis: update module <-> changed files matching heuristic

### DIFF
--- a/tests/unit/bundle_analysis/test_bundle_comparison.py
+++ b/tests/unit/bundle_analysis/test_bundle_comparison.py
@@ -324,22 +324,33 @@ def test_bundle_asset_comparison_using_closest_size_delta():
     ].contributing_modules()
     assert [module.name for module in module_reports] == []
 
-    # Check asset contributing modules is correct when pr_files are used for filtering
+    # Check no contributing modules filter
+    module_reports = asset_comparison_d[
+        ("assets/index-666d2e09.js", "assets/index-666d2e09.js")
+    ].contributing_modules()
+    assert len(module_reports) == 28
+
+    # Check no PR changed files
+    module_reports = asset_comparison_d[
+        ("assets/index-666d2e09.js", "assets/index-666d2e09.js")
+    ].contributing_modules([])
+    assert len(module_reports) == 0
+
+    # Check with proper filtered files
     module_reports = asset_comparison_d[
         ("assets/index-666d2e09.js", "assets/index-666d2e09.js")
     ].contributing_modules(
-        pr_changed_files=[
-            "src/index.css",
-            "src/main.tsx",
-            "./index.html",
-            "/src/App.css",
-        ]  # first 3 is in, 4th is not
+        [
+            "app1/index.html",
+            "app2/index.html",  # <- don't match because dupe
+            "./app1/src/main.tsx",
+            "/example/svelte/app1/src/App.css",
+            "abc/def/ghi.ts",  # <- don't match
+        ]
     )
-    assert [module.name for module in module_reports] == [
-        "./src/index.css",
-        "./src/main.tsx",
-        "./index.html",
-    ]
+    assert set([module.name for module in module_reports]) == set(
+        ["./index.html", "./src/App.css", "./src/main.tsx"]
+    )
 
 
 def test_bundle_asset_comparison_using_uuid():


### PR DESCRIPTION
Use a different way of matching modules with what files were changed in the PR changed files list

Apply filter on modules where the module name has to be part of the PR's changed file list.
However we can't simply do a simple equality match because the module names we store is relative to the root of the app while the PR's file path is relative to the root of the repo. So we will need to check that any of the PR's file lists ends with any of the modules for the given asset.
For example,
```
PR changed files: ["abc/def.ts", "ghi/jkl.ts"],
modules: ["def.ts", "mno.ts"]
-> ["def.ts"]
```

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.