### PR TITLE
fix: new minio storage service

### DIFF
--- a/shared/storage/new_minio.py
+++ b/shared/storage/new_minio.py
@@ -243,15 +243,10 @@ class NewMinioStorageService(BaseStorageService):
     def read_file(
         self, bucket_name: str, path: str, file_obj: IO[bytes] | None = None
     ) -> bytes | None:
-        headers: dict[str, str | list[str] | Tuple[str]] = {
-            "Accept-Encoding": "gzip, zstd"
-        }
         try:
             response = cast(
                 HTTPResponse,
-                self.minio_client.get_object(  # this returns an HTTPResponse
-                    bucket_name, path, request_headers=headers
-                ),
+                self.minio_client.get_object(bucket_name, path),
             )
         except S3Error as e:
             if e.code == "NoSuchKey":


### PR DESCRIPTION
We were running into a [S3Error in Sentry](https://codecov.sentry.io/issues/6313961939/events/ce6eb9249f614f26b0ff662de9362882/) when we enabled the new Minio storage backend and this is the fix for that. The reason we were passing these headers in the first place was due to the docs [here](https://cloud.google.com/storage/docs/transcoding). 

The only difference between the requests was that this header was being set so I removed it to see if it would fix the error in staging and it did.