### PR TITLE
feat: Make Amplitude publish fail gracefully

### DIFF
--- a/shared/events/amplitude/metrics.py
+++ b/shared/events/amplitude/metrics.py
@@ -1,0 +1,10 @@
+from shared.metrics import Counter
+
+AMPLITUDE_PUBLISH_COUNTER = Counter(
+    "amplitude_publish",
+    "Total Amplitude publish calls",
+    [
+        "state", # 'success' or 'failure'
+        "event_type", # AmplitudeEventType
+    ]
+)

--- a/shared/events/amplitude/metrics.py
+++ b/shared/events/amplitude/metrics.py
@@ -13,6 +13,6 @@ AMPLITUDE_PUBLISH_FAILURE_COUNTER = Counter(
     "Total Amplitude publish calls that failed",
     [
         "event_type",  # AmplitudeEventType
-        "error", # Exception class name
+        "error",  # Exception class name
     ],
 )

--- a/shared/events/amplitude/metrics.py
+++ b/shared/events/amplitude/metrics.py
@@ -4,7 +4,7 @@ AMPLITUDE_PUBLISH_COUNTER = Counter(
     "amplitude_publish",
     "Total Amplitude publish calls",
     [
-        "state", # 'success' or 'failure'
-        "event_type", # AmplitudeEventType
-    ]
+        "state",  # 'success' or 'failure'
+        "event_type",  # AmplitudeEventType
+    ],
 )

--- a/shared/events/amplitude/metrics.py
+++ b/shared/events/amplitude/metrics.py
@@ -4,7 +4,15 @@ AMPLITUDE_PUBLISH_COUNTER = Counter(
     "amplitude_publish",
     "Total Amplitude publish calls",
     [
-        "state",  # 'success' or 'failure'
         "event_type",  # AmplitudeEventType
+    ],
+)
+
+AMPLITUDE_PUBLISH_FAILURE_COUNTER = Counter(
+    "amplitude_publish_failure",
+    "Total Amplitude publish calls that failed",
+    [
+        "event_type",  # AmplitudeEventType
+        "error", # Exception class name
     ],
 )

--- a/shared/events/amplitude/publisher.py
+++ b/shared/events/amplitude/publisher.py
@@ -49,6 +49,15 @@ class AmplitudeEventPublisher(EventPublisher):
     def publish(
         self, event_type: AmplitudeEventType, event_properties: AmplitudeEventProperties
     ):
+        try:
+            self.unsafe_publish(event_type, event_properties)
+        except Exception as e:
+            log.error("Failed to publish Amplitude event", extra=dict(error=str(e)))
+
+    def unsafe_publish(
+
+        self, event_type: AmplitudeEventType, event_properties: AmplitudeEventProperties
+    ):
         user_id = event_properties["user_ownerid"]
 
         # Handle special set_orgs event

--- a/shared/events/amplitude/publisher.py
+++ b/shared/events/amplitude/publisher.py
@@ -6,7 +6,10 @@ from django.conf import settings
 from amplitude import Amplitude, BaseEvent, Config, EventOptions
 from shared.environment.environment import Environment, get_current_env
 from shared.events.amplitude import UNKNOWN_USER_OWNERID
-from shared.events.amplitude.metrics import AMPLITUDE_PUBLISH_COUNTER, AMPLITUDE_PUBLISH_FAILURE_COUNTER
+from shared.events.amplitude.metrics import (
+    AMPLITUDE_PUBLISH_COUNTER,
+    AMPLITUDE_PUBLISH_FAILURE_COUNTER,
+)
 from shared.events.amplitude.types import (
     AMPLITUDE_REQUIRED_PROPERTIES,
     AmplitudeEventProperties,
@@ -62,10 +65,7 @@ class AmplitudeEventPublisher(EventPublisher):
         except Exception as e:
             inc_counter(
                 AMPLITUDE_PUBLISH_FAILURE_COUNTER,
-                labels={
-                    "event_type": event_type,
-                    "error": e.__class__.__name__
-                },
+                labels={"event_type": event_type, "error": e.__class__.__name__},
             )
             log.error("Failed to publish Amplitude event", extra=dict(error=str(e)))
 

--- a/shared/events/amplitude/publisher.py
+++ b/shared/events/amplitude/publisher.py
@@ -55,7 +55,6 @@ class AmplitudeEventPublisher(EventPublisher):
             log.error("Failed to publish Amplitude event", extra=dict(error=str(e)))
 
     def unsafe_publish(
-
         self, event_type: AmplitudeEventType, event_properties: AmplitudeEventProperties
     ):
         user_id = event_properties["user_ownerid"]

--- a/shared/events/amplitude/publisher.py
+++ b/shared/events/amplitude/publisher.py
@@ -67,7 +67,14 @@ class AmplitudeEventPublisher(EventPublisher):
                 AMPLITUDE_PUBLISH_FAILURE_COUNTER,
                 labels={"event_type": event_type, "error": e.__class__.__name__},
             )
-            log.error("Failed to publish Amplitude event", extra=dict(error=str(e)))
+            log.error(
+                "Failed to publish Amplitude event",
+                extra=dict(
+                    event_type=event_type,
+                    error_name=e.__class__.__name__,
+                    error_message=str(e),
+                ),
+            )
 
     def _unsafe_publish(
         self, event_type: AmplitudeEventType, event_properties: AmplitudeEventProperties

--- a/shared/events/amplitude/publisher.py
+++ b/shared/events/amplitude/publisher.py
@@ -54,10 +54,13 @@ class AmplitudeEventPublisher(EventPublisher):
         try:
             self.unsafe_publish(event_type, event_properties)
         except Exception as e:
-            inc_counter(AMPLITUDE_PUBLISH_COUNTER, labels={
-                "state": "failure",
-                "event_type": event_type,
-            })
+            inc_counter(
+                AMPLITUDE_PUBLISH_COUNTER,
+                labels={
+                    "state": "failure",
+                    "event_type": event_type,
+                },
+            )
             log.error("Failed to publish Amplitude event", extra=dict(error=str(e)))
 
     def unsafe_publish(
@@ -84,10 +87,13 @@ class AmplitudeEventPublisher(EventPublisher):
                     user_id=str(event_properties["user_ownerid"])
                 ),
             )
-            inc_counter(AMPLITUDE_PUBLISH_COUNTER, labels={
-                "state": "success",
-                "event_type": event_type,
-            })
+            inc_counter(
+                AMPLITUDE_PUBLISH_COUNTER,
+                labels={
+                    "state": "success",
+                    "event_type": event_type,
+                },
+            )
             return
 
         # Handle normal events
@@ -106,10 +112,13 @@ class AmplitudeEventPublisher(EventPublisher):
                 groups={"org": org} if org is not None else {},
             )
         )
-        inc_counter(AMPLITUDE_PUBLISH_COUNTER, labels={
-            "state": "success",
-            "event_type": event_type,
-        })
+        inc_counter(
+            AMPLITUDE_PUBLISH_COUNTER,
+            labels={
+                "state": "success",
+                "event_type": event_type,
+            },
+        )
         return
 
     def __transform_properties(

--- a/tests/unit/events/test_amplitude.py
+++ b/tests/unit/events/test_amplitude.py
@@ -74,6 +74,7 @@ def test_publish(amplitude_mock, base_event_mock):
         groups={"org": 321},
     )
 
+
 @override_settings(AMPLITUDE_API_KEY="asdf1234")
 @patch("shared.events.amplitude.publisher.BaseEvent")
 @patch("shared.events.amplitude.publisher.Amplitude")
@@ -172,6 +173,7 @@ def test_publish_converts_anonymous_owner_id_to_user_id(
             "org": 321,
         },
     )
+
 
 @override_settings(AMPLITUDE_API_KEY="asdf1234")
 @patch("shared.events.amplitude.publisher.Amplitude")

--- a/tests/unit/events/test_amplitude.py
+++ b/tests/unit/events/test_amplitude.py
@@ -3,7 +3,10 @@ from unittest.mock import Mock, patch
 from django.test import override_settings
 
 from shared.events.amplitude import UNKNOWN_USER_OWNERID, AmplitudeEventPublisher
-from shared.events.amplitude.metrics import AMPLITUDE_PUBLISH_COUNTER, AMPLITUDE_PUBLISH_FAILURE_COUNTER
+from shared.events.amplitude.metrics import (
+    AMPLITUDE_PUBLISH_COUNTER,
+    AMPLITUDE_PUBLISH_FAILURE_COUNTER,
+)
 from shared.events.amplitude.publisher import StubbedAmplitudeClient
 
 
@@ -51,10 +54,10 @@ def test_set_orgs_throws_when_missing_org_ids(mock_inc_counter, _):
 
     amplitude.publish("set_orgs", {"user_ownerid": 123})
 
-    mock_inc_counter.assert_called_with(AMPLITUDE_PUBLISH_FAILURE_COUNTER, labels={
-        "event_type": "set_orgs",
-        "error": "MissingEventPropertyException"
-    })
+    mock_inc_counter.assert_called_with(
+        AMPLITUDE_PUBLISH_FAILURE_COUNTER,
+        labels={"event_type": "set_orgs", "error": "MissingEventPropertyException"},
+    )
 
 
 @override_settings(AMPLITUDE_API_KEY="asdf1234")
@@ -76,6 +79,7 @@ def test_publish(amplitude_mock, base_event_mock):
         groups={"org": 321},
     )
 
+
 @override_settings(AMPLITUDE_API_KEY="asdf1234")
 @patch("shared.events.amplitude.publisher.BaseEvent")
 @patch("shared.events.amplitude.publisher.Amplitude")
@@ -96,10 +100,7 @@ def test_publish_increments_counter(mock_inc_counter, amplitude_mock, base_event
         groups={"org": 321},
     )
     mock_inc_counter.assert_called_once_with(
-        AMPLITUDE_PUBLISH_COUNTER,
-        labels={
-            "event_type": "App Installed"
-        }
+        AMPLITUDE_PUBLISH_COUNTER, labels={"event_type": "App Installed"}
     )
 
 
@@ -229,10 +230,13 @@ def test_publish_missing_required_property(mock_inc_counter, _):
 
     amplitude.publish("App Installed", {"user_ownerid": 123})
 
-    mock_inc_counter.assert_called_with(AMPLITUDE_PUBLISH_FAILURE_COUNTER, labels={
-        "event_type": "App Installed",
-        "error": "MissingEventPropertyException"
-    })
+    mock_inc_counter.assert_called_with(
+        AMPLITUDE_PUBLISH_FAILURE_COUNTER,
+        labels={
+            "event_type": "App Installed",
+            "error": "MissingEventPropertyException",
+        },
+    )
 
 
 @override_settings(AMPLITUDE_API_KEY=None)


### PR DESCRIPTION
This PR adds an `_unsafe_publish` method to the Amplitude event publisher, converting the existing `publish` method to be safe by default (i.e., it will always fail gracefully).

Also adds prometheus metrics to track success and failures of amplitude publish calls.
