### PR TITLE
fix: Nonsentry user on sentry plan should be able to update plan

### DIFF
--- a/shared/plan/service.py
+++ b/shared/plan/service.py
@@ -168,7 +168,7 @@ class PlanService:
         # Build list of available tiers based on conditions
         available_tiers = [TierName.PRO.value]
 
-        if is_sentry_user(owner):
+        if is_sentry_user(owner) or curr_plan.is_sentry_plan:
             available_tiers.append(TierName.SENTRY.value)
 
         if (

--- a/tests/unit/plan/test_plan.py
+++ b/tests/unit/plan/test_plan.py
@@ -563,6 +563,29 @@ class AvailablePlansBeforeTrial(TestCase):
             == expected_result
         )
 
+    @patch("shared.plan.service.is_sentry_user")
+    def test_available_plans_for_sentry_plan_not_sentry_user(self, is_sentry_user):
+        is_sentry_user.return_value = False
+        self.current_org.plan = PlanName.SENTRY_MONTHLY.value
+        self.current_org.save()
+
+        plan_service = PlanService(current_org=self.current_org)
+
+        expected_result = {
+            DEFAULT_FREE_PLAN,
+            PlanName.CODECOV_PRO_MONTHLY.value,
+            PlanName.CODECOV_PRO_YEARLY.value,
+            PlanName.SENTRY_MONTHLY.value,
+            PlanName.SENTRY_YEARLY.value,
+            PlanName.TEAM_MONTHLY.value,
+            PlanName.TEAM_YEARLY.value,
+        }
+
+        assert (
+            set(plan.name for plan in plan_service.available_plans(owner=self.owner))
+            == expected_result
+        )
+
 
 @freeze_time("2023-06-19")
 class AvailablePlansExpiredTrialLessThanTenUsers(TestCase):


### PR DESCRIPTION
This PR aims to fix a bug where a user who has not linked their Sentry account tries to update their plan details while they're on the sentry plan. We naively search for the "available plans" for the user adding the sentry plans to that list if they have the account linked. But we should also add the sentry plans to that list if they're currently on a sentry plan



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.