### PR TITLE
ref: Change name of Upload Sent event to Upload Received

### DIFF
--- a/shared/events/amplitude/types.py
+++ b/shared/events/amplitude/types.py
@@ -8,9 +8,8 @@ E.g., every 'App Installed' event must have the 'ownerid' property.
 
 Guidelines:
  - Event names should:
-   - be of the form "[Noun] [Past-tense verb]",
-   - have each word capitalized,
-   - describe an action taken by the user.
+   - be of the form "[Noun] [Past-tense verb]" and
+   - have each word capitalized.
  - Keep the event types very generic as we have a limited number of them.
    Instead, add more detail in `properties` where possible.
  - Try to keep event property names unique to the event type to avoid

--- a/shared/events/amplitude/types.py
+++ b/shared/events/amplitude/types.py
@@ -25,7 +25,7 @@ type AmplitudeEventType = Literal[
     "User Created",
     "User Logged in",
     "App Installed",
-    "Upload Sent",
+    "Upload Received",
     "set_orgs",  # special event for setting a user's member orgs
 ]
 
@@ -70,5 +70,5 @@ AMPLITUDE_REQUIRED_PROPERTIES: dict[
     "User Created": [],
     "User Logged in": [],
     "App Installed": ["ownerid"],
-    "Upload Sent": ["ownerid", "repoid", "commitid", "pullid", "upload_type"],
+    "Upload Received": ["ownerid", "repoid", "commitid", "pullid", "upload_type"],
 }

--- a/tests/unit/events/test_amplitude.py
+++ b/tests/unit/events/test_amplitude.py
@@ -135,7 +135,7 @@ def test_publish_converts_to_camel_case(amplitude_mock, base_event_mock):
     amplitude.client.track = Mock()
 
     amplitude.publish(
-        "Upload Sent",
+        "Upload Received",
         {
             "user_ownerid": 123,
             "ownerid": 321,
@@ -149,7 +149,7 @@ def test_publish_converts_to_camel_case(amplitude_mock, base_event_mock):
     amplitude_mock.assert_called_once()
     amplitude.client.track.assert_called_once()
     base_event_mock.assert_called_once_with(
-        "Upload Sent",
+        "Upload Received",
         user_id="123",
         event_properties={
             "ownerid": 321,
@@ -175,7 +175,7 @@ def test_publish_converts_anonymous_owner_id_to_user_id(
     amplitude.client.track = Mock()
 
     amplitude.publish(
-        "Upload Sent",
+        "Upload Received",
         {
             "user_ownerid": UNKNOWN_USER_OWNERID,
             "ownerid": 321,
@@ -189,7 +189,7 @@ def test_publish_converts_anonymous_owner_id_to_user_id(
     amplitude_mock.assert_called_once()
     amplitude.client.track.assert_called_once()
     base_event_mock.assert_called_once_with(
-        "Upload Sent",
+        "Upload Received",
         user_id="anon",
         event_properties={
             "ownerid": 321,


### PR DESCRIPTION
After a discussion with Ajay, we've decided to change the name of this event to align better with our grand plans for events.
