### PR TITLE
feat: Add required event properties for Amplitude upload event

### DIFF
--- a/shared/events/amplitude/publisher.py
+++ b/shared/events/amplitude/publisher.py
@@ -4,7 +4,7 @@ from typing import Union
 from django.conf import settings
 
 from amplitude import Amplitude, BaseEvent, Config, EventOptions
-from shared.environment.environment import get_current_env, Environment
+from shared.environment.environment import Environment, get_current_env
 from shared.events.amplitude.types import (
     AMPLITUDE_REQUIRED_PROPERTIES,
     AmplitudeEventProperties,
@@ -118,9 +118,15 @@ class StubbedAmplitudeClient(Amplitude):
         group_name: Union[str, list[str]],
         event_options: EventOptions,
     ):
-        log.info(f'StubbedAmplitudeClient set_group {group_type}: {group_name}', extra=event_options.get_event_body())
+        log.info(
+            f"StubbedAmplitudeClient set_group {group_type}: {group_name}",
+            extra=event_options.get_event_body(),
+        )
         return
 
     def track(self, event: BaseEvent):
-        log.info(f'StubbedAmplitudeClient tracked event {event.event_type}', extra=event.get_event_body())
+        log.info(
+            f"StubbedAmplitudeClient tracked event {event.event_type}",
+            extra=event.get_event_body(),
+        )
         return

--- a/shared/events/amplitude/publisher.py
+++ b/shared/events/amplitude/publisher.py
@@ -118,7 +118,9 @@ class StubbedAmplitudeClient(Amplitude):
         group_name: Union[str, list[str]],
         event_options: EventOptions,
     ):
+        log.info(f'StubbedAmplitudeClient set_group {group_type}: {group_name}', extra=event_options.get_event_body())
         return
 
     def track(self, event: BaseEvent):
+        log.info(f'StubbedAmplitudeClient tracked event {event.event_type}', extra=event.get_event_body())
         return

--- a/shared/events/amplitude/types.py
+++ b/shared/events/amplitude/types.py
@@ -43,6 +43,8 @@ type AmplitudeEventProperty = Literal[
     "ownerid",
     "org_ids",
     "repoid",
+    "commitid",
+    "pullid",
     "upload_type",
 ]
 
@@ -56,6 +58,8 @@ class AmplitudeEventProperties(BaseAmplitudeEventProperties, total=False):
     ownerid: int  # ownerid of owner being acted upon
     org_ids: list[int]
     repoid: int
+    commitid: int # commit.id NOT commit.commitid. We do not want a commit SHA here!
+    pullid: int | None
     upload_type: Literal["Coverage report", "Bundle", "Test results"]
 
 
@@ -66,5 +70,5 @@ AMPLITUDE_REQUIRED_PROPERTIES: dict[
     "User Created": [],
     "User Logged in": [],
     "App Installed": ["ownerid"],
-    "Upload Sent": ["ownerid", "repoid", "upload_type"],
+    "Upload Sent": ["ownerid", "repoid", "commitid", "pullid", "upload_type"],
 }

--- a/shared/events/amplitude/types.py
+++ b/shared/events/amplitude/types.py
@@ -58,7 +58,7 @@ class AmplitudeEventProperties(BaseAmplitudeEventProperties, total=False):
     ownerid: int  # ownerid of owner being acted upon
     org_ids: list[int]
     repoid: int
-    commitid: int # commit.id NOT commit.commitid. We do not want a commit SHA here!
+    commitid: int  # commit.id NOT commit.commitid. We do not want a commit SHA here!
     pullid: int | None
     upload_type: Literal["Coverage report", "Bundle", "Test results"]
 

--- a/tests/unit/events/test_amplitude.py
+++ b/tests/unit/events/test_amplitude.py
@@ -92,8 +92,10 @@ def test_publish_converts_to_camel_case(amplitude_mock, base_event_mock):
         {
             "user_ownerid": 123,
             "ownerid": 321,
-            "upload_type": "Coverage report",
             "repoid": 132,
+            "commitid": 12,
+            "pullid": None,
+            "upload_type": "Coverage report",
         },
     )
 
@@ -104,8 +106,9 @@ def test_publish_converts_to_camel_case(amplitude_mock, base_event_mock):
         user_id="123",
         event_properties={
             "ownerid": 321,
-            "uploadType": "Coverage report",
             "repoid": 132,
+            "commitid": 12,
+            "uploadType": "Coverage report",
         },
         groups={
             "org": 321,

--- a/tests/unit/events/test_amplitude.py
+++ b/tests/unit/events/test_amplitude.py
@@ -108,6 +108,7 @@ def test_publish_converts_to_camel_case(amplitude_mock, base_event_mock):
             "ownerid": 321,
             "repoid": 132,
             "commitid": 12,
+            "pullid": None,
             "uploadType": "Coverage report",
         },
         groups={


### PR DESCRIPTION
Adds the required event properties for the Amplitude 'Upload Sent' event that will be instrumented in API after this is merged.
