### PR TITLE
feat: Add org user group to events with ownerid property

### DIFF
--- a/shared/events/amplitude/publisher.py
+++ b/shared/events/amplitude/publisher.py
@@ -62,11 +62,15 @@ class AmplitudeEventPublisher(EventPublisher):
 
         # Track event with validated payload, we will raise an exception before
         # this if bad payload.
+        org = structured_payload.get('ownerid', None)
         self.client.track(
             BaseEvent(
                 event_type,
                 user_id=str(event_properties["user_ownerid"]),
                 event_properties=structured_payload,
+                groups={
+                    "org": org
+                } if org is not None else {}
             )
         )
         return

--- a/shared/events/amplitude/publisher.py
+++ b/shared/events/amplitude/publisher.py
@@ -62,15 +62,13 @@ class AmplitudeEventPublisher(EventPublisher):
 
         # Track event with validated payload, we will raise an exception before
         # this if bad payload.
-        org = structured_payload.get('ownerid', None)
+        org = structured_payload.get("ownerid", None)
         self.client.track(
             BaseEvent(
                 event_type,
                 user_id=str(event_properties["user_ownerid"]),
                 event_properties=structured_payload,
-                groups={
-                    "org": org
-                } if org is not None else {}
+                groups={"org": org} if org is not None else {},
             )
         )
         return

--- a/tests/unit/events/test_amplitude.py
+++ b/tests/unit/events/test_amplitude.py
@@ -50,7 +50,10 @@ def test_publish(amplitude_mock, base_event_mock):
     amplitude_mock.assert_called_once()
     amplitude.client.track.assert_called_once()
     base_event_mock.assert_called_once_with(
-        "App Installed", user_id="123", event_properties={"ownerid": 321}
+        "App Installed", 
+        user_id="123", 
+        event_properties={"ownerid": 321},
+        groups={"org": 321}
     )
 
 
@@ -69,7 +72,10 @@ def test_publish_removes_extra_properties(amplitude_mock, base_event_mock):
     amplitude_mock.assert_called_once()
     amplitude.client.track.assert_called_once()
     base_event_mock.assert_called_once_with(
-        "App Installed", user_id="123", event_properties={"ownerid": 321}
+        "App Installed", 
+        user_id="123", 
+        event_properties={"ownerid": 321},
+        groups={"org": 321}
     )
 
 
@@ -101,6 +107,9 @@ def test_publish_converts_to_camel_case(amplitude_mock, base_event_mock):
             "uploadType": "Coverage report",
             "repoid": 132,
         },
+        groups={
+            'org': 321,
+        }
     )
 
 

--- a/tests/unit/events/test_amplitude.py
+++ b/tests/unit/events/test_amplitude.py
@@ -50,10 +50,10 @@ def test_publish(amplitude_mock, base_event_mock):
     amplitude_mock.assert_called_once()
     amplitude.client.track.assert_called_once()
     base_event_mock.assert_called_once_with(
-        "App Installed", 
-        user_id="123", 
+        "App Installed",
+        user_id="123",
         event_properties={"ownerid": 321},
-        groups={"org": 321}
+        groups={"org": 321},
     )
 
 
@@ -72,10 +72,10 @@ def test_publish_removes_extra_properties(amplitude_mock, base_event_mock):
     amplitude_mock.assert_called_once()
     amplitude.client.track.assert_called_once()
     base_event_mock.assert_called_once_with(
-        "App Installed", 
-        user_id="123", 
+        "App Installed",
+        user_id="123",
         event_properties={"ownerid": 321},
-        groups={"org": 321}
+        groups={"org": 321},
     )
 
 
@@ -108,8 +108,8 @@ def test_publish_converts_to_camel_case(amplitude_mock, base_event_mock):
             "repoid": 132,
         },
         groups={
-            'org': 321,
-        }
+            "org": 321,
+        },
     )
 
 


### PR DESCRIPTION
Sets org=ownerid when ownerid is passed as an event property. This is something I forgot to do in the first iteration, but is the intended behavior for mapping events to orgs.
