### PR TITLE
feat: add metadata to MinioStorageService

### DIFF
--- a/shared/storage/__init__.py
+++ b/shared/storage/__init__.py
@@ -1,8 +1,7 @@
 from shared.config import get_config
-from shared.storage.base import BaseStorageService
 from shared.storage.minio import MinioStorageService
 
 
-def get_appropriate_storage_service(*_args, **_kwargs) -> BaseStorageService:
+def get_appropriate_storage_service(*_args, **_kwargs) -> MinioStorageService:
     minio_config = get_config("services", "minio", default={})
     return MinioStorageService(minio_config)

--- a/tests/unit/storage/test_minio.py
+++ b/tests/unit/storage/test_minio.py
@@ -329,3 +329,18 @@ def test_minio_with_region():
     storage = MinioStorageService(minio_no_ports_config)
     assert storage.minio_config == minio_no_ports_config
     assert storage.minio_client._base_url.region == "example"
+
+
+def test_write_then_read_file_with_metadata():
+    storage = make_storage()
+    path = f"test_write_then_read_file_with_metadata/{uuid4().hex}"
+    data = "lorem ipsum dolor test_write_then_read_file_with_metadata á"
+
+    ensure_bucket(storage)
+    _ = storage.write_file(BUCKET_NAME, path, data, metadata={"test": "test"})
+    metadata_container = {}
+    reading_result = storage.read_file(
+        BUCKET_NAME, path, metadata_container=metadata_container
+    )
+    assert reading_result.decode() == data
+    assert metadata_container == {"test": "test"}


### PR DESCRIPTION
GCS/S3 objects allow you to add metadata to them when writing, and you can read that metadata back. This is done via request/response headers. The reason I chose to pass in a metadata_container instead of changing the return type of read_file is because I wanted to offer the option to not care about an object's metadata, and this also makes it so this PR won't involve a bunch of changes to the call sites  in worker and API and instead i can just change the call sites i actually care about