### PR TITLE
fix: quick fix

### DIFF
--- a/shared/django_apps/db_settings.py
+++ b/shared/django_apps/db_settings.py
@@ -125,7 +125,7 @@ else:
         "services", "ta_timeseries_database", "username", default="postgres"
     )
     TA_TIMESERIES_DATABASE_NAME = get_config(
-        "services", "ta_timeseries_database", "name", default="postgres"
+        "services", "ta_timeseries_database", "name", default="test_analytics"
     )
     TA_TIMESERIES_DATABASE_PASSWORD = get_config(
         "services", "ta_timeseries_database", "password", default="postgres"

--- a/shared/django_apps/dummy_settings.py
+++ b/shared/django_apps/dummy_settings.py
@@ -96,7 +96,7 @@ DATABASES = {
     },
     "ta_timeseries": {
         "ENGINE": "django.db.backends.postgresql",
-        "NAME": "postgres",
+        "NAME": "test_analytics",
         "USER": "postgres",
         "PASSWORD": "postgres",
         "HOST": "timescale",

--- a/shared/django_apps/ta_timeseries/migrations/0002_testrun_summary_1day.py
+++ b/shared/django_apps/ta_timeseries/migrations/0002_testrun_summary_1day.py
@@ -33,7 +33,7 @@ class Migration(migrations.Migration):
                     COUNT(*) FILTER (WHERE outcome = 'flaky_fail') AS flaky_fail_count,
                     MAX(timestamp) AS updated_at,
                     array_merge_dedup_agg(flags) as flags
-                from timeseries_testrun
+                from ta_timeseries_testrun
                 group by
                     repo_id, testsuite, classname, name, timestamp_bin;
             """,
@@ -61,7 +61,7 @@ class Migration(migrations.Migration):
                     COUNT(*) FILTER (WHERE outcome = 'flaky_fail') AS flaky_fail_count,
                     MAX(timestamp) AS updated_at,
                     array_merge_dedup_agg(flags) as flags
-                from timeseries_testrun
+                from ta_timeseries_testrun
                 where branch in ('main', 'master', 'develop')
                 group by
                     repo_id, branch, testsuite, classname, name, timestamp_bin;

--- a/shared/django_apps/ta_timeseries/models.py
+++ b/shared/django_apps/ta_timeseries/models.py
@@ -33,19 +33,19 @@ class Testrun(ExportModelOperationsMixin("ta_timeseries.testrun"), models.Model)
         app_label = TA_TIMESERIES_APP_LABEL
         indexes = [
             models.Index(
-                name="ts__repo_branch_time_i",
+                name="ta_ts__branch_i",
                 fields=["repo_id", "branch", "timestamp"],
             ),
             models.Index(
-                name="ts__repo_branch_test_time_i",
+                name="ta_ts__branch_test_i",
                 fields=["repo_id", "branch", "test_id", "timestamp"],
             ),
             models.Index(
-                name="ts__repo_test_id_time_i",
+                name="ta_ts__test_id_i",
                 fields=["repo_id", "test_id", "timestamp"],
             ),
             models.Index(
-                name="ts__repo_commit_time_i",
+                name="ta_ts__commit_i",
                 fields=["repo_id", "commit_sha", "timestamp"],
             ),
         ]


### PR DESCRIPTION
- if we have the 2 connections point at the same exact database, it will fail to actually make the migrations because the first one will mark the migrations as done, and the second one will see that they are done and not do anything
- renaming of the indexes to avoid conflicts
- renaming the target table in the continuous aggregates

follow-up here: https://github.com/codecov/worker/pull/1150