### PR TITLE
ci: use same coverage/test result filenames as other repos

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,6 @@
 [run]
 branch = True
+relative_files = True
 
 [report]
 exclude_lines =

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,23 +45,23 @@ jobs:
       - name: upload using codecovcli
         if: ${{ !cancelled() && !github.event.pull_request.head.repo.fork && github.repository_owner == 'codecov' }}
         run: |
-          docker-compose exec shared codecovcli -v upload-process --flag shared-docker-uploader --token ${{ secrets.CODECOV_ORG_TOKEN }} --fail-on-error
-          docker-compose exec shared codecovcli -v do-upload --report-type "test_results" --flag shared-docker-uploader --token ${{ secrets.CODECOV_ORG_TOKEN }} --fail-on-error
+          docker-compose exec shared codecovcli -v upload-process --flag shared-docker-uploader --file tests/unit.coverage.xml --token ${{ secrets.CODECOV_ORG_TOKEN }} --fail-on-error
+          docker-compose exec shared codecovcli -v do-upload --report-type "test_results" --flag shared-docker-uploader --file tests/unit.junit.xml --token ${{ secrets.CODECOV_ORG_TOKEN }} --fail-on-error
 
       - name: upload using codecovcli staging
         if: ${{ !cancelled() && !github.event.pull_request.head.repo.fork && github.repository_owner == 'codecov' }}
         run: |
-          docker-compose exec shared codecovcli -v -u ${{ secrets.CODECOV_STAGING_URL }} upload-process --flag shared-docker-uploader --token ${{ secrets.CODECOV_ORG_TOKEN_STAGING }} --fail-on-error
-          docker-compose exec shared codecovcli -v -u ${{ secrets.CODECOV_STAGING_URL }} do-upload --report-type "test_results" --flag shared-docker-uploader --token ${{ secrets.CODECOV_ORG_TOKEN_STAGING }} || true
+          docker-compose exec shared codecovcli -v -u ${{ secrets.CODECOV_STAGING_URL }} upload-process --flag shared-docker-uploader --file tests/unit.coverage.xml --token ${{ secrets.CODECOV_ORG_TOKEN_STAGING }} --fail-on-error
+          docker-compose exec shared codecovcli -v -u ${{ secrets.CODECOV_STAGING_URL }} do-upload --report-type "test_results" --flag shared-docker-uploader --file tests/unit.junit.xml --token ${{ secrets.CODECOV_ORG_TOKEN_STAGING }} || true
 
       - name: upload using codecovcli qa
         if: ${{ !cancelled() && !github.event.pull_request.head.repo.fork && github.repository_owner == 'codecov' }}
         run: |
-          docker-compose exec shared codecovcli -v -u ${{ secrets.CODECOV_QA_URL }} upload-process --flag shared-docker-uploader --token ${{ secrets.CODECOV_QA_TOKEN }} --fail-on-error
-          docker-compose exec shared codecovcli -v -u ${{ secrets.CODECOV_QA_URL }} do-upload --report-type "test_results" --flag shared-docker-uploader --token ${{ secrets.CODECOV_QA_TOKEN }} --fail-on-error
+          docker-compose exec shared codecovcli -v -u ${{ secrets.CODECOV_QA_URL }} upload-process --flag shared-docker-uploader --file tests/unit.coverage.xml --token ${{ secrets.CODECOV_QA_TOKEN }} --fail-on-error
+          docker-compose exec shared codecovcli -v -u ${{ secrets.CODECOV_QA_URL }} do-upload --report-type "test_results" --flag shared-docker-uploader --file tests/unit.junit.xml --token ${{ secrets.CODECOV_QA_TOKEN }} --fail-on-error
 
       - name: upload using codecovcli public qa
         if: ${{ !cancelled() && !github.event.pull_request.head.repo.fork && github.repository_owner == 'codecov' }}
         run: |
-          docker-compose exec shared codecovcli -v -u ${{ secrets.CODECOV_PUBLIC_QA_URL }} upload-process --flag shared-docker-uploader --token ${{ secrets.CODECOV_PUBLIC_QA_TOKEN }} --fail-on-error
-          docker-compose exec shared codecovcli -v -u ${{ secrets.CODECOV_PUBLIC_QA_URL }} do-upload --report-type "test_results" --flag shared-docker-uploader --token ${{ secrets.CODECOV_PUBLIC_QA_TOKEN }} || true
+          docker-compose exec shared codecovcli -v -u ${{ secrets.CODECOV_PUBLIC_QA_URL }} upload-process --flag shared-docker-uploader --file tests/unit.coverage.xml --token ${{ secrets.CODECOV_PUBLIC_QA_TOKEN }} --fail-on-error
+          docker-compose exec shared codecovcli -v -u ${{ secrets.CODECOV_PUBLIC_QA_URL }} do-upload --report-type "test_results" --flag shared-docker-uploader --file tests/unit.junit.xml --token ${{ secrets.CODECOV_PUBLIC_QA_TOKEN }} || true

--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,8 @@ coverage.xml
 .pytest_cache/
 cover/
 .codspeed
+*.junit.xml
+*.coverage.xml
 
 # Translations
 *.mo

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,8 @@ export CODECOV_TOKEN=${CODECOV_UPLOAD_TOKEN}
 .ONESHELL:
 
 test:
-	docker compose exec shared uv run pytest --cov=./
+	# Emit coverage/junit files inside the bind-mounted `test` directory
+	docker compose exec shared uv run pytest --cov-report=xml:tests/unit.coverage.xml --junitxml=tests/unit.junit.xml -o junit_family=legacy
 
 test.path:
 	docker compose exec shared uv run pytest $(TEST_PATH)
@@ -43,7 +44,8 @@ test_env.up:
 	docker compose up -d
 
 test_env.test:
-	docker compose exec shared uv run pytest --cov=./ --junitxml=junit.xml
+	# Emit coverage/junit files inside the bind-mounted `test` directory
+	docker compose exec shared uv run pytest --cov ./shared --cov-report=xml:tests/unit.coverage.xml --junitxml=tests/unit.junit.xml -o junit_family=legacy
 
 test_env.down:
 	docker compose down

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
     volumes:
       - ./shared/:/app/shared
       - ./tests/:/app/tests
+      - ./.coveragerc:/app/.coveragerc
 
   postgres:
     image: postgres:14-alpine


### PR DESCRIPTION
useful for https://github.com/codecov/umbrella/pull/4