### PR TITLE
fix: Avoid key-error when inserting asset chunks

### DIFF
--- a/shared/bundle_analysis/parsers/v3.py
+++ b/shared/bundle_analysis/parsers/v3.py
@@ -188,7 +188,7 @@ class ParserV3(ParserTrait):
                 assert self.session.bundle is not None
                 return self.session.id, self.session.bundle.name
         except Exception as e:
-            # Inject the plugin name to the Exception object so we have visibilitity on which plugin
+            # Inject the plugin name to the Exception object so we have visibility on which plugin
             # is causing the trouble.
             e.bundle_analysis_plugin_name = self.info.get("plugin_name", "unknown")
             raise e
@@ -408,10 +408,14 @@ class ParserV3(ParserTrait):
         for chunk in chunks:
             chunk_id = chunk.id
             asset_names = self.chunk_asset_names_index[chunk.unique_external_id]
+
+            # Only add assets which we have references for in the asset_name_to_id map
+            # This is to avoid inserting assets for non-JS files
             inserts.extend(
                 [
-                    dict(asset_id=asset_name_to_id[asset_name], chunk_id=chunk_id)
+                    dict(asset_id=asset_name_to_id.get(asset_name), chunk_id=chunk_id)
                     for asset_name in asset_names
+                    if asset_name_to_id.get(asset_name) is not None
                 ]
             )
         if inserts:


### PR DESCRIPTION

This PR updates some logic when creating associations to filter out assets that we don't have a mapping for when creating our asset_chunks prior to insertion.

Seeing around 40 instances of the error in the last week so not super wide spread but still worth fixing -> https://cloudlogging.app.goo.gl/Ckj7wYDciPS34nBb6

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.