### PR TITLE
[ft] Add allow auto pr review config setting

### DIFF
--- a/shared/validation/user_schema.py
+++ b/shared/validation/user_schema.py
@@ -592,6 +592,7 @@ schema = {
     "ai_pr_review": {
         "type": ["dict"],
         "schema": {
+            "auto_review": {"type": "boolean"},
             "enabled": {"type": "boolean"},
             "method": {"type": "string"},
             "label_name": {"type": "string"},


### PR DESCRIPTION
<!-- Describe your PR here. -->

The intended flow here will be: 

Shelter gets PR open webhook -> Forward to codecov api and get yaml config value for owner -> If they have auto reviews on, kick off seer workflow for that PR

This PR just adds that yaml config value for the owner 

Importat: The PRs that are part of this flow are either `ready_for_review` or `opened` in a non-draft state. 

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.