### PR TITLE
feat: Add anonymous user details for amplitude

### DIFF
--- a/shared/events/amplitude/__init__.py
+++ b/shared/events/amplitude/__init__.py
@@ -1,3 +1,4 @@
 from shared.events.amplitude.publisher import AmplitudeEventPublisher
+from shared.events.amplitude.constants import UNKNOWN_USER_OWNERID
 
-__all__ = ["AmplitudeEventPublisher"]
+__all__ = ["AmplitudeEventPublisher", "UNKNOWN_USER_OWNERID"]

--- a/shared/events/amplitude/__init__.py
+++ b/shared/events/amplitude/__init__.py
@@ -1,4 +1,4 @@
-from shared.events.amplitude.publisher import AmplitudeEventPublisher
 from shared.events.amplitude.constants import UNKNOWN_USER_OWNERID
+from shared.events.amplitude.publisher import AmplitudeEventPublisher
 
 __all__ = ["AmplitudeEventPublisher", "UNKNOWN_USER_OWNERID"]

--- a/shared/events/amplitude/constants.py
+++ b/shared/events/amplitude/constants.py
@@ -1,0 +1,1 @@
+UNKNOWN_USER_OWNERID = -1 # Amplitude User ID for unknown users.

--- a/shared/events/amplitude/constants.py
+++ b/shared/events/amplitude/constants.py
@@ -1,1 +1,1 @@
-UNKNOWN_USER_OWNERID = -1 # Amplitude User ID for unknown users.
+UNKNOWN_USER_OWNERID = -1  # Amplitude User ID for unknown users.

--- a/shared/events/amplitude/publisher.py
+++ b/shared/events/amplitude/publisher.py
@@ -5,7 +5,7 @@ from django.conf import settings
 
 from amplitude import Amplitude, BaseEvent, Config, EventOptions
 from shared.environment.environment import Environment, get_current_env
-from shared.events.amplitude.constants import UNKNOWN_USER_OWNERID
+from shared.events.amplitude import UNKNOWN_USER_OWNERID
 from shared.events.amplitude.types import (
     AMPLITUDE_REQUIRED_PROPERTIES,
     AmplitudeEventProperties,

--- a/shared/events/amplitude/publisher.py
+++ b/shared/events/amplitude/publisher.py
@@ -5,6 +5,7 @@ from django.conf import settings
 
 from amplitude import Amplitude, BaseEvent, Config, EventOptions
 from shared.environment.environment import Environment, get_current_env
+from shared.events.amplitude.constants import UNKNOWN_USER_OWNERID
 from shared.events.amplitude.types import (
     AMPLITUDE_REQUIRED_PROPERTIES,
     AmplitudeEventProperties,
@@ -27,6 +28,7 @@ class AmplitudeEventPublisher(EventPublisher):
     """
 
     client: Amplitude
+    anon_user_id = "anon"
 
     def __init__(self, override_env=False):
         if get_current_env() != Environment.production and not override_env:
@@ -47,8 +49,15 @@ class AmplitudeEventPublisher(EventPublisher):
     def publish(
         self, event_type: AmplitudeEventType, event_properties: AmplitudeEventProperties
     ):
+        user_id = event_properties["user_ownerid"]
+
         # Handle special set_orgs event
         if event_type == "set_orgs":
+            if user_id == UNKNOWN_USER_OWNERID:
+                # We don't want to track these events for unknown users, 
+                # shouldn't happen, but can't hurt to add this.
+                return 
+
             if "org_ids" not in event_properties:
                 raise MissingEventPropertyException(
                     "Property 'org_ids' is required for event type 'set_orgs'"
@@ -72,7 +81,7 @@ class AmplitudeEventPublisher(EventPublisher):
         self.client.track(
             BaseEvent(
                 event_type,
-                user_id=str(event_properties["user_ownerid"]),
+                user_id=str(user_id) if user_id != UNKNOWN_USER_OWNERID else self.anon_user_id,
                 event_properties=structured_payload,
                 groups={"org": org} if org is not None else {},
             )

--- a/shared/events/amplitude/publisher.py
+++ b/shared/events/amplitude/publisher.py
@@ -54,9 +54,9 @@ class AmplitudeEventPublisher(EventPublisher):
         # Handle special set_orgs event
         if event_type == "set_orgs":
             if user_id == UNKNOWN_USER_OWNERID:
-                # We don't want to track these events for unknown users, 
+                # We don't want to track these events for unknown users,
                 # shouldn't happen, but can't hurt to add this.
-                return 
+                return
 
             if "org_ids" not in event_properties:
                 raise MissingEventPropertyException(
@@ -81,7 +81,9 @@ class AmplitudeEventPublisher(EventPublisher):
         self.client.track(
             BaseEvent(
                 event_type,
-                user_id=str(user_id) if user_id != UNKNOWN_USER_OWNERID else self.anon_user_id,
+                user_id=str(user_id)
+                if user_id != UNKNOWN_USER_OWNERID
+                else self.anon_user_id,
                 event_properties=structured_payload,
                 groups={"org": org} if org is not None else {},
             )

--- a/tests/unit/events/test_amplitude.py
+++ b/tests/unit/events/test_amplitude.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock, patch
 from django.test import override_settings
 from pytest import raises
 
-from shared.events.amplitude import AmplitudeEventPublisher, UNKNOWN_USER_OWNERID
+from shared.events.amplitude import UNKNOWN_USER_OWNERID, AmplitudeEventPublisher
 from shared.events.amplitude.publisher import StubbedAmplitudeClient
 from shared.events.base import (
     MissingEventPropertyException,
@@ -35,6 +35,7 @@ def test_set_orgs_throws_when_missing_org_ids(_):
 
     with raises(MissingEventPropertyException):
         amplitude.publish("set_orgs", {"user_ownerid": 123})
+
 
 @override_settings(AMPLITUDE_API_KEY="asdf1234")
 @patch("shared.events.amplitude.publisher.Amplitude")
@@ -128,7 +129,9 @@ def test_publish_converts_to_camel_case(amplitude_mock, base_event_mock):
 @override_settings(AMPLITUDE_API_KEY="asdf1234")
 @patch("shared.events.amplitude.publisher.BaseEvent")
 @patch("shared.events.amplitude.publisher.Amplitude")
-def test_publish_converts_anonymous_owner_id_to_user_id(amplitude_mock, base_event_mock):
+def test_publish_converts_anonymous_owner_id_to_user_id(
+    amplitude_mock, base_event_mock
+):
     amplitude = AmplitudeEventPublisher(override_env=True)
 
     amplitude.client.track = Mock()

--- a/tests/unit/events/test_amplitude.py
+++ b/tests/unit/events/test_amplitude.py
@@ -27,6 +27,7 @@ def test_set_orgs(amplitude_mock, event_options_mock):
     )
     event_options_mock.assert_called_once_with(user_id="123")
 
+
 @override_settings(AMPLITUDE_API_KEY="asdf1234")
 @patch("shared.events.amplitude.publisher.EventOptions")
 @patch("shared.events.amplitude.publisher.Amplitude")
@@ -36,7 +37,9 @@ def test_set_orgs_returns_early_when_anonymous_user(amplitude_mock, event_option
     amplitude.client.set_group = Mock()
     event_options_mock.return_value = "mock_event_options"
 
-    amplitude.publish("set_orgs", {"user_ownerid": UNKNOWN_USER_OWNERID, "org_ids": [1, 32]})
+    amplitude.publish(
+        "set_orgs", {"user_ownerid": UNKNOWN_USER_OWNERID, "org_ids": [1, 32]}
+    )
 
     amplitude_mock.assert_called_once()
     amplitude.client.set_group.assert_not_called()

--- a/tests/unit/events/test_amplitude.py
+++ b/tests/unit/events/test_amplitude.py
@@ -27,6 +27,21 @@ def test_set_orgs(amplitude_mock, event_options_mock):
     )
     event_options_mock.assert_called_once_with(user_id="123")
 
+@override_settings(AMPLITUDE_API_KEY="asdf1234")
+@patch("shared.events.amplitude.publisher.EventOptions")
+@patch("shared.events.amplitude.publisher.Amplitude")
+def test_set_orgs_returns_early_when_anonymous_user(amplitude_mock, event_options_mock):
+    amplitude = AmplitudeEventPublisher(override_env=True)
+
+    amplitude.client.set_group = Mock()
+    event_options_mock.return_value = "mock_event_options"
+
+    amplitude.publish("set_orgs", {"user_ownerid": UNKNOWN_USER_OWNERID, "org_ids": [1, 32]})
+
+    amplitude_mock.assert_called_once()
+    amplitude.client.set_group.assert_not_called()
+    event_options_mock.assert_not_called()
+
 
 @override_settings(AMPLITUDE_API_KEY="asdf1234")
 @patch("shared.events.amplitude.publisher.Amplitude")
@@ -35,15 +50,6 @@ def test_set_orgs_throws_when_missing_org_ids(_):
 
     with raises(MissingEventPropertyException):
         amplitude.publish("set_orgs", {"user_ownerid": 123})
-
-
-@override_settings(AMPLITUDE_API_KEY="asdf1234")
-@patch("shared.events.amplitude.publisher.Amplitude")
-def test_set_orgs_returns_early_when_anonymous_user(_):
-    amplitude = AmplitudeEventPublisher(override_env=True)
-
-    with raises(MissingEventPropertyException):
-        amplitude.publish("set_orgs", {"user_ownerid": UNKNOWN_USER_OWNERID})
 
 
 @override_settings(AMPLITUDE_API_KEY="asdf1234")


### PR DESCRIPTION
Adds constants for using an anonymous user with Amplitude.
