### PR TITLE
feat: Add hasPublicRepos and hasActiveRepos owner props

### DIFF
--- a/shared/django_apps/codecov_auth/models.py
+++ b/shared/django_apps/codecov_auth/models.py
@@ -462,8 +462,16 @@ class Owner(ExportModelOperationsMixin("codecov_auth.owner"), models.Model):
         return self.repository_set.filter(active=True, private=True).count()
 
     @property
+    def has_public_repos(self):
+        return self.repository_set.filter(private=False).exists()
+
+    @property
     def has_private_repos(self):
         return self.repository_set.filter(private=True).exists()
+
+    @property
+    def has_active_repos(self):
+        return self.repository_set.filter(active=True).exists()
 
     @property
     def repo_credits(self):

--- a/tests/unit/django_apps/codecov_auth/test_codecov_auth_models.py
+++ b/tests/unit/django_apps/codecov_auth/test_codecov_auth_models.py
@@ -93,6 +93,48 @@ class TestOwnerModel(TestCase):
 
         assert owner.nb_active_private_repos == 1
 
+    def test_has_public_repos(self):
+        owner1 = OwnerFactory()
+        RepositoryFactory(author=owner1, active=True, private=True)
+        RepositoryFactory(author=owner1, active=True, private=False)
+        RepositoryFactory(author=owner1, active=False, private=True)
+        RepositoryFactory(author=owner1, active=False, private=False)
+        assert owner1.has_public_repos is True
+
+        owner2 = OwnerFactory()
+        RepositoryFactory(author=owner2, active=True, private=True)
+        RepositoryFactory(author=owner2, active=False, private=True)
+        RepositoryFactory(author=owner2, active=False, private=False)
+        assert owner2.has_public_repos is True
+
+        owner3 = OwnerFactory()
+        RepositoryFactory(author=owner3, active=True, private=True)
+        RepositoryFactory(author=owner3, active=False, private=True)
+        assert owner3.has_public_repos is False
+
+        owner4 = OwnerFactory()
+        assert owner4.has_public_repos is False
+
+    def test_has_active_repos(self):
+        owner1 = OwnerFactory()
+        RepositoryFactory(author=owner1, active=True, private=True)
+        RepositoryFactory(author=owner1, active=False, private=True)
+        RepositoryFactory(author=owner1, active=False, private=False)
+        assert owner1.has_active_repos is True
+
+        owner2 = OwnerFactory()
+        RepositoryFactory(author=owner2, active=False, private=True)
+        RepositoryFactory(author=owner2, active=True, private=False)
+        assert owner2.has_active_repos is True
+
+        owner3 = OwnerFactory()
+        RepositoryFactory(author=owner3, active=False, private=False)
+        RepositoryFactory(author=owner3, active=False, private=True)
+        assert owner3.has_active_repos is False
+
+        owner4 = OwnerFactory()
+        assert owner4.has_active_repos is False
+
     def test_plan_is_null_when_validating_form(self):
         owner = OwnerFactory()
         owner.plan = ""


### PR DESCRIPTION
<!-- Describe your PR here. -->
Adds two new properties to the Owner class for use from the FE for use in this ticket https://github.com/codecov/engineering-team/issues/3074

Related codecov-api PR: https://github.com/codecov/codecov-api/pull/1168


<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.