### PR TITLE
dev: Add test for default free plan

### DIFF
--- a/tests/unit/django_apps/codecov_auth/test_codecov_auth_models.py
+++ b/tests/unit/django_apps/codecov_auth/test_codecov_auth_models.py
@@ -378,6 +378,10 @@ class TestOwnerModel(TestCase):
         self.owner.save()
         assert not self.owner.can_activate_user(self.owner)
 
+    def test_default_owner_plan_is_developer(self):
+        owner = OwnerFactory()
+        assert owner.plan == DEFAULT_FREE_PLAN
+
     def test_fields_that_account_overrides(self):
         mock_all_plans_and_tiers()
         to_activate = OwnerFactory()


### PR DESCRIPTION
This PR aims to add a test for the default free plan on owner. It'll error out if that plan isn't available in the DB

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.