### PR TITLE
fix: Use default free plan const instead of specific plan

### DIFF
--- a/shared/django_apps/codecov_auth/models.py
+++ b/shared/django_apps/codecov_auth/models.py
@@ -29,7 +29,7 @@ from shared.django_apps.codecov_auth.helpers import get_gitlab_url
 from shared.django_apps.codecov_auth.managers import OwnerManager
 from shared.django_apps.core.managers import RepositoryManager
 from shared.django_apps.core.models import DateTimeWithoutTZField, Repository
-from shared.plan.constants import PlanName, TierName, TrialDaysAmount
+from shared.plan.constants import DEFAULT_FREE_PLAN, PlanName, TierName, TrialDaysAmount
 
 # Added to avoid 'doesn't declare an explicit app_label and isn't in an application in INSTALLED_APPS' error\
 # Needs to be called the same as the API app
@@ -145,7 +145,7 @@ class Account(BaseModel):
         max_length=50,
         choices=PlanName.choices(),
         null=False,
-        default=PlanName.USERS_DEVELOPER.value,
+        default=DEFAULT_FREE_PLAN,
     )
     plan_seat_count = models.SmallIntegerField(default=1, null=False, blank=True)
     free_seat_count = models.SmallIntegerField(default=0, null=False, blank=True)
@@ -327,9 +327,7 @@ class Owner(ExportModelOperationsMixin("codecov_auth.owner"), models.Model):
     staff = models.BooleanField(null=True, default=False)
     cache = models.JSONField(null=True)
     # Really an ENUM in db
-    plan = models.TextField(
-        null=True, default=PlanName.USERS_DEVELOPER.value, blank=True
-    )
+    plan = models.TextField(null=True, default=DEFAULT_FREE_PLAN, blank=True)
     plan_provider = models.TextField(
         null=True, choices=PlanProviders.choices, blank=True
     )  # postgres enum containing only "github"


### PR DESCRIPTION
<!-- Describe your PR here. -->

https://codecov.sentry.io/issues/6298875711/events/latest/?environment=dd&project=4505562661847040&query=&referrer=latest-event&sort=date&stream_index=0

I was running into 500s trying to login in to DD's instance. Turns out we were defaulting to plan "users-developer" even though they are DEC and are on a pro plan.

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.