### PR TITLE
Only benchmark the `Report` class

### DIFF
--- a/tests/benchmarks/test_report.py
+++ b/tests/benchmarks/test_report.py
@@ -3,7 +3,6 @@ import pytest
 import zstandard as zstd
 
 from shared.reports.carryforward import generate_carryforward_report
-from shared.reports.readonly import ReadOnlyReport
 from shared.reports.resources import Report
 from shared.torngit.base import TorngitBaseAdapter
 
@@ -16,19 +15,7 @@ def read_fixture(name: str) -> bytes:
     return dctx.decompress(data)
 
 
-READABLE_VARIANTS = [
-    pytest.param(Report, False, id="Report"),
-    pytest.param(ReadOnlyReport, False, id="ReadOnlyReport"),
-    pytest.param(ReadOnlyReport, True, id="Rust ReadOnlyReport"),
-]
-
-
-def init_mocks(mocker, should_load_rust) -> tuple[bytes, bytes]:
-    mocker.patch(
-        "shared.reports.readonly.ReadOnlyReport.should_load_rust_version",
-        return_value=should_load_rust,
-    )
-
+def load_report() -> tuple[bytes, bytes]:
     raw_chunks = read_fixture("tests/benchmarks/fixtures/worker_chunks.txt.zst")
     raw_report_json = read_fixture("tests/benchmarks/fixtures/worker_report.json.zst")
 
@@ -42,16 +29,16 @@ def load_diff() -> dict:
     return torngit.diff_to_json(contents)
 
 
-def do_parse(report_class, raw_report_json, raw_chunks):
+def do_parse(raw_report_json, raw_chunks):
     report_json = orjson.loads(raw_report_json)
     chunks = raw_chunks.decode()
-    return report_class.from_chunks(
+    return Report.from_chunks(
         chunks=chunks, files=report_json["files"], sessions=report_json["sessions"]
     )
 
 
-def do_full_parse(report_class, raw_report_json, raw_chunks):
-    report = do_parse(report_class, raw_report_json, raw_chunks)
+def do_full_parse(raw_report_json, raw_chunks):
+    report = do_parse(raw_report_json, raw_chunks)
     # full parsing in this case means iterating over everything in the report
     # we iterate over `files` and use `get(bind=True)`, as that is caching the
     # parsed `ReportFile` instance.
@@ -66,31 +53,28 @@ def do_full_parse(report_class, raw_report_json, raw_chunks):
     return report
 
 
-@pytest.mark.parametrize("report_class, should_load_rust", READABLE_VARIANTS)
-def test_parse_shallow(report_class, should_load_rust, mocker, benchmark):
-    raw_chunks, raw_report_json = init_mocks(mocker, should_load_rust)
+def test_parse_shallow(benchmark):
+    raw_chunks, raw_report_json = load_report()
 
     def bench_fn():
-        do_parse(report_class, raw_report_json, raw_chunks)
+        do_parse(raw_report_json, raw_chunks)
 
     benchmark(bench_fn)
 
 
-@pytest.mark.parametrize("report_class, should_load_rust", READABLE_VARIANTS)
-def test_parse_full(report_class, should_load_rust, mocker, benchmark):
-    raw_chunks, raw_report_json = init_mocks(mocker, should_load_rust)
+def test_parse_full(benchmark):
+    raw_chunks, raw_report_json = load_report()
 
     def bench_fn():
-        do_full_parse(report_class, raw_report_json, raw_chunks)
+        do_full_parse(raw_report_json, raw_chunks)
 
     benchmark(bench_fn)
 
 
-@pytest.mark.parametrize("report_class, should_load_rust", READABLE_VARIANTS)
-def test_process_totals(report_class, should_load_rust, mocker, benchmark):
-    raw_chunks, raw_report_json = init_mocks(mocker, should_load_rust)
+def test_process_totals(benchmark):
+    raw_chunks, raw_report_json = load_report()
 
-    report = do_full_parse(report_class, raw_report_json, raw_chunks)
+    report = do_full_parse(raw_report_json, raw_chunks)
 
     def bench_fn():
         # both `ReportFile` and `Report` have a cached `_totals` field,
@@ -105,11 +89,10 @@ def test_process_totals(report_class, should_load_rust, mocker, benchmark):
     benchmark(bench_fn)
 
 
-@pytest.mark.parametrize("report_class, should_load_rust", READABLE_VARIANTS)
-def test_report_filtering(report_class, should_load_rust, mocker, benchmark):
-    raw_chunks, raw_report_json = init_mocks(mocker, should_load_rust)
+def test_report_filtering(benchmark):
+    raw_chunks, raw_report_json = load_report()
 
-    report = do_full_parse(report_class, raw_report_json, raw_chunks)
+    report = do_full_parse(raw_report_json, raw_chunks)
 
     def bench_fn():
         filtered = report.filter(paths=[".*"], flags=["unit"])
@@ -137,11 +120,11 @@ def test_report_filtering(report_class, should_load_rust, mocker, benchmark):
     "do_filter",
     [pytest.param(False, id="Report"), pytest.param(True, id="FilteredReport")],
 )
-def test_report_diff_calculation(mocker, do_filter, benchmark):
-    raw_chunks, raw_report_json = init_mocks(mocker, False)
+def test_report_diff_calculation(do_filter, benchmark):
+    raw_chunks, raw_report_json = load_report()
     diff = load_diff()
 
-    report = do_full_parse(Report, raw_report_json, raw_chunks)
+    report = do_full_parse(raw_report_json, raw_chunks)
     if do_filter:
         report = report.filter(paths=[".*"], flags=["unit"])
 
@@ -151,10 +134,10 @@ def test_report_diff_calculation(mocker, do_filter, benchmark):
     benchmark(bench_fn)
 
 
-def test_report_serialize(mocker, benchmark):
-    raw_chunks, raw_report_json = init_mocks(mocker, False)
+def test_report_serialize(benchmark):
+    raw_chunks, raw_report_json = load_report()
 
-    report = do_parse(Report, raw_report_json, raw_chunks)
+    report = do_parse(raw_report_json, raw_chunks)
 
     def bench_fn():
         report.serialize()
@@ -162,22 +145,22 @@ def test_report_serialize(mocker, benchmark):
     benchmark(bench_fn)
 
 
-def test_report_merge(mocker, benchmark):
-    raw_chunks, raw_report_json = init_mocks(mocker, False)
+def test_report_merge(benchmark):
+    raw_chunks, raw_report_json = load_report()
 
-    report2 = do_full_parse(Report, raw_report_json, raw_chunks)
+    report2 = do_full_parse(raw_report_json, raw_chunks)
 
     def bench_fn():
-        report1 = do_parse(Report, raw_report_json, raw_chunks)
+        report1 = do_parse(raw_report_json, raw_chunks)
         report1.merge(report2)
 
     benchmark(bench_fn)
 
 
-def test_report_carryforward(mocker, benchmark):
-    raw_chunks, raw_report_json = init_mocks(mocker, False)
+def test_report_carryforward(benchmark):
+    raw_chunks, raw_report_json = load_report()
 
-    report = do_full_parse(Report, raw_report_json, raw_chunks)
+    report = do_full_parse(raw_report_json, raw_chunks)
 
     def bench_fn():
         generate_carryforward_report(report, paths=[".*"], flags=["unit"])


### PR DESCRIPTION
We were previously also benchmarking the `ReadOnlyReport`. However that has yielded pretty much the same numbers, regardless of the "rust" feature flag. I’m pretty sure that class as it exists now does not pull its weight, and I think we should remove it.

For now, I remove it from the benchmarks, as the benchmarks provide no additional value, but are just slowing down the benchmark suite.