### PR TITLE
fix: archive service bug in sentry

### DIFF
--- a/shared/api_archive/archive.py
+++ b/shared/api_archive/archive.py
@@ -63,7 +63,7 @@ class ArchiveService(object):
         # Set TTL from config and default to existing value
         self.ttl = ttl or int(get_config("services", "minio", "ttl", default=self.ttl))
 
-        self.storage = StorageService()
+        self.storage = StorageService(repository.repoid if repository else None)
         if repository:
             self.storage_hash = self.get_archive_hash(repository)
         else:

--- a/shared/api_archive/storage.py
+++ b/shared/api_archive/storage.py
@@ -2,51 +2,53 @@ import logging
 from datetime import timedelta
 
 from shared.config import get_config
+from shared.rollouts.features import USE_NEW_MINIO
 from shared.storage.minio import MinioStorageService
+from shared.storage.new_minio import NewMinioStorageService
 
 log = logging.getLogger(__name__)
 
 
-MINIO_CLIENT = None
+MINIO_SERVICE = None
 
 
 # Service class for interfacing with codecov's underlying storage layer, minio
-class StorageService(MinioStorageService):
-    def __init__(self, in_config=None):
-        global MINIO_CLIENT  # noqa: PLW0603
+class StorageService:
+    def __init__(self, repoid: int | None = None, in_config=None):
+        global MINIO_SERVICE  # noqa: PLW0603
+
+        minio_config: dict
 
         # init minio
         if in_config is None:
-            self.minio_config = get_config("services", "minio", default={})
+            minio_config = get_config("services", "minio", default={})
         else:
-            self.minio_config = in_config
+            minio_config = in_config
 
-        if "host" not in self.minio_config:
-            self.minio_config["host"] = "minio"
-        if "port" not in self.minio_config:
-            self.minio_config["port"] = 9000
-        if "iam_auth" not in self.minio_config:
-            self.minio_config["iam_auth"] = False
-        if "iam_endpoint" not in self.minio_config:
-            self.minio_config["iam_endpoint"] = None
+        if "host" not in minio_config:
+            minio_config["host"] = "minio"
+        if "port" not in minio_config:
+            minio_config["port"] = 9000
+        if "iam_auth" not in minio_config:
+            minio_config["iam_auth"] = False
+        if "iam_endpoint" not in minio_config:
+            minio_config["iam_endpoint"] = None
 
-        if not MINIO_CLIENT:
-            MINIO_CLIENT = self.init_minio_client(
-                self.minio_config["host"],
-                self.minio_config["port"],
-                self.minio_config["access_key_id"],
-                self.minio_config["secret_access_key"],
-                self.minio_config["verify_ssl"],
-                self.minio_config["iam_auth"],
-                self.minio_config["iam_endpoint"],
-            )
+        if not MINIO_SERVICE:
+            use_new = repoid and USE_NEW_MINIO.check_value(repoid)
+            if use_new:
+                MINIO_SERVICE = NewMinioStorageService(minio_config)
+            else:
+                MINIO_SERVICE = MinioStorageService(minio_config)
             log.info("----- created minio_client: ---- ")
-        self.minio_client = MINIO_CLIENT
+        self.minio_service = MINIO_SERVICE
 
     def create_presigned_put(self, bucket, path, expires):
+        assert MINIO_SERVICE is not None
         expires = timedelta(seconds=expires)
-        return self.minio_client.presigned_put_object(bucket, path, expires)
+        return MINIO_SERVICE.minio_client.presigned_put_object(bucket, path, expires)
 
     def create_presigned_get(self, bucket, path, expires):
+        assert MINIO_SERVICE is not None
         expires = timedelta(seconds=expires)
-        return self.minio_client.presigned_get_object(bucket, path, expires)
+        return MINIO_SERVICE.minio_client.presigned_get_object(bucket, path, expires)


### PR DESCRIPTION
Previously, the archive service uses the storage service (not base storage service) used the minio service, which can't read files written by the new minio service, so when we enabled the new minio feature the archive service started failing.

This change makes it so the storage service uses the new minio service based on the value of the feature flag.