### PR TITLE
Merge `EditableReportFile` into `ReportFile`

### DIFF
--- a/shared/reports/editable.py
+++ b/shared/reports/editable.py
@@ -1,116 +1,13 @@
 import dataclasses
 import logging
-from copy import copy
-from typing import List
 
 import sentry_sdk
 
 from shared.reports.resources import Report, ReportFile
-from shared.reports.types import EMPTY
 
 log = logging.getLogger(__name__)
 
-
-class EditableReportFile(ReportFile):
-    __slots__ = ("_details",)
-
-    @classmethod
-    def from_ReportFile(cls, report_file: ReportFile):
-        name = report_file.name
-        editable_file = cls(name)
-        editable_file._totals = report_file._totals
-        editable_file._lines = report_file._lines
-        editable_file._ignore = report_file._ignore
-        editable_file._details = report_file._details
-        editable_file.fix_details()
-        return editable_file
-
-    def fix_details(self):
-        if self._details is None:
-            self._details = {}
-        if self._details.get("present_sessions") is not None:
-            self._details["present_sessions"] = set(
-                self._details.get("present_sessions")
-            )
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.fix_details()
-
-    @property
-    def details(self):
-        if not self._details:
-            return self._details
-        if self._details.get("present_sessions") is None:
-            return self._details
-        res = copy(self._details)
-        res["present_sessions"] = sorted(self._details.get("present_sessions"))
-        return res
-
-    def delete_labels(
-        self, session_ids_to_delete: List[int], label_ids_to_delete: List[int]
-    ):
-        """Given a list of session_ids and label_ids to delete
-        Remove all datapoints that belong to at least 1 session_ids to delete and include
-        at least 1 of the label_ids to be removed
-        """
-        for index, line in self.lines:
-            if line.datapoints is not None:
-                if any(
-                    (
-                        dp.sessionid in session_ids_to_delete
-                        and label_id in label_ids_to_delete
-                    )
-                    for dp in line.datapoints
-                    for label_id in dp.label_ids
-                ):
-                    # Line fits change requirements
-                    new_line = self.line_without_labels(
-                        line, session_ids_to_delete, label_ids_to_delete
-                    )
-                    if new_line == EMPTY:
-                        del self[index]
-                    else:
-                        self[index] = new_line
-        self._totals = None
-        self.calculate_present_sessions()
-
-    def calculate_present_sessions(self):
-        all_sessions = set()
-        for _, line in self.lines:
-            all_sessions.update(int(s.id) for s in line.sessions)
-        self._details["present_sessions"] = all_sessions
-
-    def merge(self, *args, **kwargs):
-        res = super().merge(*args, **kwargs)
-        self.calculate_present_sessions()
-        return res
-
-    def delete_multiple_sessions(self, session_ids_to_delete: set[int]):
-        if "present_sessions" not in self._details:
-            self.calculate_present_sessions()
-        current_sessions = self._details["present_sessions"]
-
-        new_sessions = current_sessions.difference(session_ids_to_delete)
-        if current_sessions == new_sessions:
-            return  # nothing to do
-
-        self._details["present_sessions"] = new_sessions
-        self._totals = None  # force a refresh of the on-demand totals
-
-        if not new_sessions:
-            self._lines = []  # no remaining sessions means no line data
-            return
-
-        for index, line in self.lines:
-            if any(s.id in session_ids_to_delete for s in line.sessions):
-                new_line = self.line_without_multiple_sessions(
-                    line, session_ids_to_delete
-                )
-                if new_line == EMPTY:
-                    del self[index]
-                else:
-                    self[index] = new_line
+EditableReportFile = ReportFile  # re-export
 
 
 class EditableReport(Report):
@@ -124,9 +21,7 @@ class EditableReport(Report):
         super().merge(new_report, joined)
         for file in self:
             if isinstance(file, ReportFile):
-                self._chunks[self._files.get(file.name).file_index] = (
-                    EditableReportFile.from_ReportFile(file)
-                )
+                self._chunks[self._files.get(file.name).file_index] = file
 
     def turn_chunks_into_reports(self):
         filename_mapping = {
@@ -140,7 +35,7 @@ class EditableReport(Report):
             if chunk is not None and file_summary is not None:
                 if isinstance(chunk, ReportFile):
                     chunk = chunk._lines
-                report_file = self.file_class(
+                report_file = ReportFile(
                     name=filename,
                     totals=file_summary.file_totals,
                     lines=chunk,
@@ -216,4 +111,5 @@ class EditableReport(Report):
                         if point.sessionid == old_id:
                             point.sessionid = new_id
 
-            report_file._details["present_sessions"] = all_sessions
+            report_file._invalidate_caches()
+            report_file.__present_sessions = all_sessions

--- a/shared/reports/types.py
+++ b/shared/reports/types.py
@@ -172,6 +172,9 @@ class ReportLine(object):
             for i, sess in enumerate(self.sessions):
                 if not isinstance(sess, LineSession) and sess is not None:
                     self.sessions[i] = LineSession(*sess)
+        else:
+            self.sessions = {}
+
         if self.datapoints is not None:
             for i, cov_dp in enumerate(self.datapoints):
                 if not isinstance(cov_dp, CoverageDatapoint) and cov_dp is not None:

--- a/tests/integration/test_report.py
+++ b/tests/integration/test_report.py
@@ -746,16 +746,10 @@ def test_filter_exception():
 
 
 @pytest.mark.integration
-@pytest.mark.parametrize(
-    "chunk, res",
-    [
-        (None, "null"),
-        (ReportFile(name="name.ply"), "{}\n"),
-        (
-            [ReportLine.create(2), ReportLine.create(1)],
-            "[[2,null,null,null,null,null],[1,null,null,null,null,null]]",
-        ),
-    ],
-)
-def test_encode_chunk(chunk, res):
-    assert _encode_chunk(chunk) == res
+def test_encode_chunk():
+    assert _encode_chunk(None) == "null"
+    assert _encode_chunk(ReportFile(name="name.ply")) == '{"present_sessions":[]}\n'
+    assert (
+        _encode_chunk([ReportLine.create(2), ReportLine.create(1)])
+        == "[[2,null,null,null,null,null],[1,null,null,null,null,null]]"
+    )

--- a/tests/integration/test_report_file.py
+++ b/tests/integration/test_report_file.py
@@ -356,15 +356,7 @@ def test_shift_lines_by_diff():
 
 
 @pytest.mark.integration
-@pytest.mark.parametrize(
-    "r, encoded_val",
-    [
-        (ReportFile("name.py"), "{}\n"),
-        (
-            ReportFile("name.py", lines=[ReportLine.create(1), ReportLine.create(2)]),
-            "null\n[1]\n[2]",
-        ),
-    ],
-)
-def test_encode(r, encoded_val):
-    assert r._encode() == encoded_val
+def test_encode():
+    assert ReportFile("name.py")._encode() == '{"present_sessions":[]}\n'
+    f = ReportFile("name.py", lines=[ReportLine.create(1), ReportLine.create(2)])
+    assert f._encode() == '{"present_sessions":[]}\n[1]\n[2]'

--- a/tests/unit/test_report.py
+++ b/tests/unit/test_report.py
@@ -923,19 +923,13 @@ def test_filter_exception(mocker):
 
 
 @pytest.mark.unit
-@pytest.mark.parametrize(
-    "chunk, res",
-    [
-        (None, "null"),
-        (ReportFile(name="name.ply"), "{}\n"),
-        (
-            [ReportLine.create(2), ReportLine.create(1)],
-            "[[2,null,null,null,null,null],[1,null,null,null,null,null]]",
-        ),
-    ],
-)
-def test_encode_chunk(chunk, res):
-    assert _encode_chunk(chunk) == res
+def test_encode_chunk():
+    assert _encode_chunk(None) == "null"
+    assert _encode_chunk(ReportFile(name="name.ply")) == '{"present_sessions":[]}\n'
+    assert (
+        _encode_chunk([ReportLine.create(2), ReportLine.create(1)])
+        == "[[2,null,null,null,null,null],[1,null,null,null,null,null]]"
+    )
 
 
 @pytest.mark.unit
@@ -1097,94 +1091,14 @@ def test_shift_lines_by_diff():
     report = Report(sessions={0: Session()})
     report.append(r)
     assert list(r.lines) == [
-        (
-            1,
-            ReportLine(
-                coverage=0,
-                type=None,
-                sessions=None,
-                messages=None,
-                complexity=None,
-                datapoints=None,
-            ),
-        ),
-        (
-            2,
-            ReportLine(
-                coverage=1,
-                type=None,
-                sessions=None,
-                messages=None,
-                complexity=None,
-                datapoints=None,
-            ),
-        ),
-        (
-            3,
-            ReportLine(
-                coverage=2,
-                type=None,
-                sessions=None,
-                messages=None,
-                complexity=None,
-                datapoints=None,
-            ),
-        ),
-        (
-            4,
-            ReportLine(
-                coverage=3,
-                type=None,
-                sessions=None,
-                messages=None,
-                complexity=None,
-                datapoints=None,
-            ),
-        ),
-        (
-            5,
-            ReportLine(
-                coverage=4,
-                type=None,
-                sessions=None,
-                messages=None,
-                complexity=None,
-                datapoints=None,
-            ),
-        ),
-        (
-            6,
-            ReportLine(
-                coverage=5,
-                type=None,
-                sessions=None,
-                messages=None,
-                complexity=None,
-                datapoints=None,
-            ),
-        ),
-        (
-            7,
-            ReportLine(
-                coverage=6,
-                type=None,
-                sessions=None,
-                messages=None,
-                complexity=None,
-                datapoints=None,
-            ),
-        ),
-        (
-            8,
-            ReportLine(
-                coverage=7,
-                type=None,
-                sessions=None,
-                messages=None,
-                complexity=None,
-                datapoints=None,
-            ),
-        ),
+        (1, ReportLine.create(0)),
+        (2, ReportLine.create(1)),
+        (3, ReportLine.create(2)),
+        (4, ReportLine.create(3)),
+        (5, ReportLine.create(4)),
+        (6, ReportLine.create(5)),
+        (7, ReportLine.create(6)),
+        (8, ReportLine.create(7)),
     ]
     assert report.totals == ReportTotals(
         files=1,
@@ -1224,50 +1138,10 @@ def test_shift_lines_by_diff():
     )
     assert report.files == ["filename"]
     assert list(report.get("filename").lines) == [
-        (
-            2,
-            ReportLine(
-                coverage=1,
-                type=None,
-                sessions=None,
-                messages=None,
-                complexity=None,
-                datapoints=None,
-            ),
-        ),
-        (
-            3,
-            ReportLine(
-                coverage=2,
-                type=None,
-                sessions=None,
-                messages=None,
-                complexity=None,
-                datapoints=None,
-            ),
-        ),
-        (
-            4,
-            ReportLine(
-                coverage=3,
-                type=None,
-                sessions=None,
-                messages=None,
-                complexity=None,
-                datapoints=None,
-            ),
-        ),
-        (
-            7,
-            ReportLine(
-                coverage=7,
-                type=None,
-                sessions=None,
-                messages=None,
-                complexity=None,
-                datapoints=None,
-            ),
-        ),
+        (2, ReportLine.create(1)),
+        (3, ReportLine.create(2)),
+        (4, ReportLine.create(3)),
+        (7, ReportLine.create(7)),
     ]
     assert report._files == {
         "filename": ReportFileSummary(


### PR DESCRIPTION
The main purpose of the `EditableReportFile` was to offer methods to delete labels/sessions, as well as to properly maintain uptodate versions of `present_sessions` and `totals` when doing mutations on the file.

All the methods were now moved to `ReportFile`, which has also gained new functionality related to making sure that caches are cleared when necessary, and re-computed on-demand, so that they are always correct.

---

I plan to do a similar thing for `EditableReport` as well in a followup, as it has a similar purpose in relation to maintaining uptodate `totals`.

This is part of https://github.com/codecov/engineering-team/issues/3381