### PR TITLE
fix: remove test_analytics database

### DIFF
--- a/shared/django_apps/db_routers/__init__.py
+++ b/shared/django_apps/db_routers/__init__.py
@@ -18,8 +18,6 @@ class MultiDatabaseRouter:
                     return "timeseries_read"
                 else:
                     return "timeseries"
-            case "test_analytics":
-                return "test_analytics"
             case _:
                 if settings.DATABASE_READ_REPLICA_ENABLED:
                     return "default_read"
@@ -30,34 +28,25 @@ class MultiDatabaseRouter:
         match model._meta.app_label:
             case "timeseries":
                 return "timeseries"
-            case "test_analytics":
-                return "test_analytics"
             case _:
                 return "default"
 
     def allow_migrate(self, db, app_label, model_name=None, **hints):
         match db:
-            case "timeseries_read" | "test_analytics_read" | "default_read":
+            case "timeseries_read" | "default_read":
                 return False
             case "timeseries":
                 if not settings.TIMESERIES_ENABLED:
                     return False
                 return app_label == "timeseries"
-            case "test_analytics":
-                if not settings.TEST_ANALYTICS_DATABASE_ENABLED:
-                    return False
-                return app_label == "test_analytics"
             case _:
-                return app_label not in {"timeseries", "test_analytics"}
+                return app_label not in {"timeseries"}
 
     def allow_relation(self, obj1, obj2, **hints):
         obj1_app = obj1._meta.app_label
         obj2_app = obj2._meta.app_label
 
-        if obj1_app in {"timeseries", "test_analytics"} or obj2_app in {
-            "timeseries",
-            "test_analytics",
-        }:
+        if obj1_app in {"timeseries"} or obj2_app in {"timeseries"}:
             return obj1_app == obj2_app
         else:
             return True

--- a/shared/django_apps/db_settings.py
+++ b/shared/django_apps/db_settings.py
@@ -158,47 +158,6 @@ if TIMESERIES_ENABLED:
             "CONN_MAX_AGE": CONN_MAX_AGE,
         }
 
-TEST_ANALYTICS_DATABASE_ENABLED = get_config(
-    "setup", "test_analytics_database", "enabled", default=True
-)
-
-test_analytics_database_url = get_config("services", "test_analytics_database_url")
-if test_analytics_database_url:
-    test_analytics_database_conf = urlparse(test_analytics_database_url)
-    TEST_ANALYTICS_DATABASE_NAME = test_analytics_database_conf.path.replace("/", "")
-    TEST_ANALYTICS_DATABASE_USER = test_analytics_database_conf.username
-    TEST_ANALYTICS_DATABASE_PASSWORD = test_analytics_database_conf.password
-    TEST_ANALYTICS_DATABASE_HOST = test_analytics_database_conf.hostname
-    TEST_ANALYTICS_DATABASE_PORT = test_analytics_database_conf.port
-else:
-    TEST_ANALYTICS_DATABASE_NAME = get_config(
-        "services", "test_analytics_database", "name", default="test_analytics"
-    )
-    TEST_ANALYTICS_DATABASE_USER = get_config(
-        "services", "test_analytics_database", "username", default="postgres"
-    )
-    TEST_ANALYTICS_DATABASE_PASSWORD = get_config(
-        "services", "test_analytics_database", "password", default="postgres"
-    )
-    TEST_ANALYTICS_DATABASE_HOST = get_config(
-        "services", "test_analytics_database", "host", default="postgres"
-    )
-    TEST_ANALYTICS_DATABASE_PORT = get_config(
-        "services", "test_analytics_database", "port", default=5432
-    )
-
-
-if TEST_ANALYTICS_DATABASE_ENABLED:
-    DATABASES["test_analytics"] = {
-        "ENGINE": "psqlextra.backend",
-        "NAME": TEST_ANALYTICS_DATABASE_NAME,
-        "USER": TEST_ANALYTICS_DATABASE_USER,
-        "PASSWORD": TEST_ANALYTICS_DATABASE_PASSWORD,
-        "HOST": TEST_ANALYTICS_DATABASE_HOST,
-        "PORT": TEST_ANALYTICS_DATABASE_PORT,
-        "CONN_MAX_AGE": CONN_MAX_AGE,
-    }
-
 
 # See https://django-postgres-extra.readthedocs.io/en/main/settings.html
 POSTGRES_EXTRA_DB_BACKEND_BASE: "django_prometheus.db.backends.postgresql"  # type: ignore

--- a/shared/django_apps/dummy_settings.py
+++ b/shared/django_apps/dummy_settings.py
@@ -93,14 +93,6 @@ DATABASES = {
         "HOST": "timescale",
         "PORT": 5432,
     },
-    "test_analytics": {
-        "ENGINE": "psqlextra.backend",
-        "NAME": "test_analytics",
-        "USER": "postgres",
-        "PASSWORD": "postgres",
-        "HOST": "postgres",
-        "PORT": 5432,
-    },
 }
 
 # Password validation

--- a/tests/unit/django_apps/test_db_routers.py
+++ b/tests/unit/django_apps/test_db_routers.py
@@ -65,30 +65,6 @@ class TestMultiDatabaseRouter:
         assert router.allow_migrate("default", "timeseries") == False
         assert router.allow_migrate("default_read", "timeseries") == False
 
-    @override_settings(TEST_ANALYTICS_DATABASE_ENABLED=False)
-    def test_allow_migrate_test_analytics_disabled(self):
-        router = MultiDatabaseRouter()
-        assert router.allow_migrate("test_analytics", "test_analytics") == False
-        assert router.allow_migrate("test_analytics_read", "test_analytics") == False
-        assert router.allow_migrate("test_analytics", "default") == False
-        assert router.allow_migrate("test_analytics_read", "default") == False
-        assert router.allow_migrate("default", "default") == True
-        assert router.allow_migrate("default_read", "default") == False
-        assert router.allow_migrate("default", "test_analytics") == False
-        assert router.allow_migrate("default_read", "test_analytics") == False
-
-    @override_settings(TEST_ANALYTICS_DATABASE_ENABLED=True)
-    def test_allow_migrate_test_analytics_enabled(self):
-        router = MultiDatabaseRouter()
-        assert router.allow_migrate("test_analytics", "test_analytics") == True
-        assert router.allow_migrate("test_analytics_read", "test_analytics") == False
-        assert router.allow_migrate("test_analytics", "default") == False
-        assert router.allow_migrate("test_analytics_read", "default") == False
-        assert router.allow_migrate("default", "default") == True
-        assert router.allow_migrate("default_read", "default") == False
-        assert router.allow_migrate("default", "test_analytics") == False
-        assert router.allow_migrate("default_read", "test_analytics") == False
-
     def test_allow_relation(self, mocker):
         # At time of writing, the Django timeseries models don't live in this
         # repo so we're pretending a different model is from the timeseries app


### PR DESCRIPTION
we'll just use the default as it's probably faster, but we won't get to scale TA DB separately