### PR TITLE
Switch benchmarks back to instrumentation mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,11 +28,12 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: astral-sh/setup-uv@v5
+      - uses: actions/setup-python@v5
       - run: uv sync --all-extras --dev
 
       - uses: CodSpeedHQ/action@v3
         with:
-          run: uv run pytest tests/ --codspeed --codspeed-mode=walltime --codspeed-warmup-time=0.25 --codspeed-max-time=1
+          run: uv run pytest tests/ --codspeed
           token: ${{ secrets.CODSPEED_TOKEN }}
 
   test:


### PR DESCRIPTION
The walltime instrumentation is only usable on codspeed bare metal runners, which we don’t currently use.

In the meantime, it would be nice to get *some* kind of result for the benchmark, even if it takes a long time.