### PR TITLE
Optimize `match/_any`

### DIFF
--- a/shared/reports/carryforward.py
+++ b/shared/reports/carryforward.py
@@ -4,7 +4,7 @@ from typing import Mapping, Sequence
 
 from shared.reports.editable import EditableReport
 from shared.reports.resources import Report
-from shared.utils.match import match
+from shared.utils.match import Matcher
 from shared.utils.sessions import SessionType
 
 log = logging.getLogger(__name__)
@@ -73,8 +73,9 @@ def generate_carryforward_report(
         totals=None,
     )
     if paths:
+        matcher = Matcher(paths)
         for filename in new_report.files:
-            if not match(paths, filename):
+            if not matcher.match(filename):
                 del new_report[filename]
     sessions_to_delete = []
     for sid, session in new_report.sessions.items():

--- a/shared/reports/filtered.py
+++ b/shared/reports/filtered.py
@@ -5,7 +5,7 @@ from shared.config import get_config
 from shared.helpers.numeric import ratio
 from shared.reports.types import EMPTY, ReportTotals
 from shared.utils.make_network_file import make_network_file
-from shared.utils.match import match, match_any
+from shared.utils.match import Matcher
 from shared.utils.merge import get_complexity_from_sessions, line_type, merge_all
 from shared.utils.totals import agg_totals, sum_totals
 
@@ -161,6 +161,7 @@ class FilteredReport(object):
     def __init__(self, report, path_patterns, flags):
         self.report = report
         self.path_patterns = path_patterns
+        self._matcher = Matcher(path_patterns)
         self.flags = flags
         self._totals = None
         self._sessions_to_include = None
@@ -172,10 +173,11 @@ class FilteredReport(object):
     def _calculate_sessionids_to_include(self):
         if not self.flags:
             return set(self.report.sessions.keys())
+        flags_matcher = Matcher(self.flags)
         old_style_sessions = set(
             sid
             for (sid, session) in self.report.sessions.items()
-            if match_any(self.flags, session.flags)
+            if flags_matcher.match_any(session.flags)
         )
         new_style_sessions = set(
             sid
@@ -203,7 +205,7 @@ class FilteredReport(object):
         return self._sessions_to_include
 
     def should_include(self, filename):
-        return match(self.path_patterns, filename)
+        return self._matcher.match(filename)
 
     @property
     def network(self):

--- a/shared/reports/readonly.py
+++ b/shared/reports/readonly.py
@@ -12,7 +12,7 @@ from shared.reports.resources import (
     ReportTotals,
     chunks_from_storage_contains_header,
 )
-from shared.utils.match import match
+from shared.utils.match import Matcher
 
 log = logging.getLogger(__name__)
 
@@ -173,8 +173,9 @@ class ReadOnlyReport(object):
     def filter(self, paths=None, flags=None):
         if paths is None and flags is None:
             return self
+        matcher = Matcher(paths)
         matching_files = (
-            set(f for f in self.files if match(paths, f)) if paths else None
+            set(f for f in self.files if matcher.match(f)) if paths else None
         )
         rust_analyzer = FilterAnalyzer(
             files=matching_files, flags=flags if flags else None

--- a/shared/utils/match.py
+++ b/shared/utils/match.py
@@ -1,37 +1,65 @@
 import re
+from typing import Sequence
 
 
-def match(patterns, string):
-    if patterns is None or string in patterns:
-        return True
+class Matcher:
+    def __init__(self, patterns: Sequence[str] | None):
+        self._patterns = set(patterns or [])
+        self._is_initialized = False
+        self._positives: list[re.Pattern] = []
+        self._negatives: list[re.Pattern] = []
 
-    patterns = set([_f for _f in patterns if _f])
-    negatives = [a for a in patterns if a.startswith(("^!", "!"))]
-    positives = patterns - set(negatives)
+    def _get_matchers(self) -> tuple[list[re.Pattern], list[re.Pattern]]:
+        if not self._is_initialized:
+            for pattern in self._patterns:
+                if not pattern:
+                    continue
+                if pattern.startswith(("^!", "!")):
+                    self._negatives.append(re.compile(pattern.replace("!", "")))
+                else:
+                    self._positives.append(re.compile(pattern))
+            self._is_initialized = True
 
-    # must not match
-    for pattern in negatives:
-        # matched a negative search
-        if re.match(pattern.replace("!", ""), string):
+        return self._positives, self._negatives
+
+    def match(self, s: str) -> bool:
+        if not self._patterns or s in self._patterns:
+            return True
+
+        positives, negatives = self._get_matchers()
+
+        # must not match
+        for pattern in negatives:
+            # matched a negative search
+            if pattern.match(s):
+                return False
+
+        if positives:
+            for pattern in positives:
+                # match was found
+                if pattern.match(s):
+                    return True
+
+            # did not match any required paths
             return False
 
-    if positives:
-        for pattern in positives:
-            # match was found
-            if re.match(pattern, string):
-                return True
+        else:
+            # no positives: everyting else is ok
+            return True
 
-        # did not match any required paths
-        return False
-
-    else:
-        # no positives: everyting else is ok
-        return True
+    def match_any(self, strings: Sequence[str] | None) -> bool:
+        if not strings:
+            return False
+        return any(self.match(s) for s in strings)
 
 
-def match_any(patterns, match_any_of_these):
-    if match_any_of_these:
-        for string in match_any_of_these:
-            if match(patterns, string):
-                return True
-    return False
+def match(patterns: Sequence[str] | None, string: str):
+    matcher = Matcher(patterns)
+    return matcher.match(string)
+
+
+def match_any(
+    patterns: Sequence[str] | None, match_any_of_these: Sequence[str] | None
+) -> bool:
+    matcher = Matcher(patterns)
+    return matcher.match_any(match_any_of_these)

--- a/shared/utils/match.py
+++ b/shared/utils/match.py
@@ -6,7 +6,9 @@ class Matcher:
     def __init__(self, patterns: Sequence[str] | None):
         self._patterns = set(patterns or [])
         self._is_initialized = False
+        # a list of patterns that will result in `True` on a match
         self._positives: list[re.Pattern] = []
+        # a list of patterns that will result in `False` on a match
         self._negatives: list[re.Pattern] = []
 
     def _get_matchers(self) -> tuple[list[re.Pattern], list[re.Pattern]]:
@@ -44,7 +46,7 @@ class Matcher:
             return False
 
         else:
-            # no positives: everyting else is ok
+            # no positives: everything else is ok
             return True
 
     def match_any(self, strings: Sequence[str] | None) -> bool:


### PR DESCRIPTION
This introduces a stateful `Matcher` class that is used to implement the `match/_any` fns.

This can be used to avoid compiling regex matchers repeatedly.