### PR TITLE
Document broken branch merging logic

### DIFF
--- a/shared/utils/merge.py
+++ b/shared/utils/merge.py
@@ -242,8 +242,8 @@ def _merge_sessions(s1: list[LineSession], s2: list[LineSession]) -> list[LineSe
     if not s1 or not s2:
         return s1 or s2
 
-    session_ids_1 = set(s.id for s in s1)
-    session_ids_2 = set(s.id for s in s2)
+    session_ids_1 = {s.id for s in s1}
+    session_ids_2 = {s.id for s in s2}
     intersection = session_ids_1.intersection(session_ids_2)
     if not intersection:
         s1.extend(s2)


### PR DESCRIPTION
This is coming from a customer issue.
The customer has an upload that contains both an lcov file as well as a cobertura file.

The lcov file creates a `LineSession` with `0/2` coverage and `missed_branches=[0:5, 0:6]`.
The cobertura file encodes the same information in a different format, yielding `0/1` with `missed_braches=[0]`.

Merging those two is currently broken and yields a bogus result of `2/2`.