### PR TITLE
Port `change_sessionid` from `worker`

### DIFF
--- a/shared/reports/editable.py
+++ b/shared/reports/editable.py
@@ -3,6 +3,8 @@ import logging
 from copy import copy
 from typing import List
 
+import sentry_sdk
+
 from shared.reports.resources import Report, ReportFile
 from shared.reports.types import EMPTY
 
@@ -177,3 +179,41 @@ class EditableReport(Report):
                     )
                 else:
                     del self[file.name]
+
+    @sentry_sdk.trace
+    def change_sessionid(self, old_id: int, new_id: int):
+        """
+        This changes the session with `old_id` to have `new_id` instead.
+        It patches up all the references to that session across all files and line records.
+
+        In particular, it changes the id in all the `LineSession`s and `CoverageDatapoint`s,
+        and does the equivalent of `calculate_present_sessions`.
+        """
+        session = self.sessions[new_id] = self.sessions.pop(old_id)
+        session.id = new_id
+
+        report_file: EditableReportFile
+        for report_file in self._chunks:
+            if report_file is None:
+                continue
+
+            all_sessions = set()
+
+            for idx, _line in enumerate(report_file._lines):
+                if not _line:
+                    continue
+
+                # this turns the line into an actual `ReportLine`
+                line = report_file._lines[idx] = report_file._line(_line)
+
+                for session in line.sessions:
+                    if session.id == old_id:
+                        session.id = new_id
+                    all_sessions.add(session.id)
+
+                if line.datapoints:
+                    for point in line.datapoints:
+                        if point.sessionid == old_id:
+                            point.sessionid = new_id
+
+            report_file._details["present_sessions"] = all_sessions

--- a/tests/unit/reports/test_editable.py
+++ b/tests/unit/reports/test_editable.py
@@ -4,6 +4,7 @@ from json import loads
 from pathlib import Path
 from typing import List
 
+import orjson
 import pytest
 
 from shared.reports.editable import EditableReport, EditableReportFile
@@ -68,6 +69,43 @@ def create_sample_line(
 def test_merge_coverage():
     assert merge_coverage(0.5, Fraction(3, 4)) == Fraction(3, 4)
     assert merge_coverage(2, Fraction(3, 4)) == 2
+
+
+def test_change_sessionid():
+    line = ReportLine.create(
+        1, sessions=[LineSession(0, 1)], datapoints=[CoverageDatapoint(0, 1)]
+    )
+    file = ReportFile(name="foo.rs")
+    file.append(line)
+    report = EditableReport()
+    report.append(file)
+    session = Session(0)
+    report.add_session(session, use_id_from_session=True)
+
+    report.change_sessionid(0, 123)
+
+    def assert_sessionid(report: EditableReport):
+        assert 0 not in report.sessions
+        assert 123 in report.sessions
+        assert report.sessions[123].id == 123
+
+        file = report.get("foo.rs")
+        assert file.details["present_sessions"] == [123]
+        line = file.get(1)
+        assert line.sessions[0].id == 123
+        assert line.datapoints[0].id == 123
+
+    assert_sessionid(report)
+
+    # also assert a serialization roundtrip:
+    _totals, report_json = report.to_database()
+    chunks = report.to_archive()
+    report_json = orjson.loads(report_json)
+
+    report = EditableReport(
+        files=report_json["files"], sessions=report_json["sessions"], chunks=chunks
+    )
+    assert_sessionid(report)
 
 
 class TestEditableReportHelpers(object):


### PR DESCRIPTION
This is a first step moving that function, before further work in `shared` can happen to merge the `EditableReport` back into the main `Report` class.

---

This is part of https://github.com/codecov/engineering-team/issues/3381