### PR TITLE
Remove more unused `Report` code, change serde code to use `str`

### DIFF
--- a/shared/reports/readonly.py
+++ b/shared/reports/readonly.py
@@ -12,7 +12,6 @@ from shared.reports.resources import (
     END_OF_HEADER,
     Report,
     ReportTotals,
-    chunks_from_storage_contains_header,
 )
 from shared.utils.match import Matcher
 
@@ -23,8 +22,9 @@ class LazyRustReport(object):
     def __init__(self, filename_mapping, chunks, session_mapping):
         # Because Rust can't parse the header. It doesn't need it either,
         # So it's simpler to just never sent it.
-        if chunks_from_storage_contains_header(chunks):
-            _, chunks = chunks.split(END_OF_HEADER, 1)
+        splits = chunks.split(END_OF_HEADER, maxsplit=1)
+        if len(splits) > 1:
+            chunks = splits[1]
         self._chunks = chunks
         self._filename_mapping = filename_mapping
         self._session_mapping = session_mapping

--- a/tests/integration/test_report.py
+++ b/tests/integration/test_report.py
@@ -402,42 +402,6 @@ def test_non_zero(r, boolean):
     assert bool(r) is boolean
 
 
-@pytest.mark.integration
-def test_to_archive():
-    chunks = Report(
-        files={"file.py": [0, ReportTotals()]},
-        chunks="null\n[1]\n[1]\n[1]\n<<<<< end_of_chunk >>>>>\nnull\n[1]\n[1]\n[1]",
-    ).to_archive()
-    assert chunks == """{}\n<<<<< end_of_header >>>>>\nnull\n[1]\n[1]\n[1]"""
-
-
-@pytest.mark.integration
-def test_to_database():
-    totals, report_json = Report(
-        files={"file.py": [0, ReportTotals()]},
-        chunks="null\n[1]\n[1]\n[1]\n<<<<< end_of_chunk >>>>>\nnull\n[1]\n[1]\n[1]",
-    ).to_database()
-    assert totals == {
-        "M": 0,
-        "c": None,
-        "b": 0,
-        "d": 0,
-        "f": 1,
-        "h": 0,
-        "m": 0,
-        "C": 0,
-        "n": 0,
-        "p": 0,
-        "s": 0,
-        "diff": None,
-        "N": 0,
-    }
-    assert (
-        report_json
-        == '{"files":{"file.py":[0,[0,0,0,0,0,0,0,0,0,0,0,0,0],null,null]},"sessions":{}}'
-    )
-
-
 def test_serialize(mocker):
     report = Report(
         files={"file.py": [0, ReportTotals()]},

--- a/tests/unit/reports/test_carryforward.py
+++ b/tests/unit/reports/test_carryforward.py
@@ -1,6 +1,3 @@
-import dataclasses
-from json import loads
-
 import pytest
 
 from shared.reports.carryforward import (
@@ -9,6 +6,7 @@ from shared.reports.carryforward import (
 )
 from shared.reports.resources import Report, ReportFile, Session
 from shared.reports.types import LineSession, ReportLine
+from tests.unit.reports.utils import convert_report_to_better_readable
 
 
 @pytest.fixture
@@ -65,50 +63,10 @@ class TestCarryfowardFlag(object):
             carriedforward_session_name("CF CF CF CF CF CF CF Dude") == "CF[8] - Dude"
         )
 
-    def convert_report_to_better_readable(self, report):
-        totals_dict, report_dict = report.to_database()
-        report_dict = loads(report_dict)
-        archive_dict = {}
-        for filename in report.files:
-            file_report = report.get(filename)
-            lines = []
-            for line_number, line in file_report.lines:
-                (
-                    coverage,
-                    line_type,
-                    sessions,
-                    messages,
-                    complexity,
-                    datapoints,
-                ) = dataclasses.astuple(line)
-                sessions = [list(s) for s in sessions]
-                lines.append(
-                    (
-                        line_number,
-                        coverage,
-                        line_type,
-                        sessions,
-                        messages,
-                        complexity,
-                        datapoints,
-                    )
-                    if datapoints is not None
-                    else (
-                        line_number,
-                        coverage,
-                        line_type,
-                        sessions,
-                        messages,
-                        complexity,
-                    )
-                )
-            archive_dict[filename] = lines
-        return {"totals": totals_dict, "report": report_dict, "archive": archive_dict}
-
     def test_generate_carryforward_report(self, sample_report):
         res = generate_carryforward_report(sample_report, flags=["simple"], paths=None)
         assert res.files == ["file_1.go", "file_2.py"]
-        readable_report = self.convert_report_to_better_readable(res)
+        readable_report = convert_report_to_better_readable(res)
         expected_result = {
             "archive": {
                 "file_1.go": [
@@ -199,7 +157,7 @@ class TestCarryfowardFlag(object):
             sample_report, flags=["simple"], paths=["file_1.*"]
         )
         assert res.files == ["file_1.go"]
-        readable_report = self.convert_report_to_better_readable(res)
+        readable_report = convert_report_to_better_readable(res)
         expected_result = {
             "archive": {
                 "file_1.go": [
@@ -267,7 +225,7 @@ class TestCarryfowardFlag(object):
             sample_report, flags=["simple"], paths=["file_\\W.*"]
         )
         assert res.files == []
-        readable_report = self.convert_report_to_better_readable(res)
+        readable_report = convert_report_to_better_readable(res)
         expected_result = {
             "archive": {},
             "report": {
@@ -320,7 +278,7 @@ class TestCarryfowardFlag(object):
             sample_report, flags=["simple"], paths=[".*\\.cpp", ".*_2\\..*"]
         )
         assert res.files == ["file_2.py"]
-        readable_report = self.convert_report_to_better_readable(res)
+        readable_report = convert_report_to_better_readable(res)
         assert readable_report == {
             "archive": {
                 "file_2.py": [
@@ -375,7 +333,7 @@ class TestCarryfowardFlag(object):
     def test_generate_carryforward_report_one_file_not_covered(self, sample_report):
         res = generate_carryforward_report(sample_report, flags=["complex"], paths=None)
         assert res.files == ["file_1.go"]
-        readable_report = self.convert_report_to_better_readable(res)
+        readable_report = convert_report_to_better_readable(res)
 
         expected_result = {
             "archive": {
@@ -447,7 +405,7 @@ class TestCarryfowardFlag(object):
             session_extras={"cfed_parent": "0f9ab1fe6c879bc49a9e559b23f49fd033daadb0"},
         )
         assert res.files == ["file_1.go"]
-        readable_report = self.convert_report_to_better_readable(res)
+        readable_report = convert_report_to_better_readable(res)
 
         expected_result = {
             "archive": {

--- a/tests/unit/reports/utils.py
+++ b/tests/unit/reports/utils.py
@@ -1,0 +1,55 @@
+import dataclasses
+from json import loads
+
+from shared.reports.resources import Report
+from shared.reports.types import TOTALS_MAP
+
+
+def legacy_totals(report: Report) -> dict:
+    totals = dict(zip(TOTALS_MAP, report.totals))
+    totals["diff"] = report.diff_totals
+    return totals
+
+
+def convert_report_to_better_readable(report: Report) -> dict:
+    report_json, _chunks, _totals = report.serialize()
+
+    totals_dict = legacy_totals(report)
+    report_dict = loads(report_json)
+    report_dict.pop("totals")
+    archive_dict = {}
+    for filename in report.files:
+        file_report = report.get(filename)
+        lines = []
+        for line_number, line in file_report.lines:
+            (
+                coverage,
+                line_type,
+                sessions,
+                messages,
+                complexity,
+                datapoints,
+            ) = dataclasses.astuple(line)
+            sessions = [list(s) for s in sessions]
+            lines.append(
+                (
+                    line_number,
+                    coverage,
+                    line_type,
+                    sessions,
+                    messages,
+                    complexity,
+                    datapoints,
+                )
+                if datapoints is not None
+                else (
+                    line_number,
+                    coverage,
+                    line_type,
+                    sessions,
+                    messages,
+                    complexity,
+                )
+            )
+        archive_dict[filename] = lines
+    return {"archive": archive_dict, "report": report_dict, "totals": totals_dict}

--- a/tests/unit/test_report.py
+++ b/tests/unit/test_report.py
@@ -2,12 +2,8 @@ import pytest
 
 from shared.reports.editable import EditableReport, EditableReportFile
 from shared.reports.exceptions import LabelIndexNotFoundError, LabelNotFoundError
-from shared.reports.resources import (
-    Report,
-    ReportFile,
-    _encode_chunk,
-    chunks_from_storage_contains_header,
-)
+from shared.reports.resources import Report, ReportFile
+from shared.reports.serde import _encode_chunk
 from shared.reports.types import (
     CoverageDatapoint,
     LineSession,
@@ -92,25 +88,6 @@ def report_with_file_summaries():
             diff=0,
         ),
     )
-
-
-@pytest.mark.unit
-@pytest.mark.parametrize(
-    "chunks, expected",
-    [
-        ("", False),
-        ("{}\nline\nline\n\n", False),
-        ("{}\nline\nline\n\n<<<<< end_of_chunk >>>>>\n{}\nline\nline\n", False),
-        (
-            "{}\n<<<<< end_of_header >>>>>\n{}\nline\nline\n\n<<<<< end_of_chunk >>>>>\n{}\nline\nline\n",
-            True,
-        ),
-        ("{}\n<<<<< end_of_header >>>>>\n{}\nline\nline\n\n", True),
-        ("{}\n<<<<< end_of_header >>>>>\n", True),
-    ],
-)
-def test_chunks_from_storage_contains_header(chunks, expected):
-    assert chunks_from_storage_contains_header(chunks) == expected
 
 
 def test_files():
@@ -322,11 +299,11 @@ def test_apply_diff_no_diff():
 
 @pytest.mark.unit
 def test_encode_chunk():
-    assert _encode_chunk(None) == b"null"
-    assert _encode_chunk(ReportFile(name="name.ply")) == b'{"present_sessions":[]}\n'
+    assert _encode_chunk(None) == "null"
+    assert _encode_chunk(ReportFile(name="name.ply")) == '{"present_sessions":[]}\n'
     assert (
         _encode_chunk([ReportLine.create(2), ReportLine.create(1)])
-        == b"[[2,null,null,null,null,null],[1,null,null,null,null,null]]"
+        == "[[2,null,null,null,null,null],[1,null,null,null,null,null]]"
     )
 
 


### PR DESCRIPTION
I removed the users of the `to_archive`/`to_database` functions, so lets remove those, along with other functions.

Another change is to change the serde code to use `str`. As strange as it might sound, but I believe that python is optimizing strings a bit better, and avoids copying all the string contents around in some cases.

This also cleans up the tests a bit.