### PR TITLE
Hard-enable the `RustReport`

### DIFF
--- a/tests/unit/reports/test_changes.py
+++ b/tests/unit/reports/test_changes.py
@@ -15,8 +15,7 @@ current_file = Path(__file__)
 
 
 @pytest.fixture
-def sample_rust_report(mocker):
-    mocker.patch.object(ReadOnlyReport, "should_load_rust_version", return_value=True)
+def sample_rust_report():
     with open(current_file.parent / "samples" / "chunks_01.txt", "r") as f:
         chunks = f.read()
     files_dict = {

--- a/tests/unit/reports/test_readonly.py
+++ b/tests/unit/reports/test_readonly.py
@@ -10,8 +10,7 @@ current_file = Path(__file__)
 
 
 @pytest.fixture
-def sample_rust_report(mocker):
-    mocker.patch.object(ReadOnlyReport, "should_load_rust_version", return_value=True)
+def sample_rust_report():
     with open(current_file.parent / "samples" / "chunks_01.txt", "r") as f:
         chunks = f.read()
     files_dict = {
@@ -74,10 +73,7 @@ class TestReadOnly(object):
     @pytest.mark.parametrize(
         "report_header", [{}, {"labels_index": {0: "special_label", 1: "some_test"}}]
     )
-    def test_create_from_report(self, sample_report, mocker, report_header):
-        mocker.patch.object(
-            ReadOnlyReport, "should_load_rust_version", return_value=True
-        )
+    def test_create_from_report(self, sample_report, report_header):
         sample_report._header = report_header
         r = ReadOnlyReport.create_from_report(sample_report)
         assert r.rust_report is not None
@@ -220,9 +216,6 @@ class TestReadOnly(object):
 
     def test_from_chunks_with_totals(self, mocker):
         mocked_process_totals = mocker.patch.object(ReadOnlyReport, "_process_totals")
-        mocker.patch.object(
-            ReadOnlyReport, "should_load_rust_version", return_value=True
-        )
         with open(current_file.parent / "samples" / "chunks_01.txt", "r") as f:
             chunks = f.read()
         files_dict = {
@@ -319,68 +312,6 @@ class TestReadOnly(object):
         assert sample_rust_report.rust_report is not None
         assert sample_rust_report.rust_report.get_report() is not None
         assert sample_rust_report.filter() is sample_rust_report
-
-    def test_init_no_loading_rust(self, mocker):
-        chunks = "\n".join(
-            ["{}", "", "", "[1, null, [[0, 1], [1, 0]]]", "[0, null, [[0, 0], [1, 0]]]"]
-        )
-        files_dict = {
-            "awesome/__init__.py": [
-                2,
-                [0, 10, 8, 2, 0, "80.00000", 0, 0, 0, 0, 0, 0, 0],
-                [[0, 10, 8, 2, 0, "80.00000", 0, 0, 0, 0, 0, 0, 0]],
-                [0, 2, 1, 1, 0, "50.00000", 0, 0, 0, 0, 0, 0, 0],
-            ],
-            "tests/__init__.py": [
-                0,
-                [0, 3, 2, 1, 0, "66.66667", 0, 0, 0, 0, 0, 0, 0],
-                [[0, 3, 2, 1, 0, "66.66667", 0, 0, 0, 0, 0, 0, 0]],
-                None,
-            ],
-            "tests/test_sample.py": [
-                1,
-                [0, 7, 7, 0, 0, "100", 0, 0, 0, 0, 0, 0, 0],
-                [[0, 7, 7, 0, 0, "100", 0, 0, 0, 0, 0, 0, 0]],
-                None,
-            ],
-        }
-        sessions_dict = {
-            "0": {
-                "N": None,
-                "a": "v4/raw/2019-01-10/4434BC2A2EC4FCA57F77B473D83F928C/abf6d4df662c47e32460020ab14abf9303581429/9ccc55a1-8b41-4bb1-a946-ee7a33a7fb56.txt",
-                "c": None,
-                "d": 1547084427,
-                "e": None,
-                "f": ["unit"],
-                "j": None,
-                "n": None,
-                "p": None,
-                "t": [3, 20, 17, 3, 0, "85.00000", 0, 0, 0, 0, 0, 0, 0],
-                "": None,
-            }
-        }
-        mocker.patch.object(
-            ReadOnlyReport, "should_load_rust_version", return_value=False
-        )
-        r = ReadOnlyReport.from_chunks(
-            chunks=chunks, files=files_dict, sessions=sessions_dict
-        )
-        assert r.rust_report is None
-        assert r.totals == ReportTotals(
-            files=3,
-            lines=20,
-            hits=17,
-            misses=3,
-            partials=0,
-            coverage="85.00000",
-            branches=0,
-            methods=0,
-            messages=0,
-            sessions=1,
-            complexity=0,
-            complexity_total=0,
-            diff=0,
-        )
 
     def test_init(self, sample_rust_report):
         report = sample_rust_report


### PR DESCRIPTION
It turns out that the [`ComparisonProxy.get_impacted_files`](https://github.com/codecov/worker/blob/c87d47b6c64d150f19242c3ef1c3a5821fc0931f/services/comparison/__init__.py#L284-L290) function within `worker` is depending on the `RustReport` being enabled and present.

So lets just remove the feature flag and hard-enable this, to make it clear that other code actually depends on this.