### PR TITLE
Consolidate implementation of `calculate_diff`

### DIFF
--- a/shared/reports/diff.py
+++ b/shared/reports/diff.py
@@ -1,0 +1,88 @@
+from typing import Generator, Protocol, TypedDict
+
+from shared.reports.totals import get_line_totals
+from shared.reports.types import ReportLine, ReportTotals
+from shared.utils.totals import sum_totals
+
+
+class DiffSegment(TypedDict):
+    lines: list[str]
+    header: tuple[int, int, int, int]
+
+
+class DiffFile(TypedDict):
+    type: str
+    segments: list[DiffSegment]
+
+
+class RawDiff(TypedDict):
+    files: dict[str, DiffFile]
+
+
+class CalculatedDiff(TypedDict):
+    general: ReportTotals
+    files: dict[str, ReportTotals]
+
+
+# TODO: it might make sense to move these abstract interfaces to a different place
+class AbstractReportFile(Protocol):
+    def get(self, line_no: int) -> ReportLine | None: ...
+    def calculate_diff(self, segments: list[DiffSegment]) -> ReportTotals: ...
+
+
+class AbstractReport(Protocol):
+    def get(self, path: str) -> AbstractReportFile | None: ...
+
+
+def relevant_lines(segment: DiffSegment) -> Generator[int, None, None]:
+    """
+    Iterates over the relevant line numbers in a diff segment.
+    """
+    return (
+        i
+        for i, line in enumerate(
+            (ln for ln in segment["lines"] if ln[0] != "-"),
+            start=int(segment["header"][2]) or 1,
+        )
+        if line[0] == "+"
+    )
+
+
+def calculate_file_diff(
+    file: AbstractReportFile, segments: list[DiffSegment]
+) -> ReportTotals:
+    """
+    Calculates the `ReportTotals` across all relevant lines in the diff `segments`.
+
+    Takes a line accessor `get_line` returning an optional `ReportLine`
+    for a given line number.
+    """
+
+    line_numbers = (i for segment in segments for i in relevant_lines(segment))
+    lines = (file.get(ln) for ln in line_numbers)
+    return get_line_totals(line for line in lines if line)
+
+
+def calculate_report_diff(report: AbstractReport, diff: RawDiff) -> CalculatedDiff:
+    """
+    Calculates the `ReportTotals` across a complete Report, as well as per-file,
+    for all files present in the `diff`.
+
+    Takes a callback function that calculates the per-file totals given a file path.
+    """
+
+    files: dict[str, ReportTotals] = {}
+    # TODO: update `totals` in-place
+    list_of_file_totals = []
+
+    for path, data in diff["files"].items():
+        if data["type"] in ("modified", "new"):
+            file = report.get(path)
+            if file:
+                file_totals = calculate_file_diff(file, data["segments"])
+                files[path] = file_totals
+                list_of_file_totals.append(file_totals)
+
+    totals = sum_totals(list_of_file_totals)
+
+    return CalculatedDiff(general=totals, files=files)

--- a/tests/unit/reports/samples/test_filtered.py
+++ b/tests/unit/reports/samples/test_filtered.py
@@ -109,72 +109,6 @@ class TestFilteredReportFile(object):
         assert f.totals == expected_result
         assert f._totals == expected_result
 
-    def test_calculate_totals_from_lines(self):
-        line_1 = (
-            1,
-            ReportLine.create(coverage=1, sessions=[[0, 1]], complexity=[1, 3]),
-        )
-        line_2 = (
-            2,
-            ReportLine.create(coverage=1, sessions=[[0, 1], [1, 1]], complexity=1),
-        )
-        line_3 = (3, ReportLine.create(coverage=0, sessions=[[0, 0]]))
-        expected_result = ReportTotals(
-            files=0,
-            lines=3,
-            hits=2,
-            misses=1,
-            partials=0,
-            coverage="66.66667",
-            branches=0,
-            methods=0,
-            messages=0,
-            sessions=0,
-            complexity=2,
-            complexity_total=3,
-            diff=0,
-        )
-        assert (
-            FilteredReportFile.calculate_totals_from_lines([line_1, line_2, line_3])
-            == expected_result
-        )
-
-    def test_calculate_totals_from_lines_iterator(self):
-        line_1 = (
-            1,
-            ReportLine.create(coverage=1, sessions=[[0, 1]], complexity=[1, 3]),
-        )
-        line_2 = (
-            2,
-            ReportLine.create(coverage=1, sessions=[[0, 1], [1, 1]], complexity=1),
-        )
-        line_3 = (3, ReportLine.create(coverage=0, sessions=[[0, 0]]))
-        expected_result = ReportTotals(
-            files=0,
-            lines=3,
-            hits=2,
-            misses=1,
-            partials=0,
-            coverage="66.66667",
-            branches=0,
-            methods=0,
-            messages=0,
-            sessions=0,
-            complexity=2,
-            complexity_total=3,
-            diff=0,
-        )
-
-        def iterator_to_use():
-            yield line_1
-            yield line_2
-            yield line_3
-
-        assert (
-            FilteredReportFile.calculate_totals_from_lines(iterator_to_use())
-            == expected_result
-        )
-
     def test_line_modifier(self):
         original_file = ReportFile("file_1.py")
         file = FilteredReportFile(original_file, [0, 1, 5])
@@ -659,35 +593,10 @@ class TestFilteredReport(object):
                 },
             }
         }
-        expected_result = {
-            "files": {},
-            "general": ReportTotals(
-                files=0,
-                lines=0,
-                hits=0,
-                misses=0,
-                partials=0,
-                coverage=None,
-                branches=0,
-                methods=0,
-                messages=0,
-                sessions=0,
-                complexity=None,
-                complexity_total=None,
-                diff=0,
-            ),
-        }
         res = sample_report.filter(
             paths=["location.*"], flags=["simple"]
         ).calculate_diff(diff)
-        assert res == expected_result
-
-    def test_calculate_diff_empty_diff(self, sample_report):
-        diff = {"files": {}}
-        res = sample_report.filter(
-            paths=["location.*"], flags=["simple"]
-        ).calculate_diff(diff)
-        assert res is None
+        assert res == {"files": {}, "general": ReportTotals(coverage=None)}
 
     def test_calculate_diff_both_filters(self, sample_report):
         diff = {


### PR DESCRIPTION
This cleans up the duplicated implementations of `Filtered/Report.calculate_diff` and moves it to a new well typed file.

---

I’m a bit surprised that this does not yield any speedup in the diff calculation benchmarks (compared to https://github.com/codecov/shared/pull/525).

I think the difference between the base and `FilteredReport` is based on the actual filtering and line-mapping code that happens, instead of the different and less optimized version that was previously there.

```
                                          Benchmark Results                                          
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━┓
┃                                       Benchmark ┃   Time (best) ┃ Rel. StdDev ┃ Run time ┃  Iters ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━┩
│            test_report_diff_calculation[Report] │         803ns │        0.9% │    2.92s │ 15,975 │
│    test_report_diff_calculation[FilteredReport] │       1,886ns │        1.1% │    2.92s │ 10,437 │
└─────────────────────────────────────────────────┴───────────────┴─────────────┴──────────┴────────┘
```