### PR TITLE
Set `complexity/_total` to `None` in diff calculation

### DIFF
--- a/shared/reports/diff.py
+++ b/shared/reports/diff.py
@@ -1,3 +1,4 @@
+import dataclasses
 from typing import Generator, Literal, Protocol, TypedDict
 
 from shared.reports.totals import get_line_totals
@@ -96,5 +97,10 @@ def calculate_report_diff(report: AbstractReport, diff: RawDiff) -> CalculatedDi
                 list_of_file_totals.append(file_totals)
 
     totals = sum_totals(list_of_file_totals)
+
+    if totals.lines == 0:
+        totals = dataclasses.replace(
+            totals, coverage=None, complexity=None, complexity_total=None
+        )
 
     return CalculatedDiff(general=totals, files=files)

--- a/tests/unit/reports/samples/test_filtered.py
+++ b/tests/unit/reports/samples/test_filtered.py
@@ -595,7 +595,12 @@ class TestFilteredReport(object):
         res = sample_report.filter(
             paths=["location.*"], flags=["simple"]
         ).calculate_diff(diff)
-        assert res == {"files": {}, "general": ReportTotals(coverage=None)}
+        assert res == {
+            "files": {},
+            "general": ReportTotals(
+                coverage=None, complexity=None, complexity_total=None
+            ),
+        }
 
     def test_calculate_diff_both_filters(self, sample_report):
         diff = {


### PR DESCRIPTION
This was a recent regression from consolidating the diff calculation. Downstream code expects/asserts the `complexity/_total` to be `None` when no lines have been touched by the diff.