### PR TITLE
Consolidate implementation of `_process_totals`

### DIFF
--- a/shared/reports/totals.py
+++ b/shared/reports/totals.py
@@ -2,7 +2,8 @@ from typing import Iterator
 
 from shared.helpers.numeric import ratio
 from shared.reports.types import ReportLine, ReportTotals
-from shared.utils.merge import LineType, line_type
+from shared.utils.merge import LineType as Coverage
+from shared.utils.merge import line_type as coverage_type
 
 
 def get_line_totals(lines: Iterator[ReportLine]) -> ReportTotals:
@@ -19,12 +20,12 @@ def get_line_totals(lines: Iterator[ReportLine]) -> ReportTotals:
     complexity_total = 0
 
     for line in lines:
-        match line_type(line.coverage):
-            case LineType.hit:
+        match coverage_type(line.coverage):
+            case Coverage.hit:
                 hits += 1
-            case LineType.miss:
+            case Coverage.miss:
                 misses += 1
-            case LineType.partial:
+            case Coverage.partial:
                 partials += 1
 
         if line.type == "b":

--- a/shared/reports/totals.py
+++ b/shared/reports/totals.py
@@ -1,0 +1,59 @@
+from typing import Iterator
+
+from shared.helpers.numeric import ratio
+from shared.reports.types import ReportLine, ReportTotals
+from shared.utils.merge import LineType, line_type
+
+
+def get_line_totals(lines: Iterator[ReportLine]) -> ReportTotals:
+    """
+    Calculates the totals (`ReportTotals`) across all the given `lines` (`ReportLine`s).
+    """
+    hits = 0
+    misses = 0
+    partials = 0
+    branches = 0
+    methods = 0
+    messages = 0
+    complexity = 0
+    complexity_total = 0
+
+    for line in lines:
+        match line_type(line.coverage):
+            case LineType.hit:
+                hits += 1
+            case LineType.miss:
+                misses += 1
+            case LineType.partial:
+                partials += 1
+
+        if line.type == "b":
+            branches += 1
+        elif line.type == "m":
+            methods += 1
+
+        if line.messages:
+            messages += len(line.messages)
+
+        if isinstance(line.complexity, int):
+            complexity += line.complexity
+        elif line.complexity:
+            complexity += line.complexity[0]
+            complexity_total += line.complexity[1]
+
+    total_lines = hits + misses + partials
+
+    return ReportTotals(
+        files=0,
+        lines=total_lines,
+        hits=hits,
+        misses=misses,
+        partials=partials,
+        coverage=ratio(hits, total_lines) if total_lines else None,
+        branches=branches,
+        methods=methods,
+        messages=messages,
+        sessions=0,
+        complexity=complexity,
+        complexity_total=complexity_total,
+    )


### PR DESCRIPTION
In particular, this unifies the duplicated implementations of these methods across `Filtered/ReportFile`.

The new method also spells out a "very concise, but also unreadable" implementation that sums up the cyclomatic complexity (something I would like to remove completely eventually). This is now more readable and understandable, but more importantly, it only iterates over the `lines` *once*, instead of twice as the previous implementation did. Along with avoiding a bunch of intermediate list allocations that the `FilteredReportFile` implementation did, this should yield quite a good speedup.

---

I get the following benchmarks results now locally (as sadly, benchmarks are not yet fully working in CI):

```
                                         Benchmark Results                                          
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━┓
┃                                       Benchmark ┃   Time (best) ┃ Rel. StdDev ┃ Run time ┃ Iters ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━┩
│                     test_report_parsing[Report] │       7,184ns │        2.9% │    3.02s │ 5,396 │
│             test_report_parsing[ReadOnlyReport] │       8,229ns │        3.1% │    3.01s │ 5,041 │
│        test_report_parsing[Rust ReadOnlyReport] │       8,815ns │        1.4% │    2.94s │ 4,828 │
│             test_report_parsing[EditableReport] │     195,443ns │        0.2% │    2.96s │ 1,005 │
│                 test_report_iterate_all[Report] │  47,338,292ns │        0.3% │    2.90s │    61 │
│         test_report_iterate_all[ReadOnlyReport] │  46,308,167ns │        1.7% │    2.95s │    63 │
│    test_report_iterate_all[Rust ReadOnlyReport] │  47,148,833ns │        1.3% │    2.94s │    62 │
│         test_report_iterate_all[EditableReport] │  45,321,666ns │        0.9% │    2.96s │    65 │
│              test_report_process_totals[Report] │  58,634,083ns │        0.7% │    2.97s │    50 │
│      test_report_process_totals[ReadOnlyReport] │  57,668,083ns │        0.4% │    2.90s │    50 │
│ test_report_process_totals[Rust ReadOnlyReport] │  58,458,584ns │        1.6% │    3.00s │    50 │
│      test_report_process_totals[EditableReport] │  55,609,125ns │        1.3% │    2.92s │    52 │
│                   test_report_filtering[Report] │ 178,210,958ns │        0.8% │    2.87s │    16 │
│           test_report_filtering[ReadOnlyReport] │ 184,516,500ns │        1.1% │    2.99s │    16 │
│      test_report_filtering[Rust ReadOnlyReport] │  74,746,791ns │        0.4% │    2.94s │    39 │
│           test_report_filtering[EditableReport] │ 170,324,791ns │        0.7% │    2.93s │    17 │
│                   test_report_serialize[Report] │       2,131ns │        2.6% │    2.97s │ 9,869 │
│           test_report_serialize[EditableReport] │   2,887,927ns │        1.5% │    2.98s │   256 │
│                       test_report_merge[Report] │ 239,321,583ns │        0.4% │    2.89s │    12 │
│               test_report_merge[EditableReport] │ 249,947,583ns │        0.2% │    2.76s │    11 │
│                test_report_carryforward[Report] │   2,933,698ns │        0.3% │    2.93s │   248 │
│        test_report_carryforward[EditableReport] │   2,941,503ns │        1.1% │    2.90s │   244 │
└─────────────────────────────────────────────────┴───────────────┴─────────────┴──────────┴───────┘
```

Comparing this with the numbers in https://github.com/codecov/shared/pull/512, we can see that the `process_totals` benchmark got a speedup of 2x (-50ms), and the `filtering` benchmark as well got sped up by -50ms.