### PR TITLE
Make some benchmark code more explicit

### DIFF
--- a/shared/reports/resources.py
+++ b/shared/reports/resources.py
@@ -798,7 +798,7 @@ class Report(object):
                 line_modifier=self._line_modifier,
             )
             if bind:
-                self._chunks[_file[0]] = report_file
+                self._chunks[_file.file_index] = report_file
 
             return report_file
 


### PR DESCRIPTION
In particular, this better highlights the difference between a shallow and a full parse of the Report.

It also focuses the `totals` code a bit more, making the different operations more obvious. The filtering has also been slightly updated.

As a driveby fix, this fixes the `Report.get(bind)` code, which was completely broken (because noone was using it?)