### PR TITLE
fix: Add RiskySQL to alter type plans

### DIFF
--- a/shared/django_apps/codecov_auth/migrations/0065_alter_account_plan_alter_owner_plan.py
+++ b/shared/django_apps/codecov_auth/migrations/0065_alter_account_plan_alter_owner_plan.py
@@ -52,7 +52,16 @@ class Migration(migrations.Migration):
             ),
         ),
         migrations.RunSQL(
-            "ALTER TYPE plans ADD VALUE IF NOT EXISTS 'users-developer';"
+            sql="""
+            DO $$
+            BEGIN
+                ALTER TYPE plans ADD VALUE 'users-developer';
+            EXCEPTION
+                WHEN OTHERS THEN
+                    RAISE NOTICE 'An unexpected error occurred: %', SQLERRM;
+            END$$;
+            """,
+            reverse_sql=migrations.RunSQL.noop,
         ),
         migrations.AlterField(
             model_name="owner",

--- a/shared/django_apps/codecov_auth/migrations/0065_alter_account_plan_alter_owner_plan.py
+++ b/shared/django_apps/codecov_auth/migrations/0065_alter_account_plan_alter_owner_plan.py
@@ -2,6 +2,8 @@
 
 from django.db import migrations, models
 
+from shared.django_apps.migration_utils import RiskyRunSQL
+
 
 class Migration(migrations.Migration):
     """
@@ -51,18 +53,7 @@ class Migration(migrations.Migration):
                 max_length=50,
             ),
         ),
-        migrations.RunSQL(
-            sql="""
-            DO $$
-            BEGIN
-                ALTER TYPE plans ADD VALUE 'users-developer';
-            EXCEPTION
-                WHEN OTHERS THEN
-                    RAISE NOTICE 'An unexpected error occurred: %', SQLERRM;
-            END$$;
-            """,
-            reverse_sql=migrations.RunSQL.noop,
-        ),
+        RiskyRunSQL("ALTER TYPE plans ADD VALUE 'users-developer';"),
         migrations.AlterField(
             model_name="owner",
             name="plan",


### PR DESCRIPTION
This PR updates the plan type part of the migration to be "risky" basically failing and continuing if the type alteration encounters an error

<img width="640" alt="Screenshot 2025-02-05 at 12 46 39 PM" src="https://github.com/user-attachments/assets/70c9d4d4-9d07-45ab-a85a-a668b249487a" />


**Testing**

- Tested locally by deleting the migrations from my DB
- Updated https://github.com/codecov/shared/blob/6c6d5a11ff63ae9b927c1e69409ba4643c37e145/shared/django_apps/dummy_settings.py#L70-L71 to True
- Re-ran migrations and confirmed it ran successfully


<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.