### PR TITLE
Forward `get_flag_names` for the `ReadOnlyReport`

### DIFF
--- a/shared/reports/readonly.py
+++ b/shared/reports/readonly.py
@@ -103,6 +103,9 @@ class ReadOnlyReport(object):
                 )
         return self._flags
 
+    def get_flag_names(self) -> list[str]:
+        return self.inner_report.get_flag_names()
+
     @property
     def sessions(self):
         return self.inner_report.sessions

--- a/shared/reports/resources.py
+++ b/shared/reports/resources.py
@@ -741,7 +741,7 @@ class Report(object):
                     )
         return flags_dict
 
-    def get_flag_names(self):
+    def get_flag_names(self) -> list[str]:
         all_flags = set()
         for session in self.sessions.values():
             if session and session.flags:


### PR DESCRIPTION
The `api_report_service.ReadOnlyReport` overrides the `flags` property, but it looks like the usage of `.flags` would be better served by `get_flag_names` instead.

But that method previously did not exist on that `Report` class, so lets add it.