### PR TITLE
Make `api_archive` mockable again

### DIFF
--- a/shared/storage/__init__.py
+++ b/shared/storage/__init__.py
@@ -12,8 +12,11 @@ _storage_service_cache: dict[str, BaseStorageService] = {}
 
 def get_appropriate_storage_service(
     repoid: int | None = None,
+    force_minio=False,
 ) -> BaseStorageService:
     chosen_storage: str = get_config("services", "chosen_storage", default="minio")  # type: ignore
+    if force_minio:
+        chosen_storage = "minio"
 
     if repoid:
         if USE_MINIO.check_value(repoid, default=False):


### PR DESCRIPTION
The recent change to the `api_archive.ArchiveService` meant that all the mocks that target `get_appropriate_storage_service` within `worker` stopped working.

This fixes the mocking within `worker` by making sure that we always go through `get_appropriate_storage_service`.