### PR TITLE
emit junit results in a monorepo-friendly way

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,18 @@ CODECOV_UPLOAD_TOKEN ?= "notset"
 CODECOV_URL ?= "https://api.codecov.io"
 CODECOV_FLAG ?= ""
 full_sha := $(shell git rev-parse HEAD)
+
+# We allow this to be overridden so that we can run `pytest` from this directory
+# but have the junit file use paths relative to a parent directory. This will
+# help us move to a monorepo.
+PYTEST_ROOTDIR ?= "."
+
 export CODECOV_TOKEN=${CODECOV_UPLOAD_TOKEN}
 .ONESHELL:
 
 test:
 	# Emit coverage/junit files inside the bind-mounted `test` directory
-	docker compose exec shared uv run pytest --cov-report=xml:tests/unit.coverage.xml --junitxml=tests/unit.junit.xml -o junit_family=legacy
+	docker compose exec shared uv run pytest --cov-report=xml:tests/unit.coverage.xml --junitxml=tests/unit.junit.xml -o junit_family=legacy -c pytest.ini --rootdir=${PYTEST_ROOTDIR}
 
 test.path:
 	docker compose exec shared uv run pytest $(TEST_PATH)
@@ -45,7 +51,7 @@ test_env.up:
 
 test_env.test:
 	# Emit coverage/junit files inside the bind-mounted `test` directory
-	docker compose exec shared uv run pytest --cov ./shared --cov-report=xml:tests/unit.coverage.xml --junitxml=tests/unit.junit.xml -o junit_family=legacy
+	docker compose exec shared uv run pytest -c pytest.ini --rootdir=${PYTEST_ROOTDIR} --cov ./shared --cov-report=xml:tests/unit.coverage.xml --junitxml=tests/unit.junit.xml -o junit_family=legacy
 
 test_env.down:
 	docker compose down


### PR DESCRIPTION
see resulting test file paths here: https://app.codecov.io/gh/codecov/shared/tests/matt%2Fmonorepo-friendly-junit

sort by "Last run" to get the results of the most recent attempt

this is a bit of a hack, but better solutions are all way, way easier after cutover and involve more invasive changes to how things work.

the worker/shared/api PRs pass `--rootdir=${PYTEST_ROOTDIR} -c pytest.ini` to pytest invocations. `--rootdir=${PYTEST_ROOTDIR}` allows us to override the rootdir, and `-c pytest.ini` makes sure pytest can still find its config when we do.

by default, the rootdir is `.`, which is the directory `pytest.ini` lives in. it's as if neither argument were passed at all. the original worker/api/shared repos use the default, so they are unchanged.

[the gha-workflows PR](https://github.com/codecov/gha-workflows/pull/47) adds an optional input to the test workflows which allow `PYTEST_ROOTDIR` to be overridden. umbrella passes in `/app`, and the result is that test file paths inside `junit.xml` will have the prefix umbrella wants (e.g. `apps/worker` for worker).

so, the original repositories generate junit files with test file paths relative to the repo root, just like always. and umbrella will generate junit files with test file paths relative to _umbrella's_ root, which is what umbrella wants.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.