### PR TITLE
fix: has_seats_left property

### DIFF
--- a/shared/plan/service.py
+++ b/shared/plan/service.py
@@ -317,8 +317,8 @@ class PlanService:
             # has_seats_left will evaluate as False even though the User should be allowed to activate on the Org.
             return self.current_org.account.can_activate_user()
         return (
-            self.plan_activated_users is None
-            or len(self.plan_activated_users) < self.plan_user_count
+            self.current_org.activated_user_count is None
+            or self.current_org.activated_user_count < self.plan_user_count
         )
 
     @property

--- a/tests/unit/plan/test_plan.py
+++ b/tests/unit/plan/test_plan.py
@@ -350,6 +350,43 @@ class PlanServiceTests(TestCase):
             root_plan.plan_name == child_plan.plan_name == PlanName.FREE_PLAN_NAME.value
         )
 
+    def test_plan_service_activated_user_count_includes_student_users(self):
+        student_user = OwnerFactory(student=True)
+        other_user = OwnerFactory()
+        current_org = OwnerFactory(
+            plan=PlanName.CODECOV_PRO_MONTHLY.value,
+            plan_activated_users=[student_user.ownerid, other_user.ownerid],
+            plan_auto_activate=False,
+            plan_user_count=2,
+        )
+        current_org.save()
+
+        plan = PlanService(current_org=current_org)
+
+        assert plan.has_seats_left == True
+
+    def test_plan_service_activated_user_count_includes_student_users_and_has_no_seats_left(
+        self,
+    ):
+        student_user = OwnerFactory(student=True)
+        other_user = OwnerFactory()
+        other_user_2 = OwnerFactory()
+        current_org = OwnerFactory(
+            plan=PlanName.CODECOV_PRO_MONTHLY.value,
+            plan_activated_users=[
+                student_user.ownerid,
+                other_user.ownerid,
+                other_user_2.ownerid,
+            ],
+            plan_auto_activate=False,
+            plan_user_count=2,
+        )
+        current_org.save()
+
+        plan = PlanService(current_org=current_org)
+
+        assert plan.has_seats_left == False
+
 
 class AvailablePlansBeforeTrial(TestCase):
     """


### PR DESCRIPTION
use current_org.activated_user_count instead of plan_activated_users since activated_user_count does not include users with student=True in its calculation