### PR TITLE
Clean up `delete_session` related code

### DIFF
--- a/shared/reports/editable.py
+++ b/shared/reports/editable.py
@@ -72,11 +72,12 @@ class EditableReportFile(ReportFile):
                     else:
                         self[index] = new_line
         self._totals = None
+        self.calculate_present_sessions()
 
     def calculate_present_sessions(self):
         all_sessions = set()
         for _, line in self.lines:
-            all_sessions.update(set([int(s.id) for s in line.sessions]))
+            all_sessions.update(int(s.id) for s in line.sessions)
         self._details["present_sessions"] = all_sessions
 
     def merge(self, *args, **kwargs):
@@ -84,27 +85,20 @@ class EditableReportFile(ReportFile):
         self.calculate_present_sessions()
         return res
 
-    def delete_session(self, sessionid: int):
-        self.delete_multiple_sessions([sessionid])
-
-    def delete_multiple_sessions(self, session_ids_to_delete: List[int]):
+    def delete_multiple_sessions(self, session_ids_to_delete: set[int]):
         if "present_sessions" not in self._details:
             self.calculate_present_sessions()
-        needs_deletion = False
-        for sessionid in session_ids_to_delete:
-            if sessionid in self._details["present_sessions"]:
-                needs_deletion = True
-        if not needs_deletion:
-            return
-        self._details["present_sessions"] = [
-            x
-            for x in self._details["present_sessions"]
-            if x not in session_ids_to_delete
-        ]
+        current_sessions = self._details["present_sessions"]
+
+        new_sessions = current_sessions.difference(session_ids_to_delete)
+        if current_sessions == new_sessions:
+            return  # nothing to do
+        self._details["present_sessions"] = new_sessions
+
         for index, line in self.lines:
             if any(s.id in session_ids_to_delete for s in line.sessions):
                 new_line = self.line_without_multiple_sessions(
-                    line, set(session_ids_to_delete)
+                    line, session_ids_to_delete
                 )
                 if new_line == EMPTY:
                     del self[index]
@@ -150,9 +144,6 @@ class EditableReport(Report):
             else:
                 self._chunks[chunk_index] = None
 
-    def delete_session(self, sessionid: int):
-        return self.delete_multiple_sessions([sessionid])[0]
-
     def delete_labels(self, sessionids, labels_to_delete):
         self._totals = None
         for file in self._chunks:
@@ -160,26 +151,26 @@ class EditableReport(Report):
                 file.delete_labels(sessionids, labels_to_delete)
                 if file:
                     self._files[file.name] = dataclasses.replace(
-                        self._files.get(file.name),
+                        self._files[file.name],
                         file_totals=file.totals,
                     )
                 else:
                     del self[file.name]
         return sessionids
 
-    def delete_multiple_sessions(self, session_ids_to_delete: List[int]):
+    def delete_multiple_sessions(self, session_ids_to_delete: list[int] | set[int]):
+        session_ids_to_delete = set(session_ids_to_delete)
         self._totals = None
-        deleted_sessions = [
-            self.sessions.pop(sessionid) for sessionid in session_ids_to_delete
-        ]
+        for sessionid in session_ids_to_delete:
+            self.sessions.pop(sessionid)
+
         for file in self._chunks:
             if file is not None:
                 file.delete_multiple_sessions(session_ids_to_delete)
                 if file:
                     self._files[file.name] = dataclasses.replace(
-                        self._files.get(file.name),
+                        self._files[file.name],
                         file_totals=file.totals,
                     )
                 else:
                     del self[file.name]
-        return deleted_sessions

--- a/shared/reports/editable.py
+++ b/shared/reports/editable.py
@@ -93,7 +93,13 @@ class EditableReportFile(ReportFile):
         new_sessions = current_sessions.difference(session_ids_to_delete)
         if current_sessions == new_sessions:
             return  # nothing to do
+
         self._details["present_sessions"] = new_sessions
+        self._totals = None  # force a refresh of the on-demand totals
+
+        if not new_sessions:
+            self._lines = []  # no remaining sessions means no line data
+            return
 
         for index, line in self.lines:
             if any(s.id in session_ids_to_delete for s in line.sessions):
@@ -104,7 +110,6 @@ class EditableReportFile(ReportFile):
                     del self[index]
                 else:
                     self[index] = new_line
-        self._totals = None
 
 
 class EditableReport(Report):

--- a/shared/reports/resources.py
+++ b/shared/reports/resources.py
@@ -163,21 +163,6 @@ class ReportFile(object):
             )
         return ReportFile(name=None, totals=None, lines=lines).totals
 
-    def delete_session(self, sessionid: int):
-        self.delete_multiple_sessions([sessionid])
-
-    def delete_multiple_sessions(self, session_ids_to_delete: list[int]):
-        self._totals = None
-        for sessionid in session_ids_to_delete:
-            for index, line in self.lines:
-                if any(s.id == sessionid for s in line.sessions):
-                    log.error(
-                        "Line should not have this session since it's new",
-                        extra=dict(sessionid=sessionid, line=line),
-                    )
-                    line_without_session = self.line_without_session(line, sessionid)
-                    self._lines[index - 1] = line_without_session
-
     def __iter__(self):
         """Iter through lines
         returning (line or None)
@@ -546,10 +531,6 @@ class ReportFile(object):
             datapoints=new_datapoints,
             sessions=new_sessions,
         )
-
-    @classmethod
-    def line_without_session(cls, line: ReportLine, sessionid: int):
-        return cls.line_without_multiple_sessions(line, {sessionid})
 
     @classmethod
     def line_without_multiple_sessions(

--- a/tests/unit/test_report.py
+++ b/tests/unit/test_report.py
@@ -1007,7 +1007,7 @@ def test_delete_session():
             '["1/2", null, [[0, 0], [1, "1/2"]]]',
         ]
     )
-    report_file = ReportFile(name="file.py", lines=chunks)
+    report_file = EditableReportFile(name="file.py", lines=chunks)
     assert report_file._lines == chunks.split("\n")[1:]
     assert report_file.totals == ReportTotals(
         files=0,
@@ -1024,7 +1024,7 @@ def test_delete_session():
         complexity_total=0,
         diff=0,
     )
-    report_file.delete_session(1)
+    report_file.delete_multiple_sessions({1})
     expected_result = [
         (1, ReportLine.create(coverage=1, sessions=[LineSession(0, 1)])),
         (4, ReportLine.create(coverage=0, sessions=[LineSession(0, 0)])),


### PR DESCRIPTION
This removes the existing implementation on `Report`, as only the `EditableReport` is supposed to have them. It also removes the single `delete_session` in favor of the `delete_multiple_sessions` method.

The remaining method is optimized slightly.