### PR TITLE
fix: handle Minio client retries better

### DIFF
--- a/tests/unit/storage/test_minio.py
+++ b/tests/unit/storage/test_minio.py
@@ -134,7 +134,11 @@ class TestMinioStorageService(BaseTestCase):
         storage = MinioStorageService(minio_no_ports_config)
         assert storage.minio_config == minio_no_ports_config
         mocked_minio_client.assert_called_with(
-            "cute_url_no_ports", credentials=mocker.ANY, secure=False, region=None
+            "cute_url_no_ports",
+            credentials=mocker.ANY,
+            http_client=mocker.ANY,
+            secure=False,
+            region=None,
         )
 
     def test_minio_with_ports(self, mocker):
@@ -151,7 +155,11 @@ class TestMinioStorageService(BaseTestCase):
         storage = MinioStorageService(minio_no_ports_config)
         assert storage.minio_config == minio_no_ports_config
         mocked_minio_client.assert_called_with(
-            "cute_url_no_ports:9000", credentials=mocker.ANY, secure=False, region=None
+            "cute_url_no_ports:9000",
+            credentials=mocker.ANY,
+            http_client=mocker.ANY,
+            secure=False,
+            region=None,
         )
 
     def test_minio_with_region(self, mocker):
@@ -171,6 +179,7 @@ class TestMinioStorageService(BaseTestCase):
         mocked_minio_client.assert_called_with(
             "cute_url_no_ports:9000",
             credentials=mocker.ANY,
+            http_client=mocker.ANY,
             secure=False,
             region="example",
         )


### PR DESCRIPTION
we're running into [this issue](https://codecov.sentry.io/issues/6293115637/events/11ab665a53664b6ca25b923a37eac0f7/) on Sentry, and given the docs [here](https://cloud.google.com/storage/docs/retry-strategy#python) i want to try and change some of our HTTP retry settings