### PR TITLE
debug: Add debug log to token refresh logic

### DIFF
--- a/shared/torngit/github.py
+++ b/shared/torngit/github.py
@@ -2,7 +2,6 @@ import base64
 import hashlib
 import logging
 import os
-import sentry_sdk
 from base64 import b64decode
 from datetime import datetime, timezone
 from string import Template
@@ -10,6 +9,7 @@ from typing import Dict, List, Optional
 from urllib.parse import parse_qs, urlencode
 
 import httpx
+import sentry_sdk
 from httpx import Response
 
 from shared.config import get_config
@@ -892,7 +892,9 @@ class Github(TorngitBaseAdapter):
                     prefix, _ = _headers["Authorization"].split(" ")
                     _headers["Authorization"] = f"{prefix} {token['key']}"
                     if not self._on_token_refresh:
-                        sentry_sdk.capture_message("Refreshed github token but no on_token_refresh callback defined")
+                        sentry_sdk.capture_message(
+                            "Refreshed github token but no on_token_refresh callback defined"
+                        )
                     await self._on_token_refresh(token)
                     # Skip the rest of the validations and try again.
                     # It does consume one of the retries

--- a/shared/torngit/github.py
+++ b/shared/torngit/github.py
@@ -2,6 +2,7 @@ import base64
 import hashlib
 import logging
 import os
+import sentry_sdk
 from base64 import b64decode
 from datetime import datetime, timezone
 from string import Template
@@ -890,6 +891,8 @@ class Github(TorngitBaseAdapter):
                     # Update headers and retry
                     prefix, _ = _headers["Authorization"].split(" ")
                     _headers["Authorization"] = f"{prefix} {token['key']}"
+                    if not self._on_token_refresh:
+                        sentry_sdk.capture_message("Refreshed github token but no on_token_refresh callback defined")
                     await self._on_token_refresh(token)
                     # Skip the rest of the validations and try again.
                     # It does consume one of the retries


### PR DESCRIPTION
Adds a Sentry message when the github oauth token is refreshed but the token refresh callback is not defined. This should not be able to occur, but this could explain the behaviour we're seeing.
