### PR TITLE
chore: Add `unsupported_file_format` as part of upload errors enum

### DIFF
--- a/shared/django_apps/reports/tests/factories.py
+++ b/shared/django_apps/reports/tests/factories.py
@@ -23,6 +23,7 @@ class UploadErrorEnum(enum.Enum):
     FILE_NOT_IN_STORAGE = "file_not_in_storage"
     REPORT_EXPIRED = "report_expired"
     REPORT_EMPTY = "report_empty"
+    UNSUPPORTED_FILE_FORMAT = "unsupported_file_format"
 
 
 class CommitReportFactory(DjangoModelFactory):
@@ -98,6 +99,7 @@ class UploadErrorFactory(DjangoModelFactory):
             UploadErrorEnum.FILE_NOT_IN_STORAGE,
             UploadErrorEnum.REPORT_EMPTY,
             UploadErrorEnum.REPORT_EXPIRED,
+            UploadErrorEnum.UNSUPPORTED_FILE_FORMAT,
         ]
     )
 

--- a/shared/upload/constants.py
+++ b/shared/upload/constants.py
@@ -229,6 +229,7 @@ class UploadErrorCode(StrEnum):
     REPORT_EXPIRED = "report_expired"
     REPORT_EMPTY = "report_empty"
     PROCESSING_TIMEOUT = "processing_timeout"
+    UNSUPPORTED_FILE_FORMAT = "unsupported_file_format"
 
     # We don't want these - try to add error cases when they arise
     UNKNOWN_PROCESSING = "unknown_processing"


### PR DESCRIPTION
<!-- Describe your PR here. -->
New error supported by worker for uploads.  

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.